### PR TITLE
Fix self-hosted runner false positives and add recursive callee resolution

### DIFF
--- a/cmd/trajan/github/scan.go
+++ b/cmd/trajan/github/scan.go
@@ -200,6 +200,7 @@ func executeScanAndOutput(ctx context.Context, platform platforms.Platform, targ
 
 	// Enumerate self-hosted runners for double-layer detection
 	if ghPlatform, ok := platform.(*github.Platform); ok {
+		executor.SetMetadata("github_client", ghPlatform.Client())
 		if runnerResult, err := ghPlatform.ScanRunners(ctx, target); err == nil {
 			executor.SetMetadata("runners", runnerResult)
 		}

--- a/pkg/analysis/parser/github.go
+++ b/pkg/analysis/parser/github.go
@@ -383,6 +383,12 @@ var GitHubHostedRunners = map[string]bool{
 // For matrix expressions like ${{ matrix.os }}, resolves the variable against
 // the strategy matrix. Unresolvable expressions are treated as self-hosted.
 func (j GitHubJob) IsSelfHostedRunner() bool {
+	// Reusable workflow callers delegate runs-on to the callee.
+	// They have no runner of their own, so an empty runs-on is not self-hosted.
+	if j.Uses != "" {
+		return false
+	}
+
 	runsOn := j.GetRunsOn()
 	if runsOn == "self-hosted" {
 		return true

--- a/pkg/analysis/parser/workflow_test.go
+++ b/pkg/analysis/parser/workflow_test.go
@@ -200,3 +200,31 @@ jobs:
 	require.NoError(t, err)
 	assert.True(t, wf4.Jobs["test"].IsSelfHostedRunner(), "unresolvable expression should be flagged conservatively")
 }
+
+func TestJob_IsSelfHostedRunner_ReusableWorkflowCaller(t *testing.T) {
+	// Cross-repo reusable workflow caller — has uses but no runs-on
+	yaml1 := `
+name: CI
+on: push
+jobs:
+  call-build:
+    uses: org/shared-workflows/.github/workflows/build.yml@main
+`
+	wf1, err := ParseWorkflow([]byte(yaml1))
+	require.NoError(t, err)
+	assert.False(t, wf1.Jobs["call-build"].IsSelfHostedRunner(), "reusable workflow caller should not be flagged as self-hosted")
+}
+
+func TestJob_IsSelfHostedRunner_LocalReusableWorkflowCaller(t *testing.T) {
+	// Local reusable workflow caller — has uses with ./ prefix
+	yaml1 := `
+name: CI
+on: push
+jobs:
+  call-local:
+    uses: ./.github/workflows/reusable-build.yml
+`
+	wf1, err := ParseWorkflow([]byte(yaml1))
+	require.NoError(t, err)
+	assert.False(t, wf1.Jobs["call-local"].IsSelfHostedRunner(), "local reusable workflow caller should not be flagged as self-hosted")
+}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -325,6 +325,23 @@ func (c *Client) GetWorkflowContent(ctx context.Context, owner, repo, path strin
 	return []byte(file.Content), nil
 }
 
+// GetWorkflowContentAtRef returns the content of a workflow file at a specific git ref
+func (c *Client) GetWorkflowContentAtRef(ctx context.Context, owner, repo, path, ref string) ([]byte, error) {
+	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", owner, repo, path, ref)
+
+	var file WorkflowFile
+	if err := c.get(ctx, apiPath, &file); err != nil {
+		return nil, fmt.Errorf("getting workflow content at ref: %w", err)
+	}
+
+	// Decode base64 content
+	if file.Encoding == "base64" {
+		return decodeBase64(file.Content)
+	}
+
+	return []byte(file.Content), nil
+}
+
 // GetFileMetadata returns metadata (including SHA) for a file via the contents API
 func (c *Client) GetFileMetadata(ctx context.Context, owner, repo, path string) (*WorkflowFile, error) {
 	apiPath := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, path)

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -439,6 +439,31 @@ func TestClient_InviteCollaborator(t *testing.T) {
 	}
 }
 
+func TestClient_GetWorkflowContentAtRef(t *testing.T) {
+	expectedContent := "name: Reusable\non: workflow_call\njobs:\n  build:\n    runs-on: self-hosted"
+	encodedContent := base64.StdEncoding.EncodeToString([]byte(expectedContent))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/repos/owner/repo/contents/.github/workflows/reusable.yml", r.URL.Path)
+		assert.Equal(t, "v1.0.0", r.URL.Query().Get("ref"))
+		w.Header().Set("X-RateLimit-Remaining", "4993")
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"name":"reusable.yml",
+			"path":".github/workflows/reusable.yml",
+			"content":"` + encodedContent + `",
+			"encoding":"base64"
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	content, err := client.GetWorkflowContentAtRef(context.Background(), "owner", "repo", ".github/workflows/reusable.yml", "v1.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, expectedContent, string(content))
+}
+
 func TestClient_RemoveCollaborator(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/pkg/github/detections/runner/resolver.go
+++ b/pkg/github/detections/runner/resolver.go
@@ -11,6 +11,10 @@ import (
 	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
 
+// maxReusableWorkflowDepth matches GitHub's limit of 4 levels of nested
+// reusable workflow calls.
+const maxReusableWorkflowDepth = 4
+
 // calleeResult caches the resolution of a reusable workflow callee.
 type calleeResult struct {
 	isSelfHosted bool
@@ -20,7 +24,8 @@ type calleeResult struct {
 
 // reusableWorkflowResolver resolves the runs-on of reusable workflow callees.
 // It checks local workflows (all_workflows metadata) first, then falls back to
-// the GitHub API for cross-repo references.
+// the GitHub API for cross-repo references. Supports recursive resolution up to
+// maxReusableWorkflowDepth levels (matching GitHub's own limit).
 type reusableWorkflowResolver struct {
 	client       *github.Client
 	allWorkflows map[string][]platforms.Workflow
@@ -40,7 +45,11 @@ func newResolver(client *github.Client, allWorkflows map[string][]platforms.Work
 // usesRef is the job-level `uses:` value, e.g. "org/repo/.github/workflows/build.yml@main"
 // or "./.github/workflows/build.yml".
 // callerRepoSlug is "owner/repo" of the calling workflow.
-func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepoSlug, usesRef string) (isSelfHosted bool, runsOn string, err error) {
+func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepoSlug, usesRef string, depth int) (isSelfHosted bool, runsOn string, err error) {
+	if depth >= maxReusableWorkflowDepth {
+		return false, "", nil // fail-open at max depth
+	}
+
 	r.mu.Lock()
 	if cached, ok := r.cache[usesRef]; ok {
 		r.mu.Unlock()
@@ -48,7 +57,7 @@ func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepo
 	}
 	r.mu.Unlock()
 
-	isSelfHosted, runsOn, err = r.doResolve(ctx, callerRepoSlug, usesRef)
+	isSelfHosted, runsOn, err = r.doResolve(ctx, callerRepoSlug, usesRef, depth)
 
 	r.mu.Lock()
 	r.cache[usesRef] = &calleeResult{isSelfHosted: isSelfHosted, runsOn: runsOn, err: err}
@@ -57,18 +66,18 @@ func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepo
 	return isSelfHosted, runsOn, err
 }
 
-func (r *reusableWorkflowResolver) doResolve(ctx context.Context, callerRepoSlug, usesRef string) (bool, string, error) {
+func (r *reusableWorkflowResolver) doResolve(ctx context.Context, callerRepoSlug, usesRef string, depth int) (bool, string, error) {
 	// Local reference: ./.github/workflows/build.yml
 	if strings.HasPrefix(usesRef, "./") {
-		return r.resolveLocal(callerRepoSlug, usesRef)
+		return r.resolveLocal(ctx, callerRepoSlug, usesRef, depth)
 	}
 
 	// Cross-repo reference: owner/repo/.github/workflows/build.yml@ref
-	return r.resolveCrossRepo(ctx, callerRepoSlug, usesRef)
+	return r.resolveCrossRepo(ctx, usesRef, depth)
 }
 
 // resolveLocal resolves a local reusable workflow reference against all_workflows metadata.
-func (r *reusableWorkflowResolver) resolveLocal(callerRepoSlug, usesRef string) (bool, string, error) {
+func (r *reusableWorkflowResolver) resolveLocal(ctx context.Context, callerRepoSlug, usesRef string, depth int) (bool, string, error) {
 	// Strip leading "./"
 	localPath := strings.TrimPrefix(usesRef, "./")
 
@@ -84,7 +93,7 @@ func (r *reusableWorkflowResolver) resolveLocal(callerRepoSlug, usesRef string) 
 
 	for _, wf := range repoWorkflows {
 		if wf.Path == localPath || strings.HasSuffix(wf.Path, "/"+localPath) {
-			return r.parseCalleeContent(wf.Content)
+			return r.parseCalleeContent(ctx, callerRepoSlug, wf.Content, depth)
 		}
 	}
 
@@ -93,7 +102,7 @@ func (r *reusableWorkflowResolver) resolveLocal(callerRepoSlug, usesRef string) 
 
 // resolveCrossRepo resolves a cross-repo reusable workflow reference.
 // Format: owner/repo/path@ref
-func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, callerRepoSlug, usesRef string) (bool, string, error) {
+func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, usesRef string, depth int) (bool, string, error) {
 	owner, repo, path, ref, err := parseCrossRepoRef(usesRef)
 	if err != nil {
 		return false, "", err
@@ -106,7 +115,7 @@ func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, callerR
 		if repoWorkflows, ok := r.allWorkflows[repoSlug]; ok {
 			for _, wf := range repoWorkflows {
 				if wf.Path == path || strings.HasSuffix(wf.Path, "/"+path) {
-					return r.parseCalleeContent(wf.Content)
+					return r.parseCalleeContent(ctx, repoSlug, wf.Content, depth)
 				}
 			}
 		}
@@ -122,11 +131,13 @@ func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, callerR
 		return false, "", fmt.Errorf("fetching cross-repo workflow %s: %w", usesRef, err)
 	}
 
-	return r.parseCalleeContent(content)
+	return r.parseCalleeContent(ctx, repoSlug, content, depth)
 }
 
 // parseCalleeContent parses workflow YAML and checks if any job uses a self-hosted runner.
-func (r *reusableWorkflowResolver) parseCalleeContent(content []byte) (bool, string, error) {
+// If a callee job itself calls another reusable workflow, recurses using calleeRepoSlug
+// as the context for local (./) references.
+func (r *reusableWorkflowResolver) parseCalleeContent(ctx context.Context, calleeRepoSlug string, content []byte, depth int) (bool, string, error) {
 	p := parser.NewGitHubParser()
 	wf, err := p.Parse(content)
 	if err != nil {
@@ -136,6 +147,17 @@ func (r *reusableWorkflowResolver) parseCalleeContent(content []byte) (bool, str
 	for _, job := range wf.Jobs {
 		if job.SelfHosted {
 			return true, job.RunsOn, nil
+		}
+
+		// Nested reusable workflow call — recurse with the callee's repo slug
+		if job.Uses != "" {
+			isSelfHosted, runsOn, err := r.resolveCallee(ctx, calleeRepoSlug, job.Uses, depth+1)
+			if err != nil {
+				continue // fail-open on nested resolution errors
+			}
+			if isSelfHosted {
+				return true, runsOn, nil
+			}
 		}
 	}
 

--- a/pkg/github/detections/runner/resolver.go
+++ b/pkg/github/detections/runner/resolver.go
@@ -1,0 +1,165 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/praetorian-inc/trajan/pkg/analysis/parser"
+	"github.com/praetorian-inc/trajan/pkg/github"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+)
+
+// calleeResult caches the resolution of a reusable workflow callee.
+type calleeResult struct {
+	isSelfHosted bool
+	runsOn       string
+	err          error
+}
+
+// reusableWorkflowResolver resolves the runs-on of reusable workflow callees.
+// It checks local workflows (all_workflows metadata) first, then falls back to
+// the GitHub API for cross-repo references.
+type reusableWorkflowResolver struct {
+	client       *github.Client
+	allWorkflows map[string][]platforms.Workflow
+	cache        map[string]*calleeResult
+	mu           sync.Mutex
+}
+
+func newResolver(client *github.Client, allWorkflows map[string][]platforms.Workflow) *reusableWorkflowResolver {
+	return &reusableWorkflowResolver{
+		client:       client,
+		allWorkflows: allWorkflows,
+		cache:        make(map[string]*calleeResult),
+	}
+}
+
+// resolveCallee determines whether a reusable workflow callee uses self-hosted runners.
+// usesRef is the job-level `uses:` value, e.g. "org/repo/.github/workflows/build.yml@main"
+// or "./.github/workflows/build.yml".
+// callerRepoSlug is "owner/repo" of the calling workflow.
+func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepoSlug, usesRef string) (isSelfHosted bool, runsOn string, err error) {
+	r.mu.Lock()
+	if cached, ok := r.cache[usesRef]; ok {
+		r.mu.Unlock()
+		return cached.isSelfHosted, cached.runsOn, cached.err
+	}
+	r.mu.Unlock()
+
+	isSelfHosted, runsOn, err = r.doResolve(ctx, callerRepoSlug, usesRef)
+
+	r.mu.Lock()
+	r.cache[usesRef] = &calleeResult{isSelfHosted: isSelfHosted, runsOn: runsOn, err: err}
+	r.mu.Unlock()
+
+	return isSelfHosted, runsOn, err
+}
+
+func (r *reusableWorkflowResolver) doResolve(ctx context.Context, callerRepoSlug, usesRef string) (bool, string, error) {
+	// Local reference: ./.github/workflows/build.yml
+	if strings.HasPrefix(usesRef, "./") {
+		return r.resolveLocal(callerRepoSlug, usesRef)
+	}
+
+	// Cross-repo reference: owner/repo/.github/workflows/build.yml@ref
+	return r.resolveCrossRepo(ctx, callerRepoSlug, usesRef)
+}
+
+// resolveLocal resolves a local reusable workflow reference against all_workflows metadata.
+func (r *reusableWorkflowResolver) resolveLocal(callerRepoSlug, usesRef string) (bool, string, error) {
+	// Strip leading "./"
+	localPath := strings.TrimPrefix(usesRef, "./")
+
+	if r.allWorkflows == nil {
+		return false, "", fmt.Errorf("no all_workflows metadata available")
+	}
+
+	// Look through all workflows for the caller's repo
+	repoWorkflows, ok := r.allWorkflows[callerRepoSlug]
+	if !ok {
+		return false, "", fmt.Errorf("repo %s not found in all_workflows", callerRepoSlug)
+	}
+
+	for _, wf := range repoWorkflows {
+		if wf.Path == localPath || strings.HasSuffix(wf.Path, "/"+localPath) {
+			return r.parseCalleeContent(wf.Content)
+		}
+	}
+
+	return false, "", fmt.Errorf("local workflow %s not found in all_workflows for %s", localPath, callerRepoSlug)
+}
+
+// resolveCrossRepo resolves a cross-repo reusable workflow reference.
+// Format: owner/repo/path@ref
+func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, callerRepoSlug, usesRef string) (bool, string, error) {
+	owner, repo, path, ref, err := parseCrossRepoRef(usesRef)
+	if err != nil {
+		return false, "", err
+	}
+
+	repoSlug := owner + "/" + repo
+
+	// Check all_workflows first (callee may already be in scope)
+	if r.allWorkflows != nil {
+		if repoWorkflows, ok := r.allWorkflows[repoSlug]; ok {
+			for _, wf := range repoWorkflows {
+				if wf.Path == path || strings.HasSuffix(wf.Path, "/"+path) {
+					return r.parseCalleeContent(wf.Content)
+				}
+			}
+		}
+	}
+
+	// Fall back to API
+	if r.client == nil {
+		return false, "", fmt.Errorf("no github client available for cross-repo resolution")
+	}
+
+	content, err := r.client.GetWorkflowContentAtRef(ctx, owner, repo, path, ref)
+	if err != nil {
+		return false, "", fmt.Errorf("fetching cross-repo workflow %s: %w", usesRef, err)
+	}
+
+	return r.parseCalleeContent(content)
+}
+
+// parseCalleeContent parses workflow YAML and checks if any job uses a self-hosted runner.
+func (r *reusableWorkflowResolver) parseCalleeContent(content []byte) (bool, string, error) {
+	p := parser.NewGitHubParser()
+	wf, err := p.Parse(content)
+	if err != nil {
+		return false, "", fmt.Errorf("parsing callee workflow: %w", err)
+	}
+
+	for _, job := range wf.Jobs {
+		if job.SelfHosted {
+			return true, job.RunsOn, nil
+		}
+	}
+
+	return false, "", nil
+}
+
+// parseCrossRepoRef parses "owner/repo/path/to/workflow.yml@ref" into components.
+func parseCrossRepoRef(usesRef string) (owner, repo, path, ref string, err error) {
+	// Split on @
+	parts := strings.SplitN(usesRef, "@", 2)
+	if len(parts) != 2 {
+		return "", "", "", "", fmt.Errorf("invalid reusable workflow reference (no @ref): %s", usesRef)
+	}
+	ref = parts[1]
+
+	// Split path: owner/repo/remaining/path
+	pathParts := strings.SplitN(parts[0], "/", 3)
+	if len(pathParts) < 3 {
+		return "", "", "", "", fmt.Errorf("invalid reusable workflow reference (need owner/repo/path): %s", usesRef)
+	}
+
+	owner = pathParts[0]
+	repo = pathParts[1]
+	path = pathParts[2]
+
+	return owner, repo, path, ref, nil
+}

--- a/pkg/github/detections/runner/resolver.go
+++ b/pkg/github/detections/runner/resolver.go
@@ -50,8 +50,15 @@ func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepo
 		return false, "", nil // fail-open at max depth
 	}
 
+	// Cache key must include the caller slug for local refs (./) because
+	// different repos can have the same local path pointing to different files.
+	cacheKey := usesRef
+	if strings.HasPrefix(usesRef, "./") {
+		cacheKey = callerRepoSlug + ":" + usesRef
+	}
+
 	r.mu.Lock()
-	if cached, ok := r.cache[usesRef]; ok {
+	if cached, ok := r.cache[cacheKey]; ok {
 		r.mu.Unlock()
 		return cached.isSelfHosted, cached.runsOn, cached.err
 	}
@@ -60,7 +67,7 @@ func (r *reusableWorkflowResolver) resolveCallee(ctx context.Context, callerRepo
 	isSelfHosted, runsOn, err = r.doResolve(ctx, callerRepoSlug, usesRef, depth)
 
 	r.mu.Lock()
-	r.cache[usesRef] = &calleeResult{isSelfHosted: isSelfHosted, runsOn: runsOn, err: err}
+	r.cache[cacheKey] = &calleeResult{isSelfHosted: isSelfHosted, runsOn: runsOn, err: err}
 	r.mu.Unlock()
 
 	return isSelfHosted, runsOn, err
@@ -102,6 +109,9 @@ func (r *reusableWorkflowResolver) resolveLocal(ctx context.Context, callerRepoS
 
 // resolveCrossRepo resolves a cross-repo reusable workflow reference.
 // Format: owner/repo/path@ref
+// Always fetches at the pinned ref via API rather than using all_workflows,
+// because all_workflows only contains the default branch and the caller may
+// pin a different tag/SHA.
 func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, usesRef string, depth int) (bool, string, error) {
 	owner, repo, path, ref, err := parseCrossRepoRef(usesRef)
 	if err != nil {
@@ -110,18 +120,6 @@ func (r *reusableWorkflowResolver) resolveCrossRepo(ctx context.Context, usesRef
 
 	repoSlug := owner + "/" + repo
 
-	// Check all_workflows first (callee may already be in scope)
-	if r.allWorkflows != nil {
-		if repoWorkflows, ok := r.allWorkflows[repoSlug]; ok {
-			for _, wf := range repoWorkflows {
-				if wf.Path == path || strings.HasSuffix(wf.Path, "/"+path) {
-					return r.parseCalleeContent(ctx, repoSlug, wf.Content, depth)
-				}
-			}
-		}
-	}
-
-	// Fall back to API
 	if r.client == nil {
 		return false, "", fmt.Errorf("no github client available for cross-repo resolution")
 	}

--- a/pkg/github/detections/runner/runner.go
+++ b/pkg/github/detections/runner/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/praetorian-inc/trajan/pkg/detections/base"
 	"github.com/praetorian-inc/trajan/pkg/github"
 	"github.com/praetorian-inc/trajan/pkg/github/detections/common"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
 
 func init() {
@@ -70,6 +71,48 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 		// OR if we couldn't check runner existence
 		if runnersExist || !hasRunnerData {
 			findings = append(findings, createFinding(wf, job, hasRunnerData, runnersExist))
+		}
+	}
+
+	// Second pass: resolve reusable workflow callers (jobs with Uses set).
+	// The parser now skips tagging these, so we resolve the callee to check.
+	var ghClient *github.Client
+	if clientData, ok := g.GetMetadata("github_client"); ok {
+		ghClient, _ = clientData.(*github.Client)
+	}
+	var allWorkflows map[string][]platforms.Workflow
+	if wfData, ok := g.GetMetadata("all_workflows"); ok {
+		allWorkflows, _ = wfData.(map[string][]platforms.Workflow)
+	}
+
+	// Only proceed if we have at least some way to resolve callees
+	if ghClient != nil || allWorkflows != nil {
+		resolver := newResolver(ghClient, allWorkflows)
+
+		for _, node := range g.GetNodesByType(graph.NodeTypeJob) {
+			job := node.(*graph.JobNode)
+			if job.Uses == "" {
+				continue
+			}
+
+			wfNode, ok := g.GetNode(job.Parent())
+			if !ok {
+				continue
+			}
+			wf := wfNode.(*graph.WorkflowNode)
+
+			isSelfHosted, resolvedRunsOn, err := resolver.resolveCallee(ctx, wf.RepoSlug, job.Uses)
+			if err != nil || !isSelfHosted {
+				continue
+			}
+
+			// Tag the job so it appears in downstream analysis
+			job.AddTag(graph.TagSelfHostedRunner)
+			job.RunsOn = resolvedRunsOn
+
+			if runnersExist || !hasRunnerData {
+				findings = append(findings, createFinding(wf, job, hasRunnerData, runnersExist))
+			}
 		}
 	}
 

--- a/pkg/github/detections/runner/runner.go
+++ b/pkg/github/detections/runner/runner.go
@@ -101,7 +101,7 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 			}
 			wf := wfNode.(*graph.WorkflowNode)
 
-			isSelfHosted, resolvedRunsOn, err := resolver.resolveCallee(ctx, wf.RepoSlug, job.Uses)
+			isSelfHosted, resolvedRunsOn, err := resolver.resolveCallee(ctx, wf.RepoSlug, job.Uses, 0)
 			if err != nil || !isSelfHosted {
 				continue
 			}

--- a/pkg/github/detections/runner/runner.go
+++ b/pkg/github/detections/runner/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/praetorian-inc/trajan/internal/registry"
 	"github.com/praetorian-inc/trajan/pkg/analysis/graph"
@@ -23,6 +24,8 @@ func init() {
 // Detection detects self-hosted runner usage
 type Detection struct {
 	base.BaseDetection
+	resolver     *reusableWorkflowResolver
+	resolverOnce sync.Once
 }
 
 // New creates a new runner plugin
@@ -87,7 +90,9 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 
 	// Only proceed if we have at least some way to resolve callees
 	if ghClient != nil || allWorkflows != nil {
-		resolver := newResolver(ghClient, allWorkflows)
+		d.resolverOnce.Do(func() {
+			d.resolver = newResolver(ghClient, allWorkflows)
+		})
 
 		for _, node := range g.GetNodesByType(graph.NodeTypeJob) {
 			job := node.(*graph.JobNode)
@@ -101,13 +106,13 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 			}
 			wf := wfNode.(*graph.WorkflowNode)
 
-			isSelfHosted, resolvedRunsOn, err := resolver.resolveCallee(ctx, wf.RepoSlug, job.Uses, 0)
+			isSelfHosted, resolvedRunsOn, err := d.resolver.resolveCallee(ctx, wf.RepoSlug, job.Uses, 0)
 			if err != nil || !isSelfHosted {
 				continue
 			}
 
-			// Tag the job so it appears in downstream analysis
-			job.AddTag(graph.TagSelfHostedRunner)
+			// Tag the job and update the graph index so downstream queries find it
+			g.UpdateNodeTag(job.ID(), graph.TagSelfHostedRunner)
 			job.RunsOn = resolvedRunsOn
 
 			if runnersExist || !hasRunnerData {

--- a/pkg/github/detections/runner/runner_test.go
+++ b/pkg/github/detections/runner/runner_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/praetorian-inc/trajan/pkg/analysis"
 	"github.com/praetorian-inc/trajan/pkg/detections"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
 
 func TestRunnerPlugin_DetectsSelfHosted(t *testing.T) {
@@ -58,4 +59,147 @@ func TestRunnerPlugin_Properties(t *testing.T) {
 	assert.Equal(t, "self-hosted-runner", p.Name())
 	assert.Equal(t, "github", p.Platform())
 	assert.Equal(t, detections.SeverityHigh, p.Severity())
+}
+
+func TestRunnerPlugin_ReusableWorkflowCallerNoFalsePositive(t *testing.T) {
+	// A caller job with uses: and no runs-on should NOT produce a finding
+	// when there is no metadata to resolve the callee (fail-open = no finding).
+	yaml := `
+name: CI
+on: push
+jobs:
+  call-build:
+    uses: org/shared/.github/workflows/build.yml@main
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	assert.Len(t, findings, 0, "reusable workflow caller with no metadata should produce 0 findings")
+}
+
+func TestRunnerPlugin_ReusableWorkflowCallerResolvesToSelfHosted(t *testing.T) {
+	// Callee has runs-on: self-hosted → should produce a finding
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-build:
+    uses: org/shared/.github/workflows/build.yml@main
+`
+	calleeYAML := `
+name: Build
+on: workflow_call
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "build"
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+
+	// Set up all_workflows with the callee so the resolver can find it
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/shared": {
+			{
+				Name:     "build.yml",
+				Path:     ".github/workflows/build.yml",
+				Content:  []byte(calleeYAML),
+				RepoSlug: "org/shared",
+			},
+		},
+	}
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1, "callee with self-hosted runner should produce a finding")
+	assert.Equal(t, detections.VulnSelfHostedRunner, findings[0].Type)
+}
+
+func TestRunnerPlugin_ReusableWorkflowCallerResolvesToGitHubHosted(t *testing.T) {
+	// Callee has runs-on: ubuntu-latest → should NOT produce a finding
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-build:
+    uses: org/shared/.github/workflows/build.yml@main
+`
+	calleeYAML := `
+name: Build
+on: workflow_call
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "build"
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/shared": {
+			{
+				Name:     "build.yml",
+				Path:     ".github/workflows/build.yml",
+				Content:  []byte(calleeYAML),
+				RepoSlug: "org/shared",
+			},
+		},
+	}
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	assert.Len(t, findings, 0, "callee with GitHub-hosted runner should produce 0 findings")
+}
+
+func TestRunnerPlugin_LocalReusableWorkflowResolution(t *testing.T) {
+	// Local reusable workflow caller (./) resolved via all_workflows
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-local:
+    uses: ./.github/workflows/reusable-build.yml
+`
+	calleeYAML := `
+name: Reusable Build
+on: workflow_call
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "build"
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+
+	allWorkflows := map[string][]platforms.Workflow{
+		"owner/repo": {
+			{
+				Name:     "reusable-build.yml",
+				Path:     ".github/workflows/reusable-build.yml",
+				Content:  []byte(calleeYAML),
+				RepoSlug: "owner/repo",
+			},
+		},
+	}
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1, "local callee with self-hosted runner should produce a finding")
+	assert.Equal(t, detections.VulnSelfHostedRunner, findings[0].Type)
 }

--- a/pkg/github/detections/runner/runner_test.go
+++ b/pkg/github/detections/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -202,4 +203,213 @@ jobs:
 
 	require.Len(t, findings, 1, "local callee with self-hosted runner should produce a finding")
 	assert.Equal(t, detections.VulnSelfHostedRunner, findings[0].Type)
+}
+
+func TestRunnerPlugin_NestedReusableWorkflow_TwoLevels(t *testing.T) {
+	// A calls B (cross-repo), B calls C (local to B's repo), C has self-hosted.
+	// Tests recursive resolution AND correct slug threading.
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-b:
+    uses: org/middle/.github/workflows/b.yml@main
+`
+	// B is in org/middle and calls C locally
+	middleYAML := `
+name: Middle
+on: workflow_call
+jobs:
+  call-c:
+    uses: ./.github/workflows/c.yml
+`
+	// C is in org/middle (same repo as B) and uses self-hosted
+	leafYAML := `
+name: Leaf
+on: workflow_call
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "self-hosted leaf"
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/middle": {
+			{
+				Name:     "b.yml",
+				Path:     ".github/workflows/b.yml",
+				Content:  []byte(middleYAML),
+				RepoSlug: "org/middle",
+			},
+			{
+				Name:     "c.yml",
+				Path:     ".github/workflows/c.yml",
+				Content:  []byte(leafYAML),
+				RepoSlug: "org/middle",
+			},
+		},
+	}
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1, "nested callee (2 levels) with self-hosted runner should produce a finding")
+	assert.Equal(t, detections.VulnSelfHostedRunner, findings[0].Type)
+}
+
+func TestRunnerPlugin_NestedReusableWorkflow_ThreeLevels(t *testing.T) {
+	// A → B → C → D, where D has self-hosted. Three levels of indirection.
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-b:
+    uses: org/b/.github/workflows/b.yml@main
+`
+	bYAML := `
+name: B
+on: workflow_call
+jobs:
+  call-c:
+    uses: org/c/.github/workflows/c.yml@main
+`
+	cYAML := `
+name: C
+on: workflow_call
+jobs:
+  call-d:
+    uses: ./.github/workflows/d.yml
+`
+	dYAML := `
+name: D
+on: workflow_call
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - run: echo "deep self-hosted"
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/b": {
+			{Name: "b.yml", Path: ".github/workflows/b.yml", Content: []byte(bYAML), RepoSlug: "org/b"},
+		},
+		"org/c": {
+			{Name: "c.yml", Path: ".github/workflows/c.yml", Content: []byte(cYAML), RepoSlug: "org/c"},
+			{Name: "d.yml", Path: ".github/workflows/d.yml", Content: []byte(dYAML), RepoSlug: "org/c"},
+		},
+	}
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1, "nested callee (3 levels) with self-hosted runner should produce a finding")
+	assert.Equal(t, detections.VulnSelfHostedRunner, findings[0].Type)
+}
+
+func TestRunnerPlugin_NestedReusableWorkflow_DepthLimitFailsOpen(t *testing.T) {
+	// Build a chain deeper than maxReusableWorkflowDepth (4).
+	// Each level calls the next. Should fail open (0 findings), not panic.
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-l1:
+    uses: org/r/.github/workflows/l1.yml@main
+`
+	makeLevel := func(next string) string {
+		return fmt.Sprintf(`
+name: Level
+on: workflow_call
+jobs:
+  next:
+    uses: %s
+`, next)
+	}
+
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/r": {
+			{Name: "l1.yml", Path: ".github/workflows/l1.yml", Content: []byte(makeLevel("org/r/.github/workflows/l2.yml@main")), RepoSlug: "org/r"},
+			{Name: "l2.yml", Path: ".github/workflows/l2.yml", Content: []byte(makeLevel("org/r/.github/workflows/l3.yml@main")), RepoSlug: "org/r"},
+			{Name: "l3.yml", Path: ".github/workflows/l3.yml", Content: []byte(makeLevel("org/r/.github/workflows/l4.yml@main")), RepoSlug: "org/r"},
+			{Name: "l4.yml", Path: ".github/workflows/l4.yml", Content: []byte(makeLevel("org/r/.github/workflows/l5.yml@main")), RepoSlug: "org/r"},
+			{Name: "l5.yml", Path: ".github/workflows/l5.yml", Content: []byte(`
+name: Deep Leaf
+on: workflow_call
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "too deep"
+`), RepoSlug: "org/r"},
+		},
+	}
+
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	assert.Len(t, findings, 0, "chain exceeding max depth should fail open with 0 findings")
+}
+
+func TestRunnerPlugin_NestedReusableWorkflow_WrongSlugNoFalsePositive(t *testing.T) {
+	// A calls B in org/middle. B calls ./.github/workflows/c.yml (local to org/middle).
+	// c.yml only exists in owner/repo, NOT in org/middle.
+	// Should NOT resolve — the local ref must use B's repo slug, not A's.
+	callerYAML := `
+name: CI
+on: push
+jobs:
+  call-b:
+    uses: org/middle/.github/workflows/b.yml@main
+`
+	middleYAML := `
+name: Middle
+on: workflow_call
+jobs:
+  call-c:
+    uses: ./.github/workflows/c.yml
+`
+	selfHostedYAML := `
+name: SelfHosted
+on: workflow_call
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "self-hosted"
+`
+	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
+	require.NoError(t, err)
+
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/middle": {
+			{Name: "b.yml", Path: ".github/workflows/b.yml", Content: []byte(middleYAML), RepoSlug: "org/middle"},
+			// c.yml is NOT here — it's missing from org/middle
+		},
+		"owner/repo": {
+			// c.yml exists here but should NOT be used for B's local ./ reference
+			{Name: "c.yml", Path: ".github/workflows/c.yml", Content: []byte(selfHostedYAML), RepoSlug: "owner/repo"},
+		},
+	}
+	g.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	assert.Len(t, findings, 0, "local ref in B should resolve against org/middle, not owner/repo")
 }

--- a/pkg/github/detections/runner/runner_test.go
+++ b/pkg/github/detections/runner/runner_test.go
@@ -2,7 +2,11 @@ package runner
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,8 +14,34 @@ import (
 
 	"github.com/praetorian-inc/trajan/pkg/analysis"
 	"github.com/praetorian-inc/trajan/pkg/detections"
+	"github.com/praetorian-inc/trajan/pkg/github"
 	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
+
+// mockContentsServer creates a test HTTP server that serves workflow files
+// via the GitHub Contents API format. files maps "owner/repo/path" to content.
+func mockContentsServer(t *testing.T, files map[string]string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path format: /repos/owner/repo/contents/path?ref=ref
+		// We match on the path portion after /repos/
+		path := r.URL.Path
+		for key, content := range files {
+			if path == "/repos/"+key {
+				encoded := base64.StdEncoding.EncodeToString([]byte(content))
+				resp := map[string]string{
+					"content":  encoded,
+					"encoding": "base64",
+				}
+				w.Header().Set("X-RateLimit-Remaining", "4999")
+				w.Header().Set("X-RateLimit-Limit", "5000")
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+}
 
 func TestRunnerPlugin_DetectsSelfHosted(t *testing.T) {
 	yaml := `
@@ -100,21 +130,14 @@ jobs:
     steps:
       - run: echo "build"
 `
+	server := mockContentsServer(t, map[string]string{
+		"org/shared/contents/.github/workflows/build.yml": calleeYAML,
+	})
+	defer server.Close()
+
 	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
 	require.NoError(t, err)
-
-	// Set up all_workflows with the callee so the resolver can find it
-	allWorkflows := map[string][]platforms.Workflow{
-		"org/shared": {
-			{
-				Name:     "build.yml",
-				Path:     ".github/workflows/build.yml",
-				Content:  []byte(calleeYAML),
-				RepoSlug: "org/shared",
-			},
-		},
-	}
-	g.SetMetadata("all_workflows", allWorkflows)
+	g.SetMetadata("github_client", github.NewClient(server.URL, "test-token"))
 
 	plugin := New()
 	findings, err := plugin.Detect(context.Background(), g)
@@ -142,20 +165,14 @@ jobs:
     steps:
       - run: echo "build"
 `
+	server := mockContentsServer(t, map[string]string{
+		"org/shared/contents/.github/workflows/build.yml": calleeYAML,
+	})
+	defer server.Close()
+
 	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
 	require.NoError(t, err)
-
-	allWorkflows := map[string][]platforms.Workflow{
-		"org/shared": {
-			{
-				Name:     "build.yml",
-				Path:     ".github/workflows/build.yml",
-				Content:  []byte(calleeYAML),
-				RepoSlug: "org/shared",
-			},
-		},
-	}
-	g.SetMetadata("all_workflows", allWorkflows)
+	g.SetMetadata("github_client", github.NewClient(server.URL, "test-token"))
 
 	plugin := New()
 	findings, err := plugin.Detect(context.Background(), g)
@@ -233,26 +250,23 @@ jobs:
     steps:
       - run: echo "self-hosted leaf"
 `
+	// B is fetched via API (cross-repo), C is resolved locally in org/middle
+	server := mockContentsServer(t, map[string]string{
+		"org/middle/contents/.github/workflows/b.yml": middleYAML,
+	})
+	defer server.Close()
+
 	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
 	require.NoError(t, err)
 
+	// C is in org/middle's all_workflows (local ./ ref resolves from here)
 	allWorkflows := map[string][]platforms.Workflow{
 		"org/middle": {
-			{
-				Name:     "b.yml",
-				Path:     ".github/workflows/b.yml",
-				Content:  []byte(middleYAML),
-				RepoSlug: "org/middle",
-			},
-			{
-				Name:     "c.yml",
-				Path:     ".github/workflows/c.yml",
-				Content:  []byte(leafYAML),
-				RepoSlug: "org/middle",
-			},
+			{Name: "c.yml", Path: ".github/workflows/c.yml", Content: []byte(leafYAML), RepoSlug: "org/middle"},
 		},
 	}
 	g.SetMetadata("all_workflows", allWorkflows)
+	g.SetMetadata("github_client", github.NewClient(server.URL, "test-token"))
 
 	plugin := New()
 	findings, err := plugin.Detect(context.Background(), g)
@@ -294,19 +308,24 @@ jobs:
     steps:
       - run: echo "deep self-hosted"
 `
+	// B and C are fetched via API (cross-repo), D is local to org/c
+	server := mockContentsServer(t, map[string]string{
+		"org/b/contents/.github/workflows/b.yml": bYAML,
+		"org/c/contents/.github/workflows/c.yml": cYAML,
+	})
+	defer server.Close()
+
 	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
 	require.NoError(t, err)
 
+	// D is local to org/c
 	allWorkflows := map[string][]platforms.Workflow{
-		"org/b": {
-			{Name: "b.yml", Path: ".github/workflows/b.yml", Content: []byte(bYAML), RepoSlug: "org/b"},
-		},
 		"org/c": {
-			{Name: "c.yml", Path: ".github/workflows/c.yml", Content: []byte(cYAML), RepoSlug: "org/c"},
 			{Name: "d.yml", Path: ".github/workflows/d.yml", Content: []byte(dYAML), RepoSlug: "org/c"},
 		},
 	}
 	g.SetMetadata("all_workflows", allWorkflows)
+	g.SetMetadata("github_client", github.NewClient(server.URL, "test-token"))
 
 	plugin := New()
 	findings, err := plugin.Detect(context.Background(), g)
@@ -336,13 +355,7 @@ jobs:
 `, next)
 	}
 
-	allWorkflows := map[string][]platforms.Workflow{
-		"org/r": {
-			{Name: "l1.yml", Path: ".github/workflows/l1.yml", Content: []byte(makeLevel("org/r/.github/workflows/l2.yml@main")), RepoSlug: "org/r"},
-			{Name: "l2.yml", Path: ".github/workflows/l2.yml", Content: []byte(makeLevel("org/r/.github/workflows/l3.yml@main")), RepoSlug: "org/r"},
-			{Name: "l3.yml", Path: ".github/workflows/l3.yml", Content: []byte(makeLevel("org/r/.github/workflows/l4.yml@main")), RepoSlug: "org/r"},
-			{Name: "l4.yml", Path: ".github/workflows/l4.yml", Content: []byte(makeLevel("org/r/.github/workflows/l5.yml@main")), RepoSlug: "org/r"},
-			{Name: "l5.yml", Path: ".github/workflows/l5.yml", Content: []byte(`
+	leafYAML := `
 name: Deep Leaf
 on: workflow_call
 jobs:
@@ -350,13 +363,20 @@ jobs:
     runs-on: self-hosted
     steps:
       - run: echo "too deep"
-`), RepoSlug: "org/r"},
-		},
-	}
+`
+
+	server := mockContentsServer(t, map[string]string{
+		"org/r/contents/.github/workflows/l1.yml": makeLevel("org/r/.github/workflows/l2.yml@main"),
+		"org/r/contents/.github/workflows/l2.yml": makeLevel("org/r/.github/workflows/l3.yml@main"),
+		"org/r/contents/.github/workflows/l3.yml": makeLevel("org/r/.github/workflows/l4.yml@main"),
+		"org/r/contents/.github/workflows/l4.yml": makeLevel("org/r/.github/workflows/l5.yml@main"),
+		"org/r/contents/.github/workflows/l5.yml": leafYAML,
+	})
+	defer server.Close()
 
 	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
 	require.NoError(t, err)
-	g.SetMetadata("all_workflows", allWorkflows)
+	g.SetMetadata("github_client", github.NewClient(server.URL, "test-token"))
 
 	plugin := New()
 	findings, err := plugin.Detect(context.Background(), g)
@@ -392,24 +412,106 @@ jobs:
     steps:
       - run: echo "self-hosted"
 `
+	// B is fetched via API
+	server := mockContentsServer(t, map[string]string{
+		"org/middle/contents/.github/workflows/b.yml": middleYAML,
+	})
+	defer server.Close()
+
 	g, err := analysis.BuildGraph("owner/repo", ".github/workflows/ci.yml", []byte(callerYAML))
 	require.NoError(t, err)
 
 	allWorkflows := map[string][]platforms.Workflow{
-		"org/middle": {
-			{Name: "b.yml", Path: ".github/workflows/b.yml", Content: []byte(middleYAML), RepoSlug: "org/middle"},
-			// c.yml is NOT here — it's missing from org/middle
-		},
+		// c.yml is NOT in org/middle — it's missing
 		"owner/repo": {
 			// c.yml exists here but should NOT be used for B's local ./ reference
 			{Name: "c.yml", Path: ".github/workflows/c.yml", Content: []byte(selfHostedYAML), RepoSlug: "owner/repo"},
 		},
 	}
 	g.SetMetadata("all_workflows", allWorkflows)
+	g.SetMetadata("github_client", github.NewClient(server.URL, "test-token"))
 
 	plugin := New()
 	findings, err := plugin.Detect(context.Background(), g)
 	require.NoError(t, err)
 
 	assert.Len(t, findings, 0, "local ref in B should resolve against org/middle, not owner/repo")
+}
+
+func TestRunnerPlugin_CacheKeyIsolation_LocalRefs(t *testing.T) {
+	// Two repos both call ./.github/workflows/build.yml locally.
+	// Repo A's build.yml is self-hosted, Repo B's is GitHub-hosted.
+	// The cache must not cross-contaminate.
+	repoAYAML := `
+name: CI-A
+on: push
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+`
+	repoBYAML := `
+name: CI-B
+on: push
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+`
+	buildSelfHosted := `
+name: Build
+on: workflow_call
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo "self-hosted"
+`
+	buildGitHubHosted := `
+name: Build
+on: workflow_call
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "github-hosted"
+`
+	// Build two separate graphs and merge findings via the resolver directly
+	allWorkflows := map[string][]platforms.Workflow{
+		"org/repo-a": {
+			{Name: "build.yml", Path: ".github/workflows/build.yml", Content: []byte(buildSelfHosted), RepoSlug: "org/repo-a"},
+		},
+		"org/repo-b": {
+			{Name: "build.yml", Path: ".github/workflows/build.yml", Content: []byte(buildGitHubHosted), RepoSlug: "org/repo-b"},
+		},
+	}
+
+	resolver := newResolver(nil, allWorkflows)
+	ctx := context.Background()
+
+	// Resolve for repo A — should be self-hosted
+	isSH_A, _, err := resolver.resolveCallee(ctx, "org/repo-a", "./.github/workflows/build.yml", 0)
+	require.NoError(t, err)
+	assert.True(t, isSH_A, "repo A's build.yml should be self-hosted")
+
+	// Resolve for repo B — should NOT be self-hosted (must not reuse A's cache)
+	isSH_B, _, err := resolver.resolveCallee(ctx, "org/repo-b", "./.github/workflows/build.yml", 0)
+	require.NoError(t, err)
+	assert.False(t, isSH_B, "repo B's build.yml should be GitHub-hosted, not cached from repo A")
+
+	// Verify both graphs produce correct findings
+	gA, err := analysis.BuildGraph("org/repo-a", ".github/workflows/ci.yml", []byte(repoAYAML))
+	require.NoError(t, err)
+	gA.SetMetadata("all_workflows", allWorkflows)
+
+	plugin := New()
+	findingsA, err := plugin.Detect(ctx, gA)
+	require.NoError(t, err)
+	assert.Len(t, findingsA, 1, "repo A should have 1 self-hosted finding")
+
+	gB, err := analysis.BuildGraph("org/repo-b", ".github/workflows/ci.yml", []byte(repoBYAML))
+	require.NoError(t, err)
+	gB.SetMetadata("all_workflows", allWorkflows)
+
+	findingsB, err := plugin.Detect(ctx, gB)
+	require.NoError(t, err)
+	assert.Len(t, findingsB, 0, "repo B should have 0 findings")
 }


### PR DESCRIPTION
## Summary

Reusable workflow callers (job-level `uses:`) have no `runs-on` — that's defined in the callee. The parser was treating the empty string as self-hosted, producing false positives on any repo using the `workflow_call` pattern.

### Bug fix
`IsSelfHostedRunner()` now returns `false` for reusable workflow callers, eliminating the false positive at the source.

### Recursive callee resolution
Added a resolver that follows reusable workflow chains up to 4 levels deep (matching GitHub's own limit) to determine whether the callee ultimately runs on a self-hosted runner. This preserves true-positive coverage that the parser fix alone would lose.

- **Local refs** (`./`): resolved via `all_workflows` metadata
- **Cross-repo refs** (`owner/repo/path@ref`): always fetched via the GitHub Contents API at the exact pinned ref (`@branch`, `@tag`, `@sha`), ensuring version-accurate resolution
- **Cache**: keyed by `callerRepoSlug:usesRef` for local refs and `usesRef` for cross-repo, preventing cross-repo contamination
- **Fail-open**: any fetch/parse error → no finding (no false positives from dead-end resolution)

### Additional fixes
- Fixed cache key collision where two repos calling the same local `./` path would share a cache entry
- Fixed cross-repo resolution ignoring `@ref` — removed `all_workflows` shortcut for cross-repo refs (default branch only) and always fetch at the pinned ref via API

Closes LAB-1410