### PR TITLE
Add Bitbucket Cloud enumerate token command

### DIFF
--- a/cmd/trajan/bitbucket/enumerate/root.go
+++ b/cmd/trajan/bitbucket/enumerate/root.go
@@ -1,0 +1,35 @@
+package enumerate
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/trajan/internal/cmdutil"
+)
+
+var enumerateCmd = &cobra.Command{
+	Use:   "enumerate",
+	Short: "Enumerate Bitbucket resources and attack surface",
+	Long: `Trajan - Bitbucket - Enumerate
+
+Enumerate and discover Bitbucket resources accessible to the authenticated token.
+
+The enumerate command provides detailed reconnaissance capabilities including:
+  - Token validation and scope analysis
+  - User identity and account status`,
+}
+
+func init() {
+	enumerateCmd.AddCommand(tokenCmd)
+}
+
+func NewEnumerateCmd() *cobra.Command {
+	return enumerateCmd
+}
+
+func getToken(cmd *cobra.Command) string {
+	return cmdutil.GetTokenForPlatform(cmd, "bitbucket")
+}
+
+func getEmail(cmd *cobra.Command) string {
+	return cmdutil.GetEmailForPlatform(cmd, "bitbucket")
+}

--- a/cmd/trajan/bitbucket/enumerate/token.go
+++ b/cmd/trajan/bitbucket/enumerate/token.go
@@ -1,0 +1,269 @@
+package enumerate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/trajan/internal/cmdutil"
+	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/bitbucket"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+
+	_ "github.com/praetorian-inc/trajan/pkg/platforms/all"
+)
+
+var tokenOutputFile string
+
+var tokenCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Validate and analyze Bitbucket token capabilities",
+	Long: `Trajan - Bitbucket - Enumerate Token
+
+Validate the Bitbucket token and analyze its capabilities.
+
+This command checks:
+  - Token validity and type (workspace/project/repo access token or API token)
+  - OAuth scopes and permissions
+  - User identity (for API tokens)
+  - Rate limit status`,
+	RunE: runTokenEnumerate,
+}
+
+func init() {
+	tokenCmd.Flags().SortFlags = false
+	tokenCmd.Flags().StringVar(&tokenOutputFile, "output-file", "", "save output to file")
+}
+
+func runTokenEnumerate(cmd *cobra.Command, args []string) error {
+	token := getToken(cmd)
+	if token == "" {
+		return fmt.Errorf("no token provided (use --token or set BITBUCKET_TOKEN/BB_TOKEN env var)")
+	}
+
+	email := getEmail(cmd)
+
+	// Validate: ATATT3x token without email
+	if strings.HasPrefix(token, "ATATT3x") && email == "" {
+		return fmt.Errorf("--email is required for API token auth (use --email or set BITBUCKET_EMAIL/BB_EMAIL env var)")
+	}
+
+	// Warn: access token with email provided
+	if strings.HasPrefix(token, "ATCTT3x") && email != "" {
+		fmt.Fprintf(os.Stderr, "Warning: email ignored for access tokens (Bearer auth used)\n")
+	}
+
+	output := cmdutil.GetOutput(cmd)
+	ctx := context.Background()
+
+	// Initialize platform
+	platform, err := registry.GetPlatform("bitbucket")
+	if err != nil {
+		return fmt.Errorf("getting platform: %w", err)
+	}
+
+	config := platforms.Config{
+		Token: token,
+		Bitbucket: &platforms.BitbucketAuth{
+			Token: token,
+			Email: email,
+		},
+	}
+	cmdutil.ApplyProxyFlags(cmd, &config)
+
+	if err := platform.Init(ctx, config); err != nil {
+		return fmt.Errorf("initializing platform: %w", err)
+	}
+
+	bbPlatform, ok := platform.(*bitbucket.Platform)
+	if !ok {
+		return fmt.Errorf("unexpected platform type")
+	}
+
+	if output == "console" {
+		fmt.Fprintf(os.Stderr, "Validating token...\n\n")
+	}
+
+	result, err := bbPlatform.EnumerateToken(ctx)
+	if err != nil {
+		return fmt.Errorf("enumerating token: %w", err)
+	}
+
+	switch output {
+	case "json":
+		return outputTokenJSON(result, tokenOutputFile)
+	default:
+		return outputTokenConsole(result)
+	}
+}
+
+func outputTokenJSON(result *bitbucket.TokenEnumerateResult, outputFile string) error {
+	enc := json.NewEncoder(os.Stdout)
+	if outputFile != "" {
+		f, err := os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("creating output file: %w", err)
+		}
+		defer f.Close()
+		enc = json.NewEncoder(f)
+	}
+
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func outputTokenConsole(result *bitbucket.TokenEnumerateResult) error {
+	fmt.Printf("=== Bitbucket Token Information ===\n\n")
+
+	if result.TokenInfo == nil {
+		fmt.Println("No token information available")
+		if len(result.Errors) > 0 {
+			fmt.Printf("\nErrors:\n")
+			for _, e := range result.Errors {
+				fmt.Printf("  • %s\n", e)
+			}
+		}
+		return nil
+	}
+
+	info := result.TokenInfo
+
+	// User info (API tokens only)
+	if result.User != nil {
+		fmt.Printf("User: %s", result.User.Username)
+		if result.User.DisplayName != "" {
+			fmt.Printf(" (%s)", result.User.DisplayName)
+		}
+		fmt.Println()
+		if result.User.AccountID != "" {
+			fmt.Printf("Account: %s\n", result.User.AccountID)
+		}
+		if result.User.AccountStatus != "" {
+			fmt.Printf("Status: %s\n", result.User.AccountStatus)
+		}
+		fmt.Println()
+	}
+
+	// Token type
+	fmt.Printf("Type: %s\n", formatTokenType(info.Type))
+
+	// Scopes
+	if info.Scopes != nil && len(info.RawScopes) > 0 {
+		fmt.Printf("\nScopes (%d):\n", len(info.RawScopes))
+		if info.Scopes.Format() == bitbucket.ScopeFormatFineGrained {
+			// Grouped display for fine-grained (API token) scopes
+			outputFineGrainedScopes(info.Scopes)
+		} else {
+			// Bullet list with implication annotations for legacy (access token) scopes
+			for _, scope := range info.RawScopes {
+				annotation := legacyScopeAnnotations[scope]
+				if annotation != "" {
+					fmt.Printf("  • %s (%s)\n", scope, annotation)
+				} else {
+					fmt.Printf("  • %s\n", scope)
+				}
+			}
+		}
+	}
+
+	// Note for API tokens
+	if info.Type == bitbucket.TokenTypeAPIToken {
+		fmt.Printf("\nNote: Scopes show maximum token permissions.\n")
+		fmt.Printf("Actual access depends on user's workspace and repository roles.\n")
+	}
+
+	// Rate limit
+	if result.RateLimit != nil && result.RateLimit.Limit > 0 {
+		nearLimit := "no"
+		if result.RateLimit.NearLimit {
+			nearLimit = "yes"
+		}
+		fmt.Printf("\nRate Limit: %d (near limit: %s)\n", result.RateLimit.Limit, nearLimit)
+	}
+
+	// Errors
+	if len(result.Errors) > 0 {
+		fmt.Printf("\nErrors:\n")
+		for _, e := range result.Errors {
+			fmt.Printf("  • %s\n", e)
+		}
+	}
+
+	return nil
+}
+
+// legacyScopeAnnotations maps scopes to their human-readable annotation text.
+// Bare scope names (e.g., "project") mean read-level access, so we annotate them.
+var legacyScopeAnnotations = map[string]string{
+	"account":           "read",
+	"project":           "read; implies repository:read",
+	"project:admin":     "",
+	"repository":        "read",
+	"repository:write":  "implies repository:read",
+	"repository:admin":  "",
+	"repository:delete": "",
+	"pullrequest":       "read; implies repository:read",
+	"pullrequest:write": "implies pullrequest:read, repository:write, repository:read",
+	"webhook":           "read+write",
+	"pipeline":          "read",
+	"pipeline:write":    "implies pipeline:read",
+	"pipeline:variable": "implies pipeline:write, pipeline:read",
+	"runner":            "read",
+	"runner:write":      "implies runner:read",
+	"test":              "read",
+	"test:write":        "implies test:read",
+}
+
+// categoryDisplayNames maps scope categories to human-readable display names.
+var categoryDisplayNames = map[string]string{
+	"repository":  "Repositories",
+	"pullrequest": "Pull Requests",
+	"project":     "Projects",
+	"workspace":   "Workspaces",
+	"pipeline":    "Pipelines",
+	"runner":      "Runners",
+	"test":        "Tests",
+	"issue":       "Issues",
+	"webhook":     "Webhooks",
+	"snippet":     "Snippets",
+	"wiki":        "Wikis",
+	"ssh-key":     "SSH Keys",
+	"gpg-key":     "GPG Keys",
+	"permission":  "Permissions",
+	"user":        "Users",
+	"package":     "Packages",
+}
+
+func outputFineGrainedScopes(scopes *bitbucket.Scopes) {
+	for _, category := range scopes.Categories() {
+		levels := scopes.Levels(category)
+		levelStrs := make([]string, len(levels))
+		for i, l := range levels {
+			levelStrs[i] = string(l)
+		}
+		displayName := categoryDisplayNames[category]
+		if displayName == "" {
+			displayName = category
+		}
+		fmt.Printf("  %-15s %s\n", displayName+":", strings.Join(levelStrs, ", "))
+	}
+}
+
+func formatTokenType(t bitbucket.TokenType) string {
+	switch t {
+	case bitbucket.TokenTypeWorkspace:
+		return "Workspace Access Token"
+	case bitbucket.TokenTypeProject:
+		return "Project Access Token"
+	case bitbucket.TokenTypeRepo:
+		return "Repository Access Token"
+	case bitbucket.TokenTypeAPIToken:
+		return "Personal API Token"
+	default:
+		return "Unknown"
+	}
+}

--- a/cmd/trajan/bitbucket/enumerate_bridge.go
+++ b/cmd/trajan/bitbucket/enumerate_bridge.go
@@ -1,0 +1,5 @@
+package bitbucket
+
+import enumerate "github.com/praetorian-inc/trajan/cmd/trajan/bitbucket/enumerate"
+
+var enumerateCmd = enumerate.NewEnumerateCmd()

--- a/cmd/trajan/bitbucket/root.go
+++ b/cmd/trajan/bitbucket/root.go
@@ -1,0 +1,19 @@
+package bitbucket
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var BitbucketCmd = &cobra.Command{
+	Use:   "bitbucket",
+	Short: "Trajan - Bitbucket",
+	Long:  `Trajan - Bitbucket`,
+}
+
+func init() {
+	// Persistent flags available to all bitbucket subcommands
+	BitbucketCmd.PersistentFlags().String("email", "", "email address for API token auth (or set BITBUCKET_EMAIL/BB_EMAIL)")
+	BitbucketCmd.PersistentFlags().String("workspace", "", "Bitbucket workspace slug (or set BITBUCKET_WORKSPACE)")
+
+	BitbucketCmd.AddCommand(enumerateCmd)
+}

--- a/cmd/trajan/root.go
+++ b/cmd/trajan/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	ado "github.com/praetorian-inc/trajan/cmd/trajan/ado"
+	bbcmd "github.com/praetorian-inc/trajan/cmd/trajan/bitbucket"
 	ghcmd "github.com/praetorian-inc/trajan/cmd/trajan/github"
 	gitlab "github.com/praetorian-inc/trajan/cmd/trajan/gitlab"
 	jenkins "github.com/praetorian-inc/trajan/cmd/trajan/jenkins"
@@ -61,12 +62,14 @@ func init() {
 	ghcmd.GitHubCmd.GroupID = "platforms"
 	gitlab.GitLabCmd.GroupID = "platforms"
 	ado.AdoCmd.GroupID = "platforms"
+	bbcmd.BitbucketCmd.GroupID = "platforms"
 	jenkins.JenkinsCmd.GroupID = "platforms"
 	jfrog.JFrogCmd.GroupID = "platforms"
 
 	rootCmd.AddCommand(ghcmd.GitHubCmd)
 	rootCmd.AddCommand(gitlab.GitLabCmd)
 	rootCmd.AddCommand(ado.AdoCmd)
+	rootCmd.AddCommand(bbcmd.BitbucketCmd)
 	rootCmd.AddCommand(jenkins.JenkinsCmd)
 	rootCmd.AddCommand(jfrog.JFrogCmd)
 

--- a/internal/cmdutil/flags.go
+++ b/internal/cmdutil/flags.go
@@ -28,6 +28,7 @@ func GetTokenForPlatform(cmd *cobra.Command, platform string) string {
 		"azuredevops": {"AZURE_DEVOPS_PAT", "AZDO_PAT"},
 		"jfrog":       {"JFROG_TOKEN"},
 		"jenkins":     {"JENKINS_TOKEN", "JENKINS_PASSWORD"},
+		"bitbucket":   {"BITBUCKET_TOKEN", "BB_TOKEN"},
 	}
 
 	if vars, ok := envVars[platform]; ok {
@@ -79,6 +80,28 @@ func GetUsernameForPlatform(cmd *cobra.Command, platform string) string {
 		for _, env := range vars {
 			if u := os.Getenv(env); u != "" {
 				return u
+			}
+		}
+	}
+
+	return ""
+}
+
+// GetEmailForPlatform retrieves email for the specified platform.
+// Checks the --email flag first, then platform-specific environment variables.
+func GetEmailForPlatform(cmd *cobra.Command, platform string) string {
+	if e, err := cmd.Flags().GetString("email"); err == nil && e != "" {
+		return e
+	}
+
+	envVars := map[string][]string{
+		"bitbucket": {"BITBUCKET_EMAIL", "BB_EMAIL"},
+	}
+
+	if vars, ok := envVars[platform]; ok {
+		for _, env := range vars {
+			if e := os.Getenv(env); e != "" {
+				return e
 			}
 		}
 	}

--- a/pkg/bitbucket/bitbucket.go
+++ b/pkg/bitbucket/bitbucket.go
@@ -1,0 +1,108 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+	"github.com/praetorian-inc/trajan/pkg/platforms/shared/proxy"
+)
+
+// Platform implements the platforms.Platform interface for Bitbucket Cloud.
+type Platform struct {
+	client *Client
+	config platforms.Config
+}
+
+// NewPlatform creates a new Bitbucket platform adapter.
+func NewPlatform() *Platform {
+	return &Platform{}
+}
+
+// Name returns the platform identifier.
+func (p *Platform) Name() string {
+	return "bitbucket"
+}
+
+// Init initializes the platform with configuration.
+func (p *Platform) Init(ctx context.Context, config platforms.Config) error {
+	p.config = config
+
+	// Build client options
+	var opts []ClientOption
+	if config.Timeout > 0 {
+		opts = append(opts, WithTimeout(config.Timeout))
+	}
+	if config.Concurrency > 0 {
+		opts = append(opts, WithConcurrency(int64(config.Concurrency)))
+	}
+
+	// Resolve proxy transport
+	transport := config.HTTPTransport
+	if transport == nil {
+		t, err := proxy.NewTransport(proxy.Config{
+			HTTPProxy:  config.HTTPProxy,
+			SOCKSProxy: config.SOCKSProxy,
+		})
+		if err != nil {
+			return fmt.Errorf("configuring proxy: %w", err)
+		}
+		transport = t
+	}
+	if transport != nil {
+		opts = append(opts, WithHTTPTransport(transport))
+	}
+
+	// Detect auth mode from token prefix
+	token := config.Token
+	if strings.HasPrefix(token, "ATATT3x") {
+		// API token — requires email for Basic auth
+		email := ""
+		if config.Bitbucket != nil {
+			email = config.Bitbucket.Email
+		}
+		if email == "" {
+			return fmt.Errorf("--email is required for API token auth (use --email or set BITBUCKET_EMAIL/BB_EMAIL env var)")
+		}
+		opts = append(opts, WithAuthMode(AuthBasic), WithEmail(email))
+	}
+	// ATCTT3x or unknown prefix → default AuthBearer (set by NewClient)
+
+	p.client = NewClient(token, opts...)
+	return nil
+}
+
+// Client returns the underlying Bitbucket client.
+func (p *Platform) Client() *Client {
+	return p.client
+}
+
+// Scan retrieves repositories and workflows from the target.
+// This is a stub — full implementation will land in a future task.
+func (p *Platform) Scan(ctx context.Context, target platforms.Target) (*platforms.ScanResult, error) {
+	return nil, fmt.Errorf("bitbucket scan not yet implemented")
+}
+
+// EnumerateToken retrieves metadata about the authenticated token,
+// including its type, scopes, associated user (if any), and rate limit info.
+func (p *Platform) EnumerateToken(ctx context.Context) (*TokenEnumerateResult, error) {
+	result := &TokenEnumerateResult{
+		Errors: make([]string, 0),
+	}
+
+	tokenInfo, user, rateLimit, err := p.client.GetTokenInfo(ctx)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("getting token info: %v", err))
+		return result, nil // Return partial result
+	}
+
+	result.TokenInfo = tokenInfo
+	result.User = user
+	result.RateLimit = rateLimit
+
+	return result, nil
+}
+
+// Ensure Platform implements the interface.
+var _ platforms.Platform = (*Platform)(nil)

--- a/pkg/bitbucket/client.go
+++ b/pkg/bitbucket/client.go
@@ -1,0 +1,120 @@
+package bitbucket
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	// DefaultBaseURL is the Bitbucket Cloud REST API v2 base URL.
+	DefaultBaseURL = "https://api.bitbucket.org"
+	// DefaultTimeout is the default HTTP client timeout.
+	DefaultTimeout = 30 * time.Second
+	// MaxConcurrentRequests is the default concurrency limit.
+	MaxConcurrentRequests = 50
+)
+
+// AuthMode selects the authentication mechanism for the Bitbucket API.
+type AuthMode int
+
+const (
+	// AuthBearer uses "Authorization: Bearer {token}" (access tokens with ATCTT3x prefix).
+	AuthBearer AuthMode = iota
+	// AuthBasic uses "Authorization: Basic base64(email:token)" (API tokens with ATATT3x prefix).
+	AuthBasic
+)
+
+// Client is a Bitbucket Cloud REST API v2 client with concurrency control.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	token      string
+	email      string // Non-empty only for AuthBasic
+	authMode   AuthMode
+	semaphore  *semaphore.Weighted
+}
+
+// String implements fmt.Stringer to prevent token leakage in logs.
+func (c *Client) String() string {
+	if c == nil {
+		return "Client{nil}"
+	}
+	return fmt.Sprintf("Client{baseURL: %q, authMode: %d, token: [REDACTED]}", c.baseURL, c.authMode)
+}
+
+// GoString implements fmt.GoStringer to prevent token leakage with %#v format.
+func (c *Client) GoString() string {
+	if c == nil {
+		return "(*Client)(nil)"
+	}
+	return fmt.Sprintf("&Client{baseURL: %q, authMode: %d, token: [REDACTED]}", c.baseURL, c.authMode)
+}
+
+// setAuth sets the Authorization header on req based on the client's auth mode.
+func (c *Client) setAuth(req *http.Request) {
+	switch c.authMode {
+	case AuthBasic:
+		creds := base64.StdEncoding.EncodeToString([]byte(c.email + ":" + c.token))
+		req.Header.Set("Authorization", "Basic "+creds)
+	default:
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// WithEmail sets the email address used for Basic authentication.
+func WithEmail(email string) ClientOption {
+	return func(c *Client) { c.email = email }
+}
+
+// WithAuthMode sets the authentication mode (Bearer or Basic).
+func WithAuthMode(mode AuthMode) ClientOption {
+	return func(c *Client) { c.authMode = mode }
+}
+
+// WithBaseURL overrides the default Bitbucket API base URL.
+func WithBaseURL(baseURL string) ClientOption {
+	return func(c *Client) { c.baseURL = baseURL }
+}
+
+// WithTimeout sets the HTTP client timeout.
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(c *Client) { c.httpClient.Timeout = timeout }
+}
+
+// WithConcurrency sets the maximum number of concurrent requests.
+func WithConcurrency(max int64) ClientOption {
+	return func(c *Client) {
+		if max > 0 {
+			c.semaphore = semaphore.NewWeighted(max)
+		}
+	}
+}
+
+// WithHTTPTransport sets a custom HTTP transport on the underlying client.
+func WithHTTPTransport(transport http.RoundTripper) ClientOption {
+	return func(c *Client) { c.httpClient.Transport = transport }
+}
+
+// NewClient creates a new Bitbucket Cloud REST API v2 client.
+// The token is required. Use ClientOption functions to configure
+// auth mode, base URL, email (for Basic auth), and other settings.
+func NewClient(token string, opts ...ClientOption) *Client {
+	c := &Client{
+		httpClient: &http.Client{Timeout: DefaultTimeout},
+		baseURL:    DefaultBaseURL,
+		token:      token,
+		authMode:   AuthBearer,
+		semaphore:  semaphore.NewWeighted(MaxConcurrentRequests),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}

--- a/pkg/bitbucket/client_http.go
+++ b/pkg/bitbucket/client_http.go
@@ -1,0 +1,166 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+// bitbucketErrorResponse is the standard Bitbucket API error envelope.
+type bitbucketErrorResponse struct {
+	Error struct {
+		Message string `json:"message"`
+		Detail  string `json:"detail"`
+	} `json:"error"`
+}
+
+// doRequest performs an HTTP request with authentication and concurrency control.
+// It handles 429 rate limiting with retries and returns an *APIError for non-2xx responses.
+func (c *Client) doRequest(ctx context.Context, method, path string) (*http.Response, error) {
+	const maxRetries = 3
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		// Acquire semaphore for concurrency control
+		if err := c.semaphore.Acquire(ctx, 1); err != nil {
+			return nil, fmt.Errorf("semaphore acquire: %w", err)
+		}
+
+		// Build full URL
+		reqURL := c.baseURL + path
+
+		// Create request
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+		if err != nil {
+			c.semaphore.Release(1)
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+
+		// Set authentication and accept headers
+		c.setAuth(req)
+		req.Header.Set("Accept", "application/json")
+
+		// Perform request
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			c.semaphore.Release(1)
+			return nil, fmt.Errorf("performing request: %w", err)
+		}
+
+		// Handle 429 rate limit with retry
+		if resp.StatusCode == http.StatusTooManyRequests {
+			retryAfter := resp.Header.Get("Retry-After")
+			seconds := 60
+			if retryAfter != "" {
+				if parsed, err := strconv.Atoi(retryAfter); err == nil && parsed > 0 {
+					seconds = parsed
+					if seconds > 300 {
+						seconds = 300
+					}
+				}
+			}
+
+			resp.Body.Close()
+			c.semaphore.Release(1)
+
+			if attempt >= maxRetries {
+				return nil, fmt.Errorf("API error 429: rate limited after %d attempts", maxRetries)
+			}
+
+			fmt.Fprintf(os.Stderr, "Bitbucket rate limited (attempt %d/%d). Retrying after %d seconds\n", attempt, maxRetries, seconds)
+
+			select {
+			case <-time.After(time.Duration(seconds) * time.Second):
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		// Check for other error status codes
+		if resp.StatusCode >= 400 {
+			c.semaphore.Release(1)
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, parseAPIError(resp.StatusCode, body)
+		}
+
+		// Success - release semaphore and return
+		c.semaphore.Release(1)
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("unexpected: exceeded max retries without returning")
+}
+
+// getRawResponse performs an HTTP request and returns the raw response
+// WITHOUT checking status codes. This is used by callers that need to
+// inspect headers or bodies from error responses (e.g., GetTokenInfo
+// reads scopes from 403 responses).
+func (c *Client) getRawResponse(ctx context.Context, method, path string) (*http.Response, error) {
+	// Acquire semaphore for concurrency control
+	if err := c.semaphore.Acquire(ctx, 1); err != nil {
+		return nil, fmt.Errorf("semaphore acquire: %w", err)
+	}
+	defer c.semaphore.Release(1)
+
+	// Build full URL
+	reqURL := c.baseURL + path
+
+	// Create request
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	// Set authentication and accept headers
+	c.setAuth(req)
+	req.Header.Set("Accept", "application/json")
+
+	// Perform request
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("performing request: %w", err)
+	}
+
+	return resp, nil
+}
+
+// getJSON performs a GET request and decodes the JSON response into result.
+func (c *Client) getJSON(ctx context.Context, path string, result interface{}) error {
+	resp, err := c.doRequest(ctx, "GET", path)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+		return fmt.Errorf("decoding JSON: %w", err)
+	}
+
+	return nil
+}
+
+// parseAPIError constructs an *APIError from a non-2xx response body.
+// It attempts to parse the Bitbucket error JSON envelope; if that fails
+// it falls back to using the raw body as the message.
+func parseAPIError(statusCode int, body []byte) *APIError {
+	apiErr := &APIError{
+		StatusCode: statusCode,
+		Body:       string(body),
+	}
+
+	var errResp bitbucketErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Error.Message != "" {
+		apiErr.Message = errResp.Error.Message
+		apiErr.Detail = errResp.Error.Detail
+	} else {
+		apiErr.Message = string(body)
+	}
+
+	return apiErr
+}

--- a/pkg/bitbucket/enumerate_types.go
+++ b/pkg/bitbucket/enumerate_types.go
@@ -1,0 +1,25 @@
+package bitbucket
+
+// TokenEnumerateResult holds the full result of a token enumeration.
+type TokenEnumerateResult struct {
+	TokenInfo *TokenInfo     `json:"token_info"`
+	User      *User          `json:"user,omitempty"`
+	RateLimit *RateLimitInfo `json:"rate_limit,omitempty"`
+	Errors    []string       `json:"errors,omitempty"`
+}
+
+// User represents a Bitbucket Cloud user account.
+type User struct {
+	DisplayName   string `json:"display_name"`
+	Username      string `json:"username"`
+	UUID          string `json:"uuid"`
+	AccountID     string `json:"account_id"`
+	AccountStatus string `json:"account_status"`
+	IsStaff       bool   `json:"is_staff"`
+}
+
+// RateLimitInfo holds rate-limiting metadata from the API response.
+type RateLimitInfo struct {
+	Limit     int  `json:"limit"`
+	NearLimit bool `json:"near_limit"`
+}

--- a/pkg/bitbucket/errors.go
+++ b/pkg/bitbucket/errors.go
@@ -1,0 +1,42 @@
+package bitbucket
+
+import (
+	"errors"
+	"fmt"
+)
+
+// APIError represents a non-2xx HTTP response from the Bitbucket API.
+// It carries the status code and response details so callers can inspect
+// the specific error condition without string parsing.
+type APIError struct {
+	StatusCode int
+	Message    string
+	Detail     string
+	Body       string
+}
+
+// Error implements the error interface.
+func (e *APIError) Error() string {
+	return fmt.Sprintf("API error %d: %s", e.StatusCode, e.Message)
+}
+
+// IsPermissionError reports whether err (or any error in its chain)
+// is a 403 Forbidden response from the Bitbucket API.
+func IsPermissionError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 403
+}
+
+// IsNotFoundError reports whether err (or any error in its chain)
+// is a 404 Not Found response from the Bitbucket API.
+func IsNotFoundError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 404
+}
+
+// IsGoneError reports whether err (or any error in its chain)
+// is a 410 Gone response from the Bitbucket API.
+func IsGoneError(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == 410
+}

--- a/pkg/bitbucket/init.go
+++ b/pkg/bitbucket/init.go
@@ -1,0 +1,12 @@
+package bitbucket
+
+import (
+	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+)
+
+func init() {
+	registry.RegisterPlatform("bitbucket", func() platforms.Platform {
+		return NewPlatform()
+	})
+}

--- a/pkg/bitbucket/scopes.go
+++ b/pkg/bitbucket/scopes.go
@@ -1,0 +1,200 @@
+package bitbucket
+
+import (
+	"sort"
+	"strings"
+)
+
+// ScopeFormat distinguishes between the two Bitbucket scope systems.
+type ScopeFormat string
+
+const (
+	// ScopeFormatLegacy is the access token scope format (e.g., "repository:admin").
+	ScopeFormatLegacy ScopeFormat = "legacy"
+	// ScopeFormatFineGrained is the API token scope format (e.g., "read:repository:bitbucket").
+	ScopeFormatFineGrained ScopeFormat = "fine_grained"
+)
+
+// ScopeLevel represents the permission level within a scope category.
+type ScopeLevel string
+
+const (
+	ScopeLevelRead     ScopeLevel = "read"
+	ScopeLevelWrite    ScopeLevel = "write"
+	ScopeLevelAdmin    ScopeLevel = "admin"
+	ScopeLevelDelete   ScopeLevel = "delete"
+	ScopeLevelVariable ScopeLevel = "variable"
+)
+
+// Scopes represents parsed OAuth scopes from a Bitbucket token.
+type Scopes struct {
+	raw          string
+	format       ScopeFormat
+	capabilities map[string]map[ScopeLevel]bool
+}
+
+// scopeEntry pairs a category with a level for the implication table.
+type scopeEntry struct {
+	category string
+	level    ScopeLevel
+}
+
+// legacyImplications is a pre-computed transitive closure of scope implications.
+// Each key maps to ALL capabilities it grants, including transitive ones.
+// The x-oauth-scopes header only reports the highest granted level, so the
+// parser must expand each scope to its full set of implied capabilities.
+var legacyImplications = map[string][]scopeEntry{
+	"project":           {{category: "project", level: ScopeLevelRead}, {category: "repository", level: ScopeLevelRead}},
+	"project:admin":     {{category: "project", level: ScopeLevelAdmin}},
+	"repository":        {{category: "repository", level: ScopeLevelRead}},
+	"repository:write":  {{category: "repository", level: ScopeLevelWrite}, {category: "repository", level: ScopeLevelRead}},
+	"repository:admin":  {{category: "repository", level: ScopeLevelAdmin}},
+	"repository:delete": {{category: "repository", level: ScopeLevelDelete}},
+	"pullrequest":       {{category: "pullrequest", level: ScopeLevelRead}, {category: "repository", level: ScopeLevelRead}},
+	"pullrequest:write": {
+		{category: "pullrequest", level: ScopeLevelWrite}, {category: "pullrequest", level: ScopeLevelRead},
+		{category: "repository", level: ScopeLevelWrite}, {category: "repository", level: ScopeLevelRead},
+	},
+	"webhook":           {{category: "webhook", level: ScopeLevelRead}, {category: "webhook", level: ScopeLevelWrite}},
+	"pipeline":          {{category: "pipeline", level: ScopeLevelRead}},
+	"pipeline:write":    {{category: "pipeline", level: ScopeLevelWrite}, {category: "pipeline", level: ScopeLevelRead}},
+	"pipeline:variable": {
+		{category: "pipeline", level: ScopeLevelVariable},
+		{category: "pipeline", level: ScopeLevelWrite},
+		{category: "pipeline", level: ScopeLevelRead},
+	},
+	"runner":       {{category: "runner", level: ScopeLevelRead}},
+	"runner:write": {{category: "runner", level: ScopeLevelWrite}, {category: "runner", level: ScopeLevelRead}},
+	"test":         {{category: "test", level: ScopeLevelRead}},
+	"test:write":   {{category: "test", level: ScopeLevelWrite}, {category: "test", level: ScopeLevelRead}},
+	"account":      {{category: "account", level: ScopeLevelRead}},
+}
+
+// ParseScopes parses the x-oauth-scopes header value into a Scopes object.
+// The format parameter determines how scope strings are interpreted.
+func ParseScopes(header string, format ScopeFormat) *Scopes {
+	s := &Scopes{
+		raw:          header,
+		format:       format,
+		capabilities: make(map[string]map[ScopeLevel]bool),
+	}
+
+	if header == "" {
+		return s
+	}
+
+	scopes := strings.Split(header, ",")
+
+	switch format {
+	case ScopeFormatLegacy:
+		s.parseLegacy(scopes)
+	case ScopeFormatFineGrained:
+		s.parseFineGrained(scopes)
+	}
+
+	return s
+}
+
+// parseLegacy processes legacy-format scopes by expanding each through
+// the implication graph.
+func (s *Scopes) parseLegacy(scopes []string) {
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		entries, ok := legacyImplications[scope]
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			s.addCapability(entry.category, entry.level)
+		}
+	}
+}
+
+// parseFineGrained processes fine-grained scopes in the format
+// "{action}:{resource}:bitbucket". Each scope is independent with no implications.
+func (s *Scopes) parseFineGrained(scopes []string) {
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		parts := strings.SplitN(scope, ":", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		action := parts[0]
+		resource := parts[1]
+		s.addCapability(resource, ScopeLevel(action))
+	}
+}
+
+// addCapability records a capability in the internal map.
+func (s *Scopes) addCapability(category string, level ScopeLevel) {
+	if s.capabilities[category] == nil {
+		s.capabilities[category] = make(map[ScopeLevel]bool)
+	}
+	s.capabilities[category][level] = true
+}
+
+// HasCapability reports whether the token has a specific capability.
+func (s *Scopes) HasCapability(category string, level ScopeLevel) bool {
+	if s == nil || s.capabilities == nil {
+		return false
+	}
+	levels, ok := s.capabilities[category]
+	if !ok {
+		return false
+	}
+	return levels[level]
+}
+
+// Categories returns a sorted list of all scope categories.
+func (s *Scopes) Categories() []string {
+	if s == nil || s.capabilities == nil {
+		return nil
+	}
+	cats := make([]string, 0, len(s.capabilities))
+	for cat := range s.capabilities {
+		cats = append(cats, cat)
+	}
+	sort.Strings(cats)
+	return cats
+}
+
+// Levels returns the permission levels granted for a specific category.
+func (s *Scopes) Levels(category string) []ScopeLevel {
+	if s == nil || s.capabilities == nil {
+		return nil
+	}
+	levels, ok := s.capabilities[category]
+	if !ok {
+		return nil
+	}
+	result := make([]ScopeLevel, 0, len(levels))
+	for level := range levels {
+		result = append(result, level)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return string(result[i]) < string(result[j])
+	})
+	return result
+}
+
+// Raw returns the original unparsed scope header value.
+func (s *Scopes) Raw() string {
+	if s == nil {
+		return ""
+	}
+	return s.raw
+}
+
+// Format returns the scope format (legacy or fine-grained).
+func (s *Scopes) Format() ScopeFormat {
+	if s == nil {
+		return ""
+	}
+	return s.format
+}

--- a/pkg/bitbucket/scopes_test.go
+++ b/pkg/bitbucket/scopes_test.go
@@ -1,0 +1,266 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseScopes_Legacy(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		wantCaps map[string][]ScopeLevel
+		notCaps  map[string][]ScopeLevel
+	}{
+		{
+			name:   "single scope repository read",
+			header: "repository",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelWrite, ScopeLevelAdmin},
+			},
+		},
+		{
+			name:   "pullrequest:write implies pullrequest and repository read+write",
+			header: "pullrequest:write",
+			wantCaps: map[string][]ScopeLevel{
+				"pullrequest": {ScopeLevelWrite, ScopeLevelRead},
+				"repository":  {ScopeLevelWrite, ScopeLevelRead},
+			},
+		},
+		{
+			name:   "repository:admin is standalone - does NOT imply read",
+			header: "repository:admin",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelAdmin},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead, ScopeLevelWrite},
+			},
+		},
+		{
+			name:   "project:admin is standalone - does NOT imply project read",
+			header: "project:admin",
+			wantCaps: map[string][]ScopeLevel{
+				"project": {ScopeLevelAdmin},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"project":    {ScopeLevelRead},
+				"repository": {ScopeLevelRead},
+			},
+		},
+		{
+			name:   "repository:delete is standalone",
+			header: "repository:delete",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelDelete},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead, ScopeLevelWrite},
+			},
+		},
+		{
+			name:   "multiple scopes combined",
+			header: "repository:admin, repository:write, pipeline:variable",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelAdmin, ScopeLevelWrite, ScopeLevelRead},
+				"pipeline":   {ScopeLevelVariable, ScopeLevelWrite, ScopeLevelRead},
+			},
+		},
+		{
+			name:   "pipeline:variable transitive - has variable, write, and read",
+			header: "pipeline:variable",
+			wantCaps: map[string][]ScopeLevel{
+				"pipeline": {ScopeLevelVariable, ScopeLevelWrite, ScopeLevelRead},
+			},
+		},
+		{
+			name:   "project implies project read and repository read",
+			header: "project",
+			wantCaps: map[string][]ScopeLevel{
+				"project":    {ScopeLevelRead},
+				"repository": {ScopeLevelRead},
+			},
+		},
+		{
+			name:     "empty string",
+			header:   "",
+			wantCaps: nil,
+		},
+		{
+			name:   "comma-only separation (no spaces)",
+			header: "repository:admin,repository:write,pipeline",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelAdmin, ScopeLevelWrite, ScopeLevelRead},
+				"pipeline":   {ScopeLevelRead},
+			},
+		},
+		{
+			name:   "unknown scopes are silently dropped",
+			header: "repository,unknown_scope,pipeline",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead},
+				"pipeline":   {ScopeLevelRead},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"unknown_scope": {ScopeLevelRead},
+			},
+		},
+		{
+			name:   "webhook grants both read and write",
+			header: "webhook",
+			wantCaps: map[string][]ScopeLevel{
+				"webhook": {ScopeLevelRead, ScopeLevelWrite},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := ParseScopes(tt.header, ScopeFormatLegacy)
+			require.NotNil(t, s)
+			assert.Equal(t, ScopeFormatLegacy, s.Format())
+			assert.Equal(t, tt.header, s.Raw())
+
+			for category, levels := range tt.wantCaps {
+				for _, level := range levels {
+					assert.True(t, s.HasCapability(category, level),
+						"expected %s:%s to be present", category, level)
+				}
+			}
+
+			for category, levels := range tt.notCaps {
+				for _, level := range levels {
+					assert.False(t, s.HasCapability(category, level),
+						"expected %s:%s to NOT be present", category, level)
+				}
+			}
+		})
+	}
+}
+
+func TestParseScopes_FineGrained(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		wantCaps map[string][]ScopeLevel
+		notCaps  map[string][]ScopeLevel
+	}{
+		{
+			name:   "single fine-grained scope",
+			header: "read:repository:bitbucket",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelWrite},
+			},
+		},
+		{
+			name:   "multiple fine-grained scopes",
+			header: "read:repository:bitbucket, write:repository:bitbucket",
+			wantCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead, ScopeLevelWrite},
+			},
+		},
+		{
+			name:     "empty string",
+			header:   "",
+			wantCaps: nil,
+		},
+		{
+			name:   "malformed scopes with only 2 parts are dropped",
+			header: "read:repository,write:pipeline:bitbucket",
+			wantCaps: map[string][]ScopeLevel{
+				"pipeline": {ScopeLevelWrite},
+			},
+			notCaps: map[string][]ScopeLevel{
+				"repository": {ScopeLevelRead},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := ParseScopes(tt.header, ScopeFormatFineGrained)
+			require.NotNil(t, s)
+			assert.Equal(t, ScopeFormatFineGrained, s.Format())
+			assert.Equal(t, tt.header, s.Raw())
+
+			for category, levels := range tt.wantCaps {
+				for _, level := range levels {
+					assert.True(t, s.HasCapability(category, level),
+						"expected %s:%s to be present", category, level)
+				}
+			}
+
+			for category, levels := range tt.notCaps {
+				for _, level := range levels {
+					assert.False(t, s.HasCapability(category, level),
+						"expected %s:%s to NOT be present", category, level)
+				}
+			}
+		})
+	}
+}
+
+func TestScopes_HasCapability_NonExistent(t *testing.T) {
+	s := ParseScopes("repository", ScopeFormatLegacy)
+
+	assert.False(t, s.HasCapability("nonexistent", ScopeLevelRead),
+		"non-existent category should return false")
+	assert.False(t, s.HasCapability("repository", ScopeLevelAdmin),
+		"non-existent level should return false")
+}
+
+func TestScopes_HasCapability_Nil(t *testing.T) {
+	var s *Scopes
+	assert.False(t, s.HasCapability("repository", ScopeLevelRead))
+}
+
+func TestScopes_Categories(t *testing.T) {
+	s := ParseScopes("pullrequest:write, pipeline:variable", ScopeFormatLegacy)
+	cats := s.Categories()
+
+	assert.Equal(t, []string{"pipeline", "pullrequest", "repository"}, cats,
+		"categories should be sorted and include implied categories")
+}
+
+func TestScopes_Categories_Empty(t *testing.T) {
+	s := ParseScopes("", ScopeFormatLegacy)
+	assert.Empty(t, s.Categories())
+}
+
+func TestScopes_Categories_Nil(t *testing.T) {
+	var s *Scopes
+	assert.Nil(t, s.Categories())
+}
+
+func TestScopes_Levels(t *testing.T) {
+	s := ParseScopes("pipeline:variable", ScopeFormatLegacy)
+	levels := s.Levels("pipeline")
+
+	assert.Len(t, levels, 3)
+	assert.Contains(t, levels, ScopeLevelVariable)
+	assert.Contains(t, levels, ScopeLevelWrite)
+	assert.Contains(t, levels, ScopeLevelRead)
+}
+
+func TestScopes_Levels_NonExistent(t *testing.T) {
+	s := ParseScopes("repository", ScopeFormatLegacy)
+	assert.Nil(t, s.Levels("nonexistent"))
+}
+
+func TestScopes_Raw_Nil(t *testing.T) {
+	var s *Scopes
+	assert.Equal(t, "", s.Raw())
+}
+
+func TestScopes_Format_Nil(t *testing.T) {
+	var s *Scopes
+	assert.Equal(t, ScopeFormat(""), s.Format())
+}

--- a/pkg/bitbucket/tokeninfo.go
+++ b/pkg/bitbucket/tokeninfo.go
@@ -1,0 +1,158 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// TokenType identifies the kind of Bitbucket credential.
+type TokenType string
+
+const (
+	// TokenTypeWorkspace is a workspace-scoped access token.
+	TokenTypeWorkspace TokenType = "workspace_access_token"
+	// TokenTypeProject is a project-scoped access token.
+	TokenTypeProject TokenType = "project_access_token"
+	// TokenTypeRepo is a repository-scoped access token.
+	TokenTypeRepo TokenType = "repo_access_token"
+	// TokenTypeAPIToken is a user-level API token (ATATT3x prefix).
+	TokenTypeAPIToken TokenType = "api_token"
+	// TokenTypeUnknown is returned when the credential type header is missing or unrecognized.
+	TokenTypeUnknown TokenType = "unknown"
+)
+
+// TokenInfo holds metadata about a Bitbucket authentication token,
+// derived from the response headers of the /2.0/user endpoint.
+type TokenInfo struct {
+	Type       TokenType `json:"type"`
+	AuthMethod string    `json:"auth_method"` // "bearer" or "basic"
+	Scopes     *Scopes   `json:"-"`           // Parsed scopes (excluded from JSON)
+	RawScopes  []string  `json:"scopes"`      // Raw scope strings for JSON output
+}
+
+// mapCredentialType converts the x-credential-type header value to a TokenType constant.
+func mapCredentialType(value string) TokenType {
+	switch value {
+	case "workspace_access_token":
+		return TokenTypeWorkspace
+	case "project_access_token":
+		return TokenTypeProject
+	case "repo_access_token":
+		return TokenTypeRepo
+	case "api_token":
+		return TokenTypeAPIToken
+	default:
+		return TokenTypeUnknown
+	}
+}
+
+// GetTokenInfo retrieves token metadata by calling the /2.0/user endpoint
+// and inspecting the response headers. For API tokens (Basic auth) the
+// endpoint returns 200 with user information. For access tokens (Bearer auth)
+// it returns 403, but the headers still contain scope and credential type data.
+// A 401 response indicates an invalid token.
+func (c *Client) GetTokenInfo(ctx context.Context) (*TokenInfo, *User, *RateLimitInfo, error) {
+	resp, err := c.getRawResponse(ctx, "GET", "/2.0/user")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("calling /2.0/user: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Parse response headers
+	credType := resp.Header.Get("x-credential-type")
+	scopeHeader := resp.Header.Get("x-oauth-scopes")
+
+	// Build raw scopes list from header
+	var rawScopes []string
+	if scopeHeader != "" {
+		for _, s := range strings.Split(scopeHeader, ",") {
+			trimmed := strings.TrimSpace(s)
+			if trimmed != "" {
+				rawScopes = append(rawScopes, trimmed)
+			}
+		}
+	}
+	if rawScopes == nil {
+		rawScopes = []string{}
+	}
+
+	// Parse rate limit info (only present when Bitbucket enforces limits)
+	var rateLimit *RateLimitInfo
+	if limitStr := resp.Header.Get("x-ratelimit-limit"); limitStr != "" {
+		rateLimit = &RateLimitInfo{}
+		if parsed, parseErr := strconv.Atoi(limitStr); parseErr == nil {
+			rateLimit.Limit = parsed
+		}
+		// x-ratelimit-nearlimit is a numeric threshold, not a boolean
+		if nearLimitStr := resp.Header.Get("x-ratelimit-nearlimit"); nearLimitStr != "" {
+			if threshold, parseErr := strconv.Atoi(nearLimitStr); parseErr == nil {
+				rateLimit.NearLimit = rateLimit.Limit > 0 && threshold > 0
+			}
+		}
+	}
+
+	// Determine scope format based on auth mode
+	var format ScopeFormat
+	switch c.authMode {
+	case AuthBasic:
+		format = ScopeFormatFineGrained
+	default:
+		format = ScopeFormatLegacy
+	}
+
+	// Parse scopes
+	scopes := ParseScopes(scopeHeader, format)
+
+	// Determine auth method string
+	authMethod := "bearer"
+	if c.authMode == AuthBasic {
+		authMethod = "basic"
+	}
+
+	// Handle response based on status code
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// API token — parse user from body
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return nil, nil, nil, fmt.Errorf("reading response body: %w", readErr)
+		}
+
+		var user User
+		if jsonErr := json.Unmarshal(body, &user); jsonErr != nil {
+			return nil, nil, nil, fmt.Errorf("decoding user: %w", jsonErr)
+		}
+
+		info := &TokenInfo{
+			Type:       mapCredentialType(credType),
+			AuthMethod: authMethod,
+			Scopes:     scopes,
+			RawScopes:  rawScopes,
+		}
+		return info, &user, rateLimit, nil
+
+	case resp.StatusCode == http.StatusForbidden:
+		// Access token — no user info but headers are valid
+		info := &TokenInfo{
+			Type:       mapCredentialType(credType),
+			AuthMethod: authMethod,
+			Scopes:     scopes,
+			RawScopes:  rawScopes,
+		}
+		return info, nil, rateLimit, nil
+
+	case resp.StatusCode == http.StatusUnauthorized:
+		if c.authMode == AuthBasic {
+			return nil, nil, nil, fmt.Errorf("authentication failed (HTTP 401): verify both email and token are correct")
+		}
+		return nil, nil, nil, fmt.Errorf("token is invalid (HTTP 401)")
+
+	default:
+		return nil, nil, nil, fmt.Errorf("unexpected status %d from /2.0/user", resp.StatusCode)
+	}
+}

--- a/pkg/platforms/all/all.go
+++ b/pkg/platforms/all/all.go
@@ -5,6 +5,7 @@ package all
 import (
 	// Import all platform implementations to trigger init() registration
 	_ "github.com/praetorian-inc/trajan/pkg/azuredevops"
+	_ "github.com/praetorian-inc/trajan/pkg/bitbucket"
 	_ "github.com/praetorian-inc/trajan/pkg/github"
 	_ "github.com/praetorian-inc/trajan/pkg/gitlab"
 	_ "github.com/praetorian-inc/trajan/pkg/jenkins"

--- a/pkg/platforms/platform.go
+++ b/pkg/platforms/platform.go
@@ -14,6 +14,7 @@ const (
 	PlatformAzureDevOps = "azuredevops"
 	PlatformJFrog       = "jfrog"
 	PlatformJenkins     = "jenkins"
+	PlatformBitbucket   = "bitbucket"
 )
 
 // TargetType represents what kind of target to scan
@@ -66,6 +67,12 @@ type JenkinsAuth struct {
 	Token    string `json:"token,omitempty"`
 }
 
+// BitbucketAuth contains Bitbucket-specific authentication
+type BitbucketAuth struct {
+	Token string `json:"token,omitempty"` // ATCTT3x (access) or ATATT3x (API)
+	Email string `json:"email,omitempty"` // Required for ATATT3x tokens
+}
+
 // Config holds platform configuration
 type Config struct {
 	// Existing fields (keep these)
@@ -80,6 +87,7 @@ type Config struct {
 	AzureDevOps *AzureDevOpsAuth `json:"azuredevops,omitempty"`
 	JFrog       *JFrogAuth       `json:"jfrog,omitempty"`
 	Jenkins     *JenkinsAuth     `json:"jenkins,omitempty"`
+	Bitbucket   *BitbucketAuth   `json:"bitbucket,omitempty"`
 
 	// HTTPTransport sets a custom HTTP transport. Used in browser (WASM) context
 	// to proxy requests through localhost, bypassing CORS restrictions.


### PR DESCRIPTION
## Summary

- Implements `trajan bitbucket enumerate token` for validating Bitbucket Cloud tokens and reporting type, scopes, identity, and rate limit status
- Supports all four token types: workspace, project, and repository access tokens (Bearer auth) plus personal API tokens (Basic auth with email)
- Token introspection via single `GET /2.0/user` call — reads `x-credential-type` and `x-oauth-scopes` headers (available even on 403 responses from access tokens)
- Dual scope system: legacy format with empirically verified implication graph (pre-computed transitive closure), and fine-grained format with independent scopes and grouped category display
- Adds `BitbucketAuth` to platform config, `GetEmailForPlatform` to cmdutil, and registers bitbucket in the platform registry

## Test plan

- [x] All 17 scope parsing tests pass (legacy implications, fine-grained, edge cases)
- [x] Full test suite (105 packages) passes with zero regressions
- [x] Live-tested against 10 tokens: workspace, project, repo (full + scoped), API tokens (admin, user, scoped)
- [x] Verified edge cases: no token, API token without email, wrong email, invalid token, access token with email
- [x] Console and JSON output verified for both token families
- [x] Three independent code reviews completed (architecture, code quality, security)

LAB-2223