### PR TITLE
ci: migrate external-contrib to centralized reusable (v2.0.2)

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -9,4 +9,8 @@ on:
 jobs:
   notify:
     uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -13,4 +13,13 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    secrets: inherit
+    secrets:
+      EXTERNAL_CONTRIB_APP_ID: ${{ secrets.EXTERNAL_CONTRIB_APP_ID }}
+      EXTERNAL_CONTRIB_APP_PRIVATE_KEY: ${{ secrets.EXTERNAL_CONTRIB_APP_PRIVATE_KEY }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      LINEAR_ASSIGNEE_ID: ${{ secrets.LINEAR_ASSIGNEE_ID }}
+      LINEAR_PARENT_ISSUE_ID: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
+      LINEAR_PROJECT_ID: ${{ secrets.LINEAR_PROJECT_ID }}

--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -6,23 +6,7 @@ on:
   pull_request_target:
     types: [opened, assigned, closed]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   notify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: praetorian-inc/external-contrib-action@v2
-        with:
-          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
-          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          dry-run: "false"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@faa2e42989736cf9b3f47e5377dd5f2e0327517f  # v2.0.2
+    secrets: inherit


### PR DESCRIPTION
Replaces the broken inline `external-contribution.yml` (pinned to `external-contrib-action@v2`, PAT-based) with a caller to `public-workflows/external-contrib-notify.yml@v2.0.2`.

**Why now:** `ORG_MEMBER_CHECK_PAT` was removed from org-level secrets during the v3-App auth migration. The inline workflow reads that secret, so every PR has been hitting `ORG_MEMBER_CHECK_PAT environment variable is required` on the 'External Contribution Notify' check. This migration fixes that failure AND brings this repo onto the hardened centralized workflow path.

**What the reusable uses:**
- `EXTERNAL_CONTRIB_APP_ID` / `EXTERNAL_CONTRIB_APP_PRIVATE_KEY` via `praetorian-external-contrib-bot` GitHub App (org Members:Read only)
- `LINEAR_API_KEY`, `SLACK_BOT_TOKEN` (org-level)
- Per-repo `LINEAR_TEAM_ID`, `LINEAR_ASSIGNEE_ID`, `LINEAR_PARENT_ISSUE_ID`, `SLACK_CHANNEL_ID` (already present on this repo)

**Known pre-merge CI behavior:** the 'External Contribution Notify' check on THIS PR runs the OLD (broken) inline workflow from main because `pull_request_target` always uses the base branch. After merge, new PRs use the centralized caller.

Related: ENG-3100 (external-contrib centralization + hardening), ENG-3104 (migration sweep).