### PR TITLE
chore: bump go-ci + go-sec to v2.1.0, add paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci*'
+      - 'Makefile'
   workflow_dispatch:
 
 permissions:
@@ -12,7 +18,7 @@ permissions:
 
 jobs:
   ci:
-    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@3dcf34cfbe5e1332d490d28ed1bd119cd86cf81b  # v2.0.13
+    uses: praetorian-inc/public-workflows/.github/workflows/go-ci.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0
     permissions:
       contents: read
     with:


### PR DESCRIPTION
Bumps go-ci and go-sec callers to public-workflows v2.1.0. Adds caller-side `paths:` filter for Go-relevant files (defense-in-depth alongside the reusable-side preflight).

## Changes
- Bump `go-ci.yml` SHA → v2.1.0
- Bump `go-sec.yml` SHA → v2.1.0 (fixes `go-security.yml` → `go-sec.yml` rename where needed)
- Add `paths:` filter: `**/*.go`, `go.mod`, `go.sum`, `.golangci*`, `Makefile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)