### PR TITLE
feat(local): add --path flag for local workflow scanning (LAB-2079)

### DIFF
--- a/cmd/trajan/local/root.go
+++ b/cmd/trajan/local/root.go
@@ -1,0 +1,14 @@
+package local
+
+import "github.com/spf13/cobra"
+
+// LocalCmd is the root command for local filesystem scanning.
+var LocalCmd = &cobra.Command{
+	Use:   "local",
+	Short: "Trajan - Local",
+	Long:  "Trajan - Scan a local filesystem path for CI/CD workflow vulnerabilities",
+}
+
+func init() {
+	LocalCmd.AddCommand(scanCmd)
+}

--- a/cmd/trajan/local/scan.go
+++ b/cmd/trajan/local/scan.go
@@ -1,0 +1,144 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/praetorian-inc/trajan/internal/cmdutil"
+	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/detections"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+	"github.com/praetorian-inc/trajan/pkg/scanner"
+
+	// Import all platforms to trigger init() registration
+	_ "github.com/praetorian-inc/trajan/pkg/platforms/all"
+
+	// All detections (triggers init() registration)
+	_ "github.com/praetorian-inc/trajan/pkg/detections/all"
+)
+
+var (
+	scanPath        string
+	scanConcurrency int
+	severity        string
+	capabilities    string
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan a local filesystem path for CI/CD workflow vulnerabilities",
+	Long: `Trajan - Local - Scan
+
+Scan local CI/CD workflow files for security vulnerabilities.
+Walks the filesystem path and auto-detects the CI platform (GitHub Actions,
+GitLab CI, Jenkins, Azure Pipelines) based on file naming conventions.`,
+	RunE: runScan,
+}
+
+func init() {
+	scanCmd.Flags().SortFlags = false
+	scanCmd.Flags().StringVar(&scanPath, "path", "", "filesystem path to scan (file or directory)")
+	scanCmd.Flags().IntVar(&scanConcurrency, "concurrency", 10, "number of concurrent workers")
+	scanCmd.Flags().StringVar(&severity, "severity", "", "comma-separated severity levels to show (critical, high, medium, low, info)")
+	scanCmd.Flags().StringVar(&capabilities, "capabilities", "", "comma-separated detection types to run (e.g., pwn_request,artifact_poisoning)")
+}
+
+func runScan(cmd *cobra.Command, args []string) error {
+	if scanPath == "" {
+		return fmt.Errorf("must specify --path")
+	}
+
+	verbose := cmdutil.GetVerbose(cmd)
+	output := cmdutil.GetOutput(cmd)
+
+	ctx := context.Background()
+
+	platform, err := registry.GetPlatform("local")
+	if err != nil {
+		return fmt.Errorf("getting platform: %w", err)
+	}
+
+	config := platforms.Config{
+		Concurrency: scanConcurrency,
+	}
+	cmdutil.ApplyProxyFlags(cmd, &config)
+
+	if err := platform.Init(ctx, config); err != nil {
+		return fmt.Errorf("initializing platform: %w", err)
+	}
+
+	target := platforms.Target{Type: platforms.TargetLocal, Value: scanPath}
+
+	return executeScanAndOutput(ctx, platform, target, verbose, output)
+}
+
+// executeScanAndOutput performs vulnerability scan and outputs results.
+func executeScanAndOutput(ctx context.Context, platform platforms.Platform, target platforms.Target, verbose bool, output string) error {
+	result, err := platform.Scan(ctx, target)
+	if err != nil {
+		return fmt.Errorf("scanning: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Found %d repositories, %d workflows\n", len(result.Repositories), cmdutil.CountWorkflows(result.Workflows))
+
+	// Aggregate detections from all registered detection platforms so every
+	// discovered workflow file gets the right plugins.
+	var allPlugins []detections.Detection
+	for _, p := range registry.ListDetectionPlatforms() {
+		allPlugins = append(allPlugins, registry.GetDetections(p)...)
+	}
+
+	if verbose && len(allPlugins) == 0 {
+		fmt.Fprintf(os.Stderr, "Warning: no plugins registered\n")
+	}
+
+	fmt.Fprintf(os.Stderr, "Running %d detectors...\n", len(allPlugins))
+
+	executor := scanner.NewDetectionExecutor(allPlugins, scanConcurrency)
+	executor.SetMetadata("all_workflows", result.Workflows)
+
+	execResult, err := executor.Execute(ctx, result.Workflows)
+	if err != nil {
+		return fmt.Errorf("executing plugins: %w", err)
+	}
+
+	findings := execResult.Findings
+	if capabilities != "" {
+		filteredFindings, filterErr := cmdutil.FilterFindingsByCapabilities(execResult.Findings, capabilities)
+		if filterErr != nil {
+			return fmt.Errorf("filtering by capabilities: %w", filterErr)
+		}
+		findings = filteredFindings
+	}
+
+	if severity != "" {
+		filteredFindings, filterErr := cmdutil.FilterFindingsBySeverity(findings, severity)
+		if filterErr != nil {
+			return fmt.Errorf("filtering by severity: %w", filterErr)
+		}
+		findings = filteredFindings
+	}
+
+	fmt.Fprintf(os.Stderr, "Analysis complete: %d findings\n", len(findings))
+
+	if len(execResult.Errors) > 0 && verbose {
+		fmt.Fprintf(os.Stderr, "Warning: %d errors occurred during plugin execution\n", len(execResult.Errors))
+		for _, execErr := range execResult.Errors {
+			fmt.Fprintf(os.Stderr, "  - %v\n", execErr)
+		}
+	}
+
+	switch output {
+	case "json":
+		return cmdutil.OutputFindingsJSON(result, findings)
+	case "sarif":
+		return cmdutil.OutputFindingsSARIF(result, findings)
+	case "html":
+		return cmdutil.OutputFindingsHTML(result, findings)
+	default:
+		return cmdutil.OutputFindingsConsole(result, findings)
+	}
+}

--- a/cmd/trajan/root.go
+++ b/cmd/trajan/root.go
@@ -12,6 +12,7 @@ import (
 	gitlab "github.com/praetorian-inc/trajan/cmd/trajan/gitlab"
 	jenkins "github.com/praetorian-inc/trajan/cmd/trajan/jenkins"
 	jfrog "github.com/praetorian-inc/trajan/cmd/trajan/jfrog"
+	local "github.com/praetorian-inc/trajan/cmd/trajan/local"
 )
 
 var (
@@ -63,12 +64,14 @@ func init() {
 	ado.AdoCmd.GroupID = "platforms"
 	jenkins.JenkinsCmd.GroupID = "platforms"
 	jfrog.JFrogCmd.GroupID = "platforms"
+	local.LocalCmd.GroupID = "platforms"
 
 	rootCmd.AddCommand(ghcmd.GitHubCmd)
 	rootCmd.AddCommand(gitlab.GitLabCmd)
 	rootCmd.AddCommand(ado.AdoCmd)
 	rootCmd.AddCommand(jenkins.JenkinsCmd)
 	rootCmd.AddCommand(jfrog.JFrogCmd)
+	rootCmd.AddCommand(local.LocalCmd)
 
 	// Utility commands
 	searchCmd.Hidden = true

--- a/pkg/lib/lib.go
+++ b/pkg/lib/lib.go
@@ -64,6 +64,11 @@ type ScanConfig struct {
 
 	// Timeout is the maximum duration for the scan (default: 5 minutes).
 	Timeout time.Duration
+
+	// LocalPath, when set, scans the local filesystem path using the local
+	// platform. Platform is auto-set to "local" and Token/Org/Repo are not
+	// required.
+	LocalPath string
 }
 
 // ScanResult contains the complete results of a Trajan scan.
@@ -89,10 +94,32 @@ func applyDefaults(cfg ScanConfig) ScanConfig {
 	return cfg
 }
 
+// detectionsForScan returns the appropriate detections for a scan.
+// For local scans, it aggregates detections from all registered platforms so
+// that any discovered workflow file gets the right plugins regardless of CI
+// platform.
+func detectionsForScan(platform string) []detections.Detection {
+	if platform != platforms.PlatformLocal {
+		return registry.GetDetectionsForPlatform(platform)
+	}
+
+	// Local scan: aggregate detections from every registered detection platform.
+	var all []detections.Detection
+	for _, p := range registry.ListDetectionPlatforms() {
+		all = append(all, registry.GetDetections(p)...)
+	}
+	return all
+}
+
 // Scan performs a complete CI/CD security scan: platform initialization,
 // workflow discovery, and detection execution.
 func Scan(ctx context.Context, cfg ScanConfig) (*ScanResult, error) {
 	cfg = applyDefaults(cfg)
+
+	// Auto-configure platform for local path scans.
+	if cfg.LocalPath != "" && cfg.Platform == "" {
+		cfg.Platform = platforms.PlatformLocal
+	}
 
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
@@ -115,13 +142,18 @@ func Scan(ctx context.Context, cfg ScanConfig) (*ScanResult, error) {
 	}
 
 	// Build target
-	target := platforms.Target{
-		Type:  platforms.TargetRepo,
-		Value: cfg.Org + "/" + cfg.Repo,
-	}
-	if cfg.Repo == "" {
-		target.Type = platforms.TargetOrg
-		target.Value = cfg.Org
+	var target platforms.Target
+	if cfg.Platform == platforms.PlatformLocal {
+		target = platforms.Target{Type: platforms.TargetLocal, Value: cfg.LocalPath}
+	} else {
+		target = platforms.Target{
+			Type:  platforms.TargetRepo,
+			Value: cfg.Org + "/" + cfg.Repo,
+		}
+		if cfg.Repo == "" {
+			target.Type = platforms.TargetOrg
+			target.Value = cfg.Org
+		}
 	}
 
 	// Scan for workflows
@@ -131,7 +163,7 @@ func Scan(ctx context.Context, cfg ScanConfig) (*ScanResult, error) {
 	}
 
 	// Execute detections against the workflow map
-	dets := registry.GetDetectionsForPlatform(cfg.Platform)
+	dets := detectionsForScan(cfg.Platform)
 	executor := scanner.NewDetectionExecutor(dets, cfg.Concurrency)
 	execResult, err := executor.Execute(ctx, scanResult.Workflows)
 	if err != nil {

--- a/pkg/lib/lib_test.go
+++ b/pkg/lib/lib_test.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -102,4 +104,40 @@ func TestGetDetections_GitHub(t *testing.T) {
 	allDets := GetDetectionsForPlatform("github")
 	assert.GreaterOrEqual(t, len(allDets), len(dets),
 		"GetDetectionsForPlatform should include cross-platform detections")
+}
+
+// TestScan_LocalPath verifies the public SDK path for local filesystem scanning.
+// It exercises the auto-platform branch (lib.go:120-121), TargetLocal construction
+// (lib.go:146-147), and the detectionsForScan("local") aggregator (lib.go:102-108).
+func TestScan_LocalPath(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create a known-vulnerable GitHub Actions workflow (pull_request_target + unsafe
+	// ref checkout) so that the pwn_request detection fires.
+	wfDir := filepath.Join(tmp, ".github", "workflows")
+	require.NoError(t, os.MkdirAll(wfDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wfDir, "ci.yml"), []byte(`name: PR Target
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: npm install && npm test
+`), 0o644))
+
+	result, err := Scan(context.Background(), ScanConfig{LocalPath: tmp})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.NotEmpty(t, result.Workflows, "expected at least one workflow from local scan")
+
+	// The first workflow's path must reference the file we created.
+	assert.Contains(t, result.Workflows[0].Path, "ci.yml")
+
+	assert.NotEmpty(t, result.Findings, "expected detections to fire against the vulnerable workflow")
+
+	assert.Empty(t, result.Errors)
 }

--- a/pkg/local/init.go
+++ b/pkg/local/init.go
@@ -1,0 +1,12 @@
+package local
+
+import (
+	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+)
+
+func init() {
+	registry.RegisterPlatform(platforms.PlatformLocal, func() platforms.Platform {
+		return NewPlatform()
+	})
+}

--- a/pkg/local/init_test.go
+++ b/pkg/local/init_test.go
@@ -1,0 +1,20 @@
+package local_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/trajan/internal/registry"
+	_ "github.com/praetorian-inc/trajan/pkg/local"
+)
+
+// TestInit_RegistersLocalPlatform verifies that importing pkg/local triggers its
+// init() function, which registers the "local" platform with the global registry.
+func TestInit_RegistersLocalPlatform(t *testing.T) {
+	p, err := registry.GetPlatform("local")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.Equal(t, "local", p.Name())
+}

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -1,0 +1,148 @@
+// Package local implements a platforms.Platform that scans local filesystem paths.
+package local
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/praetorian-inc/trajan/pkg/analysis/parser"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+)
+
+// Platform implements platforms.Platform for local filesystem scanning.
+type Platform struct {
+	config platforms.Config
+}
+
+// NewPlatform creates a new local filesystem platform.
+func NewPlatform() *Platform {
+	return &Platform{}
+}
+
+// Name returns the platform identifier.
+func (p *Platform) Name() string {
+	return "local"
+}
+
+// Init stores config; no remote client is needed for local scanning.
+func (p *Platform) Init(_ context.Context, config platforms.Config) error {
+	p.config = config
+	return nil
+}
+
+// Scan walks the local filesystem path and discovers CI/CD workflow files.
+// It only handles targets of type TargetLocal.
+func (p *Platform) Scan(_ context.Context, target platforms.Target) (*platforms.ScanResult, error) {
+	if target.Type != platforms.TargetLocal {
+		return nil, fmt.Errorf("unsupported target type for local: %s", target.Type)
+	}
+
+	absRoot, err := filepath.Abs(target.Value)
+	if err != nil {
+		return nil, fmt.Errorf("resolving path %s: %w", target.Value, err)
+	}
+
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("accessing path %s: %w", absRoot, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Scanning local path %s...\n", absRoot)
+
+	result := &platforms.ScanResult{
+		Workflows: make(map[string][]platforms.Workflow),
+	}
+
+	repoName := filepath.Base(absRoot)
+
+	var candidates []string
+	if !info.IsDir() {
+		// Single file: treat it as a candidate directly.
+		candidates = []string{absRoot}
+	} else {
+		candidates, err = walkCandidates(absRoot)
+		if err != nil {
+			return nil, fmt.Errorf("walking %s: %w", absRoot, err)
+		}
+	}
+
+	for _, absPath := range candidates {
+		var relPath string
+		if !info.IsDir() {
+			relPath = filepath.Base(absPath)
+		} else {
+			rel, relErr := filepath.Rel(absRoot, absPath)
+			if relErr != nil {
+				result.Errors = append(result.Errors, relErr)
+				continue
+			}
+			relPath = filepath.ToSlash(rel)
+		}
+
+		wfParser := parser.DetectParser(relPath)
+		if wfParser == nil {
+			continue
+		}
+
+		content, readErr := os.ReadFile(absPath)
+		if readErr != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("reading %s: %w", absPath, readErr))
+			continue
+		}
+
+		platform := wfParser.Platform()
+		key := "local:" + platform
+		wf := platforms.Workflow{
+			Name:     filepath.Base(absPath),
+			Path:     relPath,
+			Content:  content,
+			RepoSlug: key,
+			Metadata: map[string]interface{}{"platform": platform},
+		}
+		result.Workflows[key] = append(result.Workflows[key], wf)
+	}
+
+	platformCount := len(result.Workflows)
+	totalWorkflows := 0
+	for _, wfs := range result.Workflows {
+		totalWorkflows += len(wfs)
+	}
+	fmt.Fprintf(os.Stderr, "Found %d workflows across %d platforms\n", totalWorkflows, platformCount)
+
+	result.Repositories = []platforms.Repository{
+		{Name: repoName, URL: absRoot},
+	}
+
+	return result, nil
+}
+
+// walkCandidates returns all non-skipped file paths under root.
+func walkCandidates(root string) ([]string, error) {
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && skipDir(d.Name()) {
+			return filepath.SkipDir
+		}
+		if !d.IsDir() {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	return paths, err
+}
+
+// skipDir returns true for directories that should be skipped entirely.
+func skipDir(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor":
+		return true
+	}
+	return false
+}
+
+var _ platforms.Platform = (*Platform)(nil)

--- a/pkg/local/local_test.go
+++ b/pkg/local/local_test.go
@@ -1,0 +1,310 @@
+package local_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/trajan/pkg/local"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+
+	// Belt-and-suspenders: ensure all parser init() functions have run.
+	_ "github.com/praetorian-inc/trajan/pkg/analysis/parser"
+)
+
+// YAML fixtures — must match the CanParse expectations of each parser.
+const githubYAML = `name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`
+
+const gitlabYAML = `test:
+  script:
+    - echo hi
+`
+
+const jenkinsfile = `pipeline { agent any; stages { stage('test') { steps { sh 'echo hi' } } } }
+`
+
+const azureYAML = `trigger: [main]
+jobs:
+  - job: test
+    steps:
+      - script: echo hi
+`
+
+// writeFile creates all required parent directories and writes content to path.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// newInitialized creates a Platform, calls Init, and returns it ready to use.
+func newInitialized(t *testing.T) *local.Platform {
+	t.Helper()
+	p := local.NewPlatform()
+	require.NoError(t, p.Init(context.Background(), platforms.Config{}))
+	return p
+}
+
+// TestPlatform_Name asserts that Name() returns "local".
+func TestPlatform_Name(t *testing.T) {
+	p := local.NewPlatform()
+	assert.Equal(t, "local", p.Name())
+}
+
+// TestPlatform_Scan_GitHubWorkflow verifies a GitHub Actions workflow is detected.
+func TestPlatform_Scan_GitHubWorkflow(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, ".github", "workflows", "ci.yml"), githubYAML)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, result.Workflows, 1, "expected exactly one platform bucket")
+
+	wfs, ok := result.Workflows["local:github"]
+	require.True(t, ok, "bucket 'local:github' not found")
+	require.Len(t, wfs, 1)
+
+	wf := wfs[0]
+	assert.Equal(t, "ci.yml", wf.Name)
+	assert.Equal(t, ".github/workflows/ci.yml", wf.Path)
+	assert.NotEmpty(t, wf.Content)
+	assert.Equal(t, "local:github", wf.RepoSlug)
+	assert.Equal(t, "github", wf.Metadata["platform"])
+}
+
+// TestPlatform_Scan_GitLabCI verifies a GitLab CI workflow is detected.
+func TestPlatform_Scan_GitLabCI(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, ".gitlab-ci.yml"), gitlabYAML)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	wfs, ok := result.Workflows["local:gitlab"]
+	require.True(t, ok, "bucket 'local:gitlab' not found")
+	require.Len(t, wfs, 1)
+	assert.Equal(t, "gitlab", wfs[0].Metadata["platform"])
+}
+
+// TestPlatform_Scan_Jenkinsfile verifies a Jenkinsfile is detected.
+func TestPlatform_Scan_Jenkinsfile(t *testing.T) {
+	tmp := t.TempDir()
+	// Jenkinsfile must be exactly "Jenkinsfile" at the root for CanParse("Jenkinsfile") to match.
+	writeFile(t, filepath.Join(tmp, "Jenkinsfile"), jenkinsfile)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	wfs, ok := result.Workflows["local:jenkins"]
+	require.True(t, ok, "bucket 'local:jenkins' not found")
+	require.Len(t, wfs, 1)
+	assert.Equal(t, "jenkins", wfs[0].Metadata["platform"])
+}
+
+// TestPlatform_Scan_AzurePipelines verifies an Azure Pipelines workflow is detected.
+func TestPlatform_Scan_AzurePipelines(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "azure-pipelines.yml"), azureYAML)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	wfs, ok := result.Workflows["local:azure"]
+	require.True(t, ok, "bucket 'local:azure' not found")
+	require.Len(t, wfs, 1)
+	assert.Equal(t, "azure", wfs[0].Metadata["platform"])
+}
+
+// TestPlatform_Scan_MixedPlatforms verifies that workflows from multiple platforms
+// are grouped into separate buckets, and exactly one Repository is returned.
+func TestPlatform_Scan_MixedPlatforms(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, ".github", "workflows", "a.yml"), githubYAML)
+	writeFile(t, filepath.Join(tmp, ".gitlab-ci.yml"), gitlabYAML)
+	writeFile(t, filepath.Join(tmp, "Jenkinsfile"), jenkinsfile)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+
+	_, hasGitHub := result.Workflows["local:github"]
+	_, hasGitLab := result.Workflows["local:gitlab"]
+	_, hasJenkins := result.Workflows["local:jenkins"]
+	assert.True(t, hasGitHub, "expected bucket 'local:github'")
+	assert.True(t, hasGitLab, "expected bucket 'local:gitlab'")
+	assert.True(t, hasJenkins, "expected bucket 'local:jenkins'")
+	assert.Len(t, result.Workflows["local:github"], 1)
+	assert.Len(t, result.Workflows["local:gitlab"], 1)
+	assert.Len(t, result.Workflows["local:jenkins"], 1)
+
+	assert.Len(t, result.Repositories, 1, "expected exactly one repository entry")
+}
+
+// TestPlatform_Scan_SkipsNonWorkflowFiles verifies that non-workflow files produce
+// no workflows and no errors.
+func TestPlatform_Scan_SkipsNonWorkflowFiles(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "README.md"), "# readme\n")
+	writeFile(t, filepath.Join(tmp, "src", "app.go"), "package main\n")
+	writeFile(t, filepath.Join(tmp, ".github", "CODEOWNERS"), "* @owner\n")
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result.Workflows, "expected no workflows for non-workflow files")
+	assert.Empty(t, result.Errors)
+}
+
+// TestPlatform_Scan_SkipsGitDir verifies that the walker skips the .git directory
+// entirely and still finds real workflow files at other paths.
+func TestPlatform_Scan_SkipsGitDir(t *testing.T) {
+	tmp := t.TempDir()
+	// Real workflow file.
+	writeFile(t, filepath.Join(tmp, ".github", "workflows", "ci.yml"), githubYAML)
+	// Files inside .git — these must be skipped entirely.
+	writeFile(t, filepath.Join(tmp, ".git", "HEAD"), "ref: refs/heads/main\n")
+	writeFile(t, filepath.Join(tmp, ".git", "objects", "pack.yml"), "not a real workflow\n")
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	total := 0
+	for _, wfs := range result.Workflows {
+		total += len(wfs)
+	}
+	assert.Equal(t, 1, total, "expected exactly 1 workflow (the .github/workflows/ci.yml)")
+
+	wfs, ok := result.Workflows["local:github"]
+	require.True(t, ok)
+	assert.Equal(t, ".github/workflows/ci.yml", wfs[0].Path)
+}
+
+// TestPlatform_Scan_SkipsNodeModulesAndVendor verifies that node_modules and vendor
+// directories are skipped, while a top-level workflow file is still detected.
+func TestPlatform_Scan_SkipsNodeModulesAndVendor(t *testing.T) {
+	tmp := t.TempDir()
+	// Files that MUST be skipped.
+	writeFile(t, filepath.Join(tmp, "node_modules", "pkg", ".github", "workflows", "x.yml"), githubYAML)
+	writeFile(t, filepath.Join(tmp, "vendor", "somepkg", ".gitlab-ci.yml"), gitlabYAML)
+	// The one file that should be found.
+	writeFile(t, filepath.Join(tmp, ".gitlab-ci.yml"), gitlabYAML)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: tmp,
+	})
+
+	require.NoError(t, err)
+	total := 0
+	for _, wfs := range result.Workflows {
+		total += len(wfs)
+	}
+	assert.Equal(t, 1, total, "expected only the top-level .gitlab-ci.yml to be found")
+}
+
+// TestPlatform_Scan_SingleFile verifies scanning a single workflow file directly
+// (not a directory).
+func TestPlatform_Scan_SingleFile(t *testing.T) {
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, ".gitlab-ci.yml")
+	writeFile(t, filePath, gitlabYAML)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: filePath,
+	})
+
+	require.NoError(t, err)
+	wfs, ok := result.Workflows["local:gitlab"]
+	require.True(t, ok, "bucket 'local:gitlab' not found")
+	require.Len(t, wfs, 1)
+	// For a single-file target, Path is filepath.Base (just the filename).
+	assert.Equal(t, ".gitlab-ci.yml", wfs[0].Path)
+}
+
+// TestPlatform_Scan_NonexistentPath verifies that scanning a path that does not
+// exist returns an error.
+func TestPlatform_Scan_NonexistentPath(t *testing.T) {
+	p := newInitialized(t)
+	_, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: "/nonexistent/does/not/exist",
+	})
+	require.Error(t, err)
+}
+
+// TestPlatform_Scan_InvalidTargetType verifies that a non-TargetLocal target type
+// returns an error containing the expected message.
+func TestPlatform_Scan_InvalidTargetType(t *testing.T) {
+	tmp := t.TempDir()
+	p := newInitialized(t)
+	_, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetRepo,
+		Value: tmp,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported target type for local")
+}
+
+// TestPlatform_Scan_RelativePath verifies that a relative path is resolved correctly
+// by filepath.Abs inside Scan.
+func TestPlatform_Scan_RelativePath(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, ".gitlab-ci.yml"), gitlabYAML)
+
+	// t.Chdir changes cwd and restores it via t.Cleanup (Go 1.24+).
+	t.Chdir(tmp)
+
+	p := newInitialized(t)
+	result, err := p.Scan(context.Background(), platforms.Target{
+		Type:  platforms.TargetLocal,
+		Value: "./",
+	})
+
+	require.NoError(t, err)
+	wfs, ok := result.Workflows["local:gitlab"]
+	require.True(t, ok, "bucket 'local:gitlab' not found")
+	assert.Len(t, wfs, 1)
+}

--- a/pkg/platforms/all/all.go
+++ b/pkg/platforms/all/all.go
@@ -9,4 +9,5 @@ import (
 	_ "github.com/praetorian-inc/trajan/pkg/gitlab"
 	_ "github.com/praetorian-inc/trajan/pkg/jenkins"
 	_ "github.com/praetorian-inc/trajan/pkg/jfrog"
+	_ "github.com/praetorian-inc/trajan/pkg/local"
 )

--- a/pkg/platforms/platform.go
+++ b/pkg/platforms/platform.go
@@ -14,15 +14,17 @@ const (
 	PlatformAzureDevOps = "azuredevops"
 	PlatformJFrog       = "jfrog"
 	PlatformJenkins     = "jenkins"
+	PlatformLocal       = "local"
 )
 
 // TargetType represents what kind of target to scan
 type TargetType string
 
 const (
-	TargetRepo TargetType = "repo"
-	TargetOrg  TargetType = "org"
-	TargetUser TargetType = "user"
+	TargetRepo  TargetType = "repo"
+	TargetOrg   TargetType = "org"
+	TargetUser  TargetType = "user"
+	TargetLocal TargetType = "local"
 )
 
 // Target specifies what to scan


### PR DESCRIPTION
## Summary

Adds a new `local` platform that walks a filesystem path and auto-detects CI workflow files via `parser.DetectParser`, enabling offline scanning of locally cloned repositories and checked-out code during CI/CD pipeline execution — no platform API access required.

- Implements the existing `platforms.Platform` interface; plugs into the detection executor with zero changes to graph, parser, or detection layers
- Auto-detects per-file CI platform (`.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `azure-pipelines.yml`) using the existing parser registry
- Aggregates detections across all registered platforms for local scans so mixed-platform repos get the right plugins per file
- Skips `.git/`, `node_modules/`, and `vendor/` during walk

## Usage

CLI:
```
trajan local scan --path ./repo
trajan local scan --path ./repo --severity critical,high
trajan local scan --path ./repo --output json
```

SDK:
```go
result, err := lib.Scan(ctx, lib.ScanConfig{LocalPath: "./repo"})
```

## Changes

**New files**
- `pkg/local/{local.go, init.go}` — `Platform` implementation + registry registration
- `pkg/local/{local_test.go, init_test.go}` — 14 unit tests, 88.9% coverage
- `cmd/trajan/local/{root.go, scan.go}` — `trajan local scan` subcommand

**Modified**
- `pkg/platforms/platform.go` — adds `PlatformLocal` and `TargetLocal` constants
- `pkg/platforms/all/all.go` — blank-imports `pkg/local`
- `pkg/lib/lib.go` — adds `ScanConfig.LocalPath`, auto-platform routing, `detectionsForScan` aggregator
- `pkg/lib/lib_test.go` — adds `TestScan_LocalPath` end-to-end regression guard
- `cmd/trajan/root.go` — registers the new subcommand under the `platforms` group

Closes https://github.com/praetorian-inc/trajan/issues/9

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -race` all packages pass
- [x] `golangci-lint run` on new code: 0 issues
- [x] 14/14 unit tests in `pkg/local` pass (88.9% line coverage)
- [x] `TestScan_LocalPath` end-to-end lib test passes
- [x] Smoke test: `trajan local scan --path .` in this repo finds 4 GitHub workflows, produces 9 findings
- [x] `trajan local scan` without `--path` returns `must specify --path`
- [x] `trajan local scan --path /nonexistent` returns a clear stat error

🤖 Generated with [Claude Code](https://claude.com/claude-code)