### PR TITLE
ci: migrate external-contribution.yml to centralized reusable workflow

### DIFF
--- a/.github/workflows/external-contribution.yml
+++ b/.github/workflows/external-contribution.yml
@@ -6,23 +6,21 @@ on:
   pull_request_target:
     types: [opened, assigned, closed]
 
+# Permissions are declared explicitly at the caller. Reusable workflows
+# cannot elevate GITHUB_TOKEN beyond what the caller grants, so if this
+# block is omitted the notify job falls back to org/repo default token
+# permissions — which may be read-only, causing Linear/GitHub comment
+# writes to fail with "Resource not accessible by integration".
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: praetorian-inc/external-contrib-action@v2
-        with:
-          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
-          linear-assignee-id: ${{ secrets.LINEAR_ASSIGNEE_ID }}
-          linear-parent-issue-id: ${{ secrets.LINEAR_PARENT_ISSUE_ID }}
-          slack-channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-          dry-run: "false"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORG_MEMBER_CHECK_PAT: ${{ secrets.ORG_MEMBER_CHECK_PAT }}
-          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: praetorian-inc/public-workflows/.github/workflows/external-contrib-notify.yml@4900fbd3aaf1992181e2ebfb108c71fee8250c67  # v2.0.1
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
Migrates `.github/workflows/external-contribution.yml` from the old standalone `praetorian-inc/external-contrib-action@v2` to the centralized `praetorian-inc/public-workflows/external-contrib-notify.yml@v2.0.1` reusable workflow.

Sibling PRs merged across augustus, aurelian, brutus (pending), caligula, cato, florian, hadrian, julius, nerva, titus, vespasian. This cleans up the last two repos still on the old pattern.

Replaces repo-level `ORG_MEMBER_CHECK_PAT` PAT auth with org-level `EXTERNAL_CONTRIB_APP_*` GitHub App credentials forwarded via `secrets: inherit`. Permissions block at the caller level grants `issues: write` / `pull-requests: write` for the auto-reply step (reusable can only reduce from caller, not elevate).

Part of ENG-3079.