### PR TITLE
docs: add token handling guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ cd trajan && make build
 - Go 1.24 or later
 - GitHub Personal Access Token with `repo` scope (for private repositories) or `public_repo` scope (for public repositories only)
 
+### Token handling
+
+Use dedicated assessment tokens instead of personal day-to-day credentials.
+
+- Scope tokens to the repositories, organizations, and CI/CD platforms being assessed.
+- Store tokens in a secret manager or short-lived shell session; do not commit them or keep them in reusable shell history.
+- Rotate tokens after high-sensitivity assessments, demonstrations, or shared lab work.
+- Confirm the token is approved for the target environment before running scan, attack, or enumeration commands; do not reuse credentials across unrelated engagements.
+
 ## Library SDK (`pkg/lib`)
 
 Trajan can be embedded as a Go library for programmatic CI/CD security scanning. The `pkg/lib` package provides a public SDK that wraps Trajan's internal platform registry, detection engine, and scanner into a single high-level API.


### PR DESCRIPTION
## Summary
- add a token-handling section to the README requirements
- recommend dedicated assessment credentials instead of day-to-day personal tokens
- document scoping, secret storage, rotation, and engagement-boundary practices for scan, attack, and enumeration workflows

## Rationale
Trajan operates against CI/CD platforms and can require sensitive API tokens. A concise operator note helps users run assessments with stronger credential hygiene, especially in enterprise, consulting, and multi-engagement environments.

## Validation
- documentation-only change
- reviewed the README diff for scope and wording
- `git diff --check`

## Workflow note
The previous `External Contribution Notify / notify` failure came from the repository notification workflow (`Entity not found in validateAccess`) after it reached the upstream Slack/Linear-style notification step. That appears unrelated to this README-only branch and may require maintainer-side workflow or notification configuration.