### PR TITLE
chore: gitignore Claude Code session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,11 @@ browser/trajan-browser-*.zip
 test-output.txt
 .worktrees/
 .env
+
+# Claude Code session artifacts
+.claude/.output/
+.claude/hooks/
+.claude/settings.local.json
+.claude/.serena/
+.claude/.serena-warmup-status.json
+.claude/agent-memory/


### PR DESCRIPTION
## Summary

- Add Claude Code session artifacts to `.gitignore`
- Prevents `.claude/.output/`, `.claude/hooks/`, `.claude/settings.local.json`, `.claude/.serena/`, and `.claude/agent-memory/` from being accidentally committed

These are per-session scratch files generated by Claude Code that should never enter version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)