### PR TITLE
Add external contribution notification workflow

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -20,7 +20,7 @@ jobs:
           linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
           linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
           slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          dry-run: "true"
+          dry-run: "false"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -2,21 +2,27 @@ name: External Contribution Notify
 
 on:
   issues:
-    types: [opened]
+    types: [opened, assigned, closed]
   pull_request_target:
-    types: [opened]
+    types: [opened, assigned, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: praetorian-inc/external-contrib-action@v1
+      - uses: praetorian-inc/external-contrib-action@v2
         with:
-          linear-team-id: ${{ vars.LINEAR_TEAM_ID }}
-          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
-          linear-assignee-id: ${{ vars.LINEAR_ASSIGNEE_ID }}
-          linear-parent-issue-id: ${{ vars.LINEAR_PARENT_ISSUE_ID }}
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
+          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          dry-run: "true"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -1,0 +1,22 @@
+name: External Contribution Notify
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: praetorian-inc/external-contrib-action@v1
+        with:
+          linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
+          slack-channel-id: "C0A90QPJ55G"
+          linear-assignee-id: "c0dd3407-3707-42f2-9a4c-c705c01e8487"
+          linear-parent-issue-id: "e97ea7d9-219b-453a-bb2f-7a818dd6d4f6"
+        env:
+          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: praetorian-inc/external-contrib-action@v1
         with:
-          linear-team-id: "43502f93-0130-4cad-b35c-601bc4cc19a0"
-          slack-channel-id: "C0A90QPJ55G"
-          linear-assignee-id: "c0dd3407-3707-42f2-9a4c-c705c01e8487"
-          linear-parent-issue-id: "e97ea7d9-219b-453a-bb2f-7a818dd6d4f6"
+          linear-team-id: ${{ vars.LINEAR_TEAM_ID }}
+          slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+          linear-assignee-id: ${{ vars.LINEAR_ASSIGNEE_ID }}
+          linear-parent-issue-id: ${{ vars.LINEAR_PARENT_ISSUE_ID }}
         env:
           ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to detect external PRs and issues on the Trajan repo
- Creates Linear sub-issues under LAB-1401 (Trajan Post-MVP Backlog), assigned to Rao Sridhar
- Posts notifications to #trajan Slack channel (`C0A90QPJ55G`)

## Pre-requisites
The following org-level secrets must be accessible to this repo:
- `ORG_MEMBER_CHECK_PAT` — GitHub PAT with `org:read` scope
- `LINEAR_API_KEY` — Linear API key
- `SLACK_BOT_TOKEN` — Slack bot token

## Test plan
- [ ] Verify org-level secrets are available to the trajan repo
- [ ] Merge and confirm workflow appears in Actions tab
- [ ] Test with a dummy external issue to validate end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)