### PR TITLE
feat(github): extend support for GitHub Enterprise Server

### DIFF
--- a/cmd/trajan/github/attack.go
+++ b/cmd/trajan/github/attack.go
@@ -241,6 +241,9 @@ func runAttack(cmd *cobra.Command, args []string) error {
 		Token:       t,
 		Concurrency: 10,
 	}
+	if url := getURL(cmd); url != "" {
+		initConfig.BaseURL = url
+	}
 	cmdutil.ApplyProxyFlags(cmd, &initConfig)
 
 	if err := platform.Init(ctx, initConfig); err != nil {
@@ -515,6 +518,9 @@ func runAttackCleanup(cmd *cobra.Command, args []string) error {
 	initConfig := platforms.Config{
 		Token:       t,
 		Concurrency: 10,
+	}
+	if url := getURL(cmd); url != "" {
+		initConfig.BaseURL = url
 	}
 	cmdutil.ApplyProxyFlags(cmd, &initConfig)
 

--- a/cmd/trajan/github/enumerate/repos.go
+++ b/cmd/trajan/github/enumerate/repos.go
@@ -72,6 +72,9 @@ func runReposEnumerate(cmd *cobra.Command, args []string) error {
 	config := platforms.Config{
 		Token: token,
 	}
+	if url := getURL(cmd); url != "" {
+		config.BaseURL = url
+	}
 	cmdutil.ApplyProxyFlags(cmd, &config)
 
 	if err := platform.Init(ctx, config); err != nil {

--- a/cmd/trajan/github/enumerate/root.go
+++ b/cmd/trajan/github/enumerate/root.go
@@ -33,3 +33,10 @@ func NewEnumerateCmd() *cobra.Command {
 func getToken(cmd *cobra.Command) string {
 	return cmdutil.GetTokenForPlatform(cmd, "github")
 }
+
+// getURL returns the GitHub base URL from the --url persistent flag inherited
+// from the parent github command. Returns empty string when unset.
+func getURL(cmd *cobra.Command) string {
+	url, _ := cmd.Flags().GetString("url")
+	return url
+}

--- a/cmd/trajan/github/enumerate/secrets.go
+++ b/cmd/trajan/github/enumerate/secrets.go
@@ -75,6 +75,9 @@ func runSecretsEnumerate(cmd *cobra.Command, args []string) error {
 	config := platforms.Config{
 		Token: token,
 	}
+	if url := getURL(cmd); url != "" {
+		config.BaseURL = url
+	}
 	cmdutil.ApplyProxyFlags(cmd, &config)
 
 	if err := platform.Init(ctx, config); err != nil {

--- a/cmd/trajan/github/enumerate/token.go
+++ b/cmd/trajan/github/enumerate/token.go
@@ -63,6 +63,9 @@ func runTokenEnumerate(cmd *cobra.Command, args []string) error {
 	config := platforms.Config{
 		Token: token,
 	}
+	if url := getURL(cmd); url != "" {
+		config.BaseURL = url
+	}
 	cmdutil.ApplyProxyFlags(cmd, &config)
 
 	if err := platform.Init(ctx, config); err != nil {

--- a/cmd/trajan/github/retrieve.go
+++ b/cmd/trajan/github/retrieve.go
@@ -91,6 +91,9 @@ func runRetrieve(cmd *cobra.Command, args []string) error {
 		Token:       t,
 		Concurrency: 10,
 	}
+	if url := getURL(cmd); url != "" {
+		initConfig.BaseURL = url
+	}
 	cmdutil.ApplyProxyFlags(cmd, &initConfig)
 	if err := platform.Init(context.Background(), initConfig); err != nil {
 		return fmt.Errorf("initializing GitHub platform: %w", err)

--- a/cmd/trajan/github/root.go
+++ b/cmd/trajan/github/root.go
@@ -18,8 +18,19 @@ func init() {
 	GitHubCmd.AddCommand(attackCmd)
 	GitHubCmd.AddCommand(retrieveCmd)
 	GitHubCmd.AddCommand(searchCmd)
+
+	// GitHub-specific flags
+	GitHubCmd.PersistentFlags().SortFlags = false
+	GitHubCmd.PersistentFlags().String("url", "", "base URL for GitHub Enterprise Server (e.g., https://github.example.com/api/v3)")
 }
 
 func getToken(cmd *cobra.Command) string {
 	return cmdutil.GetTokenForPlatform(cmd, "github")
+}
+
+// getURL returns the GitHub base URL from the --url persistent flag.
+// Returns empty string when unset, in which case the default github.com URL is used.
+func getURL(cmd *cobra.Command) string {
+	url, _ := cmd.Flags().GetString("url")
+	return url
 }

--- a/cmd/trajan/github/scan.go
+++ b/cmd/trajan/github/scan.go
@@ -92,6 +92,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	config := buildPlatformConfig(t)
+	if url := getURL(cmd); url != "" {
+		config.BaseURL = url
+	}
 	cmdutil.ApplyProxyFlags(cmd, &config)
 
 	if err := platform.Init(ctx, config); err != nil {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -202,6 +202,10 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 		return fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/html") {
+		return fmt.Errorf("server returned HTML instead of JSON (Content-Type: %s) — GitHub Enterprise Server may be in maintenance/replication mode, or the --url may be incorrect", ct)
+	}
+
 	return json.NewDecoder(resp.Body).Decode(v)
 }
 

--- a/pkg/github/client_write.go
+++ b/pkg/github/client_write.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // === Pull Request Operations ===
@@ -613,6 +614,11 @@ func (c *Client) doWrite(ctx context.Context, method, path string, body io.Reade
 
 	// Update rate limiter from response
 	c.rateLimiter.Update(resp.Header)
+
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/html") {
+		resp.Body.Close()
+		return nil, fmt.Errorf("server returned HTML instead of JSON (Content-Type: %s) — GitHub Enterprise Server may be in maintenance/replication mode, or the --url may be incorrect", ct)
+	}
 
 	return resp, nil
 }

--- a/pkg/github/tokeninfo.go
+++ b/pkg/github/tokeninfo.go
@@ -116,6 +116,10 @@ func (c *Client) GetTokenInfo(ctx context.Context) (*TokenInfo, error) {
 		return nil, fmt.Errorf("token validation failed (%d): %s", resp.StatusCode, body)
 	}
 
+	if ct := resp.Header.Get("Content-Type"); strings.Contains(ct, "text/html") {
+		return nil, fmt.Errorf("server returned HTML instead of JSON (Content-Type: %s) — GitHub Enterprise Server may be in maintenance/replication mode, or the --url may be incorrect", ct)
+	}
+
 	var user User
 	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
 		return nil, fmt.Errorf("decoding user response: %w", err)


### PR DESCRIPTION
Closes LAB-2105

## Summary

- Adds a `--url` persistent flag to the `trajan github` command, enabling all subcommands (scan, attack, retrieve, enumerate) to target a GitHub Enterprise Server instance instead of defaulting to `api.github.com`
- Adds Content-Type validation before JSON decoding to surface clearer errors when GHES is in maintenance/replication mode or the URL is incorrect
- Mirrors the existing `--url` pattern used by GitLab and Jenkins commands to ensure parity across platforms

## Test plan

- [x] Verify `trajan github enumerate token --url <ghes-url> --token <pat>` returns token info from the GHES instance
- [x] Verify `trajan github scan --url <ghes-url> --repo <owner/repo>` scans against GHES
- [x] Verify omitting `--url` preserves default github.com behavior
- [x] Verify `--url` flag appears in `trajan github --help` and is inherited by all subcommands
- [x] Verify clear error message when GHES is in maintenance mode (HTML response)