### PR TITLE
Replace string-based HTTP error checks with typed APIError in GitLab client

### DIFF
--- a/pkg/gitlab/attacks/aiprobe/aiprobe.go
+++ b/pkg/gitlab/attacks/aiprobe/aiprobe.go
@@ -3,7 +3,6 @@ package aiprobe
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/praetorian-inc/trajan/internal/registry"
@@ -95,7 +94,7 @@ func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*atta
 	content, err := client.GetWorkflowFile(ctx, projectID, ".gitlab-ci.yml", defaultBranch)
 	if err != nil {
 		// 404 is not an error - just means no CI file exists
-		if strings.Contains(err.Error(), "404") {
+		if gitlab.IsNotFoundError(err) {
 			result.Success = true
 			result.Message = "[DRY RUN] Discovered 0 AI service endpoint(s) across 0 CI file(s)"
 			result.Data = &sharedaiprobe.ScanResults{

--- a/pkg/gitlab/attacks/common/common.go
+++ b/pkg/gitlab/attacks/common/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"strings"
 	"time"
 
 	"github.com/praetorian-inc/trajan/pkg/attacks"
@@ -233,7 +232,7 @@ func CleanupSessionArtifacts(ctx context.Context, client *gitlab.Client, session
 			switch action.Type {
 			case attacks.ArtifactBranch:
 				if err := client.DeleteBranch(ctx, projectID, action.Identifier); err != nil {
-					if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
+					if gitlab.IsNotFoundError(err) {
 						fmt.Printf("Branch %s already deleted or doesn't exist\n", action.Identifier)
 						continue
 					}
@@ -250,7 +249,7 @@ func CleanupSessionArtifacts(ctx context.Context, client *gitlab.Client, session
 				}
 
 				if err := client.DeletePipeline(ctx, projectID, pipelineID); err != nil {
-					if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "Not Found") {
+					if gitlab.IsNotFoundError(err) {
 						fmt.Printf("Pipeline %d already deleted or doesn't exist\n", pipelineID)
 						continue
 					}

--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -379,7 +379,7 @@ func (c *Client) ListGroupVariables(ctx context.Context, groupID int) ([]Variabl
 	if err := c.getPaginatedJSON(ctx, path, 20, &variables); err != nil {
 		// 403 Forbidden is expected for non-maintainer users - return empty list
 		// Other errors (network, 500s, JSON decode) should be propagated
-		if isPermissionError(err) {
+		if IsPermissionError(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("listing group variables: %w", err)
@@ -395,21 +395,12 @@ func (c *Client) ListInstanceVariables(ctx context.Context) ([]Variable, error) 
 	if err := c.getJSON(ctx, "/admin/ci/variables", &variables); err != nil {
 		// 403 Forbidden is expected for non-admin users - return empty list
 		// Other errors (network, 500s, JSON decode) should be propagated
-		if isPermissionError(err) {
+		if IsPermissionError(err) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("listing instance variables: %w", err)
 	}
 	return variables, nil
-}
-
-// isPermissionError checks if an error is a 403 Forbidden permission error.
-func isPermissionError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "403") || strings.Contains(errStr, "Forbidden")
 }
 
 // ListProtectedBranches lists protected branches for a project

--- a/pkg/gitlab/client_http.go
+++ b/pkg/gitlab/client_http.go
@@ -99,7 +99,7 @@ func (c *Client) doRequestWithBody(ctx context.Context, method, path string, bod
 			c.semaphore.Release(1)
 			defer resp.Body.Close()
 			body, _ := io.ReadAll(resp.Body)
-			return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
 		}
 
 		// Success
@@ -190,7 +190,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string) (*http.Resp
 			c.semaphore.Release(1)
 			defer resp.Body.Close()
 			body, _ := io.ReadAll(resp.Body)
-			return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
+			return nil, &APIError{StatusCode: resp.StatusCode, Body: string(body)}
 		}
 
 		// Success - release semaphore and return

--- a/pkg/gitlab/client_test.go
+++ b/pkg/gitlab/client_test.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -774,4 +775,56 @@ func BenchmarkGetTemplate_WithCaching(b *testing.B) {
 			b.Fatalf("GetTemplate failed: %v", err)
 		}
 	}
+}
+
+// TestClient_APIErrorTyped verifies that doRequest returns a typed *APIError
+// on non-2xx responses, enabling callers to use errors.As for structured inspection.
+func TestClient_APIErrorTyped(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"404 Project Not Found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	_, err := client.GetProject(context.Background(), "owner/missing")
+	require.Error(t, err)
+
+	// Error must be inspectable as *APIError through the wrapping chain
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr), "expected *APIError in chain, got: %T — %v", err, err)
+	assert.Equal(t, 404, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Body, "404 Project Not Found")
+
+	// Helper must work
+	assert.True(t, IsNotFoundError(err))
+	assert.False(t, IsPermissionError(err))
+}
+
+// TestClient_APIErrorTyped_WriteMethod verifies that doRequestWithBody (POST/PUT/DELETE) returns
+// a typed *APIError on non-2xx responses, enabling callers to use errors.As for structured inspection.
+// This tests the POST path (CreateCommit -> postJSON -> doRequestWithBody).
+func TestClient_APIErrorTyped_WriteMethod(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"404 Project Not Found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-token")
+	actions := []CommitAction{
+		{
+			Action:   "create",
+			FilePath: ".gitlab-ci.yml",
+			Content:  "test: content",
+		},
+	}
+	_, err := client.CreateCommit(context.Background(), 123, "test-branch", actions, "Test commit")
+	require.Error(t, err)
+
+	// Error must be inspectable as *APIError through the wrapping chain
+	var apiErr *APIError
+	require.True(t, errors.As(err, &apiErr), "expected *APIError in chain, got: %T — %v", err, err)
+	assert.Equal(t, 404, apiErr.StatusCode)
+	assert.Contains(t, apiErr.Body, "404 Project Not Found")
 }

--- a/pkg/gitlab/enumerate.go
+++ b/pkg/gitlab/enumerate.go
@@ -376,7 +376,7 @@ func (p *Platform) EnumerateSecrets(ctx context.Context, target platforms.Target
 	instanceVars, err := p.client.ListInstanceVariables(ctx)
 	if err != nil {
 		// 403 is expected for non-admin users - don't show as error
-		if !strings.Contains(err.Error(), "403") {
+		if !IsPermissionError(err) {
 			result.PermissionErrors = append(result.PermissionErrors,
 				fmt.Sprintf("GET /admin/ci/variables: %s", err.Error()))
 		}

--- a/pkg/gitlab/enumerate_runners.go
+++ b/pkg/gitlab/enumerate_runners.go
@@ -74,7 +74,7 @@ func (p *Platform) EnumerateRunners(ctx context.Context, projectPath string, inc
 	if includeInstance {
 		instanceRunners, err := p.client.ListInstanceRunners(ctx)
 		if err != nil {
-			if isPermissionError(err) {
+			if IsPermissionError(err) {
 				result.Errors = append(result.Errors, "listing instance runners: admin access required (403)")
 			} else {
 				result.Errors = append(result.Errors, "listing instance runners: "+err.Error())

--- a/pkg/gitlab/enumerate_runners_logs.go
+++ b/pkg/gitlab/enumerate_runners_logs.go
@@ -48,7 +48,7 @@ func (p *Platform) AnalyzeProjectLogs(ctx context.Context, projectID int, pipeli
 				trace, err := p.client.GetJobTrace(ctx, projectID, job.ID)
 				if err != nil {
 					// 410 Gone means logs expired, stop analyzing older pipelines
-					if strings.Contains(err.Error(), "410") {
+					if IsGoneError(err) {
 						break
 					}
 					// Other errors (403, etc.) - skip this job, but keep metadata if we have it

--- a/pkg/gitlab/errors.go
+++ b/pkg/gitlab/errors.go
@@ -1,0 +1,47 @@
+package gitlab
+
+import (
+	"errors"
+	"fmt"
+)
+
+// APIError represents a non-2xx HTTP response from the GitLab API.
+// It carries the status code and raw body so callers can inspect
+// the specific error condition without string parsing.
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error implements the error interface.
+// Format is identical to the previous fmt.Errorf string so existing
+// error messages and tests that check err.Error() are unaffected.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error %d: %s", e.StatusCode, e.Body)
+}
+
+// IsPermissionError reports whether err (or any error in its chain)
+// is a 403 Forbidden response from the GitLab API.
+//
+// The previous isPermissionError also matched the string "Forbidden" as a
+// fallback. That fallback is intentionally dropped: doRequest always encodes
+// the exact HTTP status code into APIError.StatusCode, making body-string
+// matching redundant.
+func IsPermissionError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 403
+}
+
+// IsNotFoundError reports whether err (or any error in its chain)
+// is a 404 Not Found response from the GitLab API.
+func IsNotFoundError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 404
+}
+
+// IsGoneError reports whether err (or any error in its chain)
+// is a 410 Gone response from the GitLab API (e.g. expired job logs).
+func IsGoneError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 410
+}

--- a/pkg/gitlab/errors_test.go
+++ b/pkg/gitlab/errors_test.go
@@ -1,0 +1,85 @@
+package gitlab
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIError_Error(t *testing.T) {
+	err := &APIError{StatusCode: 404, Body: `{"message":"not found"}`}
+	assert.Equal(t, `API error 404: {"message":"not found"}`, err.Error())
+}
+
+func TestAPIError_ErrorsAs_ThroughWrapping(t *testing.T) {
+	original := &APIError{StatusCode: 403, Body: "Forbidden"}
+	wrapped := fmt.Errorf("listing variables: %w", original)
+
+	var apiErr *APIError
+	require.True(t, errors.As(wrapped, &apiErr))
+	assert.Equal(t, 403, apiErr.StatusCode)
+	assert.Equal(t, "Forbidden", apiErr.Body)
+}
+
+func TestIsPermissionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"non-API error", errors.New("something else"), false},
+		{"403 direct", &APIError{StatusCode: 403, Body: "Forbidden"}, true},
+		{"404 direct", &APIError{StatusCode: 404, Body: "Not Found"}, false},
+		{"403 wrapped once", fmt.Errorf("listing group vars: %w", &APIError{StatusCode: 403}), true},
+		{"403 wrapped twice", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &APIError{StatusCode: 403})), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsPermissionError(tt.err))
+		})
+	}
+}
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"non-API error", errors.New("something else"), false},
+		{"404 direct", &APIError{StatusCode: 404, Body: "Not Found"}, true},
+		{"403 direct", &APIError{StatusCode: 403, Body: "Forbidden"}, false},
+		{"404 wrapped", fmt.Errorf("getting workflow file: %w", &APIError{StatusCode: 404}), true},
+		{"404 wrapped twice", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &APIError{StatusCode: 404})), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsNotFoundError(tt.err))
+		})
+	}
+}
+
+func TestIsGoneError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil", nil, false},
+		{"non-API error", errors.New("something else"), false},
+		{"410 direct", &APIError{StatusCode: 410, Body: "Gone"}, true},
+		{"404 direct", &APIError{StatusCode: 404, Body: "Not Found"}, false},
+		{"410 wrapped", fmt.Errorf("getting job trace: %w", &APIError{StatusCode: 410}), true},
+		{"410 wrapped twice", fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", &APIError{StatusCode: 410})), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, IsGoneError(tt.err))
+		})
+	}
+}

--- a/pkg/gitlab/gitlab.go
+++ b/pkg/gitlab/gitlab.go
@@ -167,7 +167,7 @@ func (p *Platform) getWorkflow(ctx context.Context, projectID int, pathWithNames
 	content, err := p.client.GetWorkflowFile(ctx, projectID, ciFile, ref)
 	if err != nil {
 		// If file doesn't exist, return nil (not all projects have CI)
-		if strings.Contains(err.Error(), "404") {
+		if IsNotFoundError(err) {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
## Summary

Introduces `APIError{StatusCode, Body}` and three exported helper functions (`IsPermissionError`, `IsNotFoundError`, `IsGoneError`) that use `errors.As` to inspect typed errors through wrapping chains. Replaces all string-based HTTP status code checks across `pkg/gitlab`, eliminating the fragile implicit contract between `doRequest`'s error format string and its callers.

## Changes

- **`pkg/gitlab/errors.go`** (new): `APIError` type implementing `error`, plus helpers using `errors.As` — correctly handles wrapped errors unlike direct type assertion
- **`pkg/gitlab/errors_test.go`** (new): Table-driven tests including double-wrap cases that enforce `errors.As` semantics
- **`pkg/gitlab/client_http.go`**: `doRequest` and `doRequestWithBody` return `&APIError{}` on non-2xx responses; 429 retry-exhaustion path intentionally kept as `fmt.Errorf` (synthetic error, not a raw HTTP response)
- **`pkg/gitlab/client_test.go`**: Integration tests for both GET and POST error paths
- **`pkg/gitlab/client.go`**: Remove private `isPermissionError` (string-based), replace call sites with `IsPermissionError`
- **Remaining call sites** in `enumerate.go`, `enumerate_runners.go`, `enumerate_runners_logs.go`, `gitlab.go`, `attacks/aiprobe/aiprobe.go`, `attacks/common/common.go`: Replace `strings.Contains(err.Error(), "4xx")` with the appropriate typed helper; remove `"strings"` import where it becomes unused

The `Error()` format string (`"API error %d: %s"`) is preserved for backward compatibility.

## Test Plan

- [x] All 15 `pkg/gitlab/...` packages pass with `-race`
- [x] `go vet` clean
- [x] Validated against live GitLab EE 18.8.2 with real runner: `scan`, `enumerate` (all subcommands), and `attack` (secrets-dump, runner-exec) all function correctly


Closes LAB-1459