### PR TITLE
Fix GitLab registry, detection classification, and client cleanups

### DIFF
--- a/pkg/attacks/all/all.go
+++ b/pkg/attacks/all/all.go
@@ -21,4 +21,6 @@ import (
 	_ "github.com/praetorian-inc/trajan/pkg/github/attacks/secretsdump"
 	_ "github.com/praetorian-inc/trajan/pkg/github/attacks/workflowinjection"
 	_ "github.com/praetorian-inc/trajan/pkg/gitlab/attacks/aiprobe"
+	_ "github.com/praetorian-inc/trajan/pkg/gitlab/attacks/runnerexec"
+	_ "github.com/praetorian-inc/trajan/pkg/gitlab/attacks/secretsdump"
 )

--- a/pkg/gitlab/attacks/runnerexec/logparser.go
+++ b/pkg/gitlab/attacks/runnerexec/logparser.go
@@ -102,8 +102,10 @@ func isBase64(s string) bool {
 	return true
 }
 
+// ansiRegex matches ANSI escape codes for stripping from log output
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[mGKH]`)
+
 // stripANSICodes removes ANSI escape codes from a string
 func stripANSICodes(s string) string {
-	ansiRegex := regexp.MustCompile(`\x1b\[[0-9;]*[mGKH]`)
 	return ansiRegex.ReplaceAllString(s, "")
 }

--- a/pkg/gitlab/attacks/runnerexec/pipeline.go
+++ b/pkg/gitlab/attacks/runnerexec/pipeline.go
@@ -3,6 +3,8 @@ package runnerexec
 import (
 	"fmt"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // GeneratePipelineYAML generates .gitlab-ci.yml for command execution
@@ -26,15 +28,19 @@ func GeneratePipelineYAML(runnerTags []string, command string) (string, error) {
 		}
 	}
 
-	// Build tags list
-	var tagsYAML strings.Builder
-	for _, tag := range runnerTags {
-		tagsYAML.WriteString(fmt.Sprintf("    - %s\n", tag))
+	// Use yaml.Marshal for safe serialization of tags (prevents YAML injection
+	// via metacharacters like ':', '#', '{', etc.)
+	pipeline := map[string]interface{}{
+		"runner-exec-job": map[string]interface{}{
+			"tags":   runnerTags,
+			"script": []string{fmt.Sprintf("(%s) 2>&1 | base64 || true", command)},
+		},
 	}
 
-	return fmt.Sprintf(`runner-exec-job:
-  tags:
-%s  script:
-    - (%s) 2>&1 | base64 || true
-`, tagsYAML.String(), command), nil
+	yamlBytes, err := yaml.Marshal(pipeline)
+	if err != nil {
+		return "", fmt.Errorf("marshaling pipeline YAML: %w", err)
+	}
+
+	return string(yamlBytes), nil
 }

--- a/pkg/gitlab/attacks/runnerexec/pipeline_test.go
+++ b/pkg/gitlab/attacks/runnerexec/pipeline_test.go
@@ -122,6 +122,33 @@ func TestGeneratePipelineYAML_MultipleTagsOneWithNewline(t *testing.T) {
 	assert.Contains(t, err.Error(), "runner tags cannot contain line breaks")
 }
 
+func TestGeneratePipelineYAML_TagsWithYAMLMetachars(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+	}{
+		{"colon", "tag: injected"},
+		{"hash comment", "tag #comment"},
+		{"curly braces", "tag{key: val}"},
+		{"square brackets", "tag[0]"},
+		{"ampersand anchor", "&anchor"},
+		{"asterisk alias", "*alias"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yamlOut, err := GeneratePipelineYAML([]string{tc.tag}, "whoami")
+			assert.NoError(t, err)
+
+			// The tag must appear quoted or escaped so YAML metacharacters
+			// cannot alter the document structure.
+			assert.Contains(t, yamlOut, tc.tag)
+			assert.Contains(t, yamlOut, "runner-exec-job:")
+			assert.Contains(t, yamlOut, "script:")
+		})
+	}
+}
+
 func TestGeneratePipelineYAML_CommandWithQuotes(t *testing.T) {
 	// Commands with quotes should work - they're preserved as-is
 	tags := []string{"docker"}

--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -142,7 +142,7 @@ func (c *Client) ListGroupProjects(ctx context.Context, groupName string) ([]Pro
 
 // ListUserProjects lists all projects for a user
 func (c *Client) ListUserProjects(ctx context.Context, username string) ([]Project, error) {
-	path := fmt.Sprintf("/users/%s/projects", username)
+	path := fmt.Sprintf("/users/%s/projects", url.PathEscape(username))
 
 	var projects []Project
 	if err := c.getPaginatedJSON(ctx, path, 20, &projects); err != nil {

--- a/pkg/gitlab/detections/mrsecrets/mrsecrets.go
+++ b/pkg/gitlab/detections/mrsecrets/mrsecrets.go
@@ -317,7 +317,7 @@ func (d *Detection) createFinding(g *graph.Graph, job *graph.JobNode, step *grap
 		Confidence:  detections.ConfidenceHigh,
 		Complexity:  detections.ComplexityZeroClick,
 		Platform:    "gitlab",
-		Class:       detections.GetVulnerabilityClass(detections.VulnExcessivePermissions),
+		Class:       detections.GetVulnerabilityClass(detections.VulnMergeRequestSecretsExposure),
 		Repository:  wf.RepoSlug,
 		Workflow:    wf.Path,
 		Job:         job.Name,

--- a/pkg/gitlab/detections/permissions/permissions.go
+++ b/pkg/gitlab/detections/permissions/permissions.go
@@ -108,7 +108,7 @@ func (d *Detection) createFinding(g *graph.Graph, step *graph.StepNode, token st
 	return detections.Finding{
 		Type:        detections.VulnTokenExposure,
 		Platform:    "gitlab",
-		Class:       detections.GetVulnerabilityClass(detections.VulnExcessivePermissions),
+		Class:       detections.GetVulnerabilityClass(detections.VulnTokenExposure),
 		Severity:    detections.SeverityHigh,
 		Confidence:  detections.ConfidenceHigh,
 		Complexity:  detections.ComplexityZeroClick,

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -31,17 +31,10 @@ func (p *Platform) Init(ctx context.Context, config platforms.Config) error {
 	p.config = config
 
 	baseURL := config.BaseURL
-	if baseURL == "" {
-		baseURL = DefaultBaseURL
-	} else {
+	if baseURL != "" {
 		// Validate URL scheme for security (prevent file://, javascript:, etc.)
 		if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
 			return fmt.Errorf("invalid URL scheme: must be http:// or https://, got: %s", baseURL)
-		}
-
-		// Ensure baseURL ends with /api/v4 for self-hosted instances
-		if !strings.HasSuffix(baseURL, "/api/v4") {
-			baseURL = strings.TrimRight(baseURL, "/") + "/api/v4"
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Register missing GitLab attack plugins (`runnerexec`, `secretsdump`) in the global registry so they're discoverable via the SDK path in `pkg/lib/`
- Fix mismatched vulnerability class in `token-exposure` and `merge-request-secrets-exposure` detections — findings were categorized as "excessive_permissions" instead of "secrets_exposure"
- Use `yaml.Marshal` for runner tag serialization in `runnerexec` to prevent YAML injection via metacharacters
- Add `url.PathEscape` to `ListUserProjects` for consistency with other client methods
- Remove duplicate `/api/v4` URL normalization between `Platform.Init` and `NewClient`
- Hoist per-call `regexp.MustCompile` in log parser to a package-level var

## Testing

- All existing tests pass (`make test-short`)
- Verified scan and attack commands against a live GitLab instance
- Added regression test for YAML metacharacter handling in pipeline generation

Closes LAB-1455, LAB-1456, LAB-1460