### PR TITLE
chore(ci): harden claude-code workflow (v2.0.10)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -2,15 +2,19 @@ name: Claude PR Assistant
 
 on:
   pull_request:
-    types: [synchronize, opened]
+    types: [opened, synchronize, reopened]
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: claude-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@main
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@135c50049eeef6e664bd7ea4aacaa33118083e30  # v2.0.10
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Supersedes #16. Same caller-visible changes as the prior PR (SHA pin, `contents: read`, concurrency, `reopened` trigger) but pinning to **v2.0.2** of `public-workflows/claude-code.yml` (commit `faa2e429...`).

v2.0.2 adds SHA-pinning of the reusable workflow's own internal actions — most importantly, replaces `anthropics/claude-code-action@beta` (a branch pin that runs with `ANTHROPIC_API_KEY` loaded) with an immutable SHA. Closes ENG-3093. No caller-visible behavior difference from v2.0.1.

Related: ENG-3081 SHA-pin policy, ENG-3093 (public-workflows internal hardening).