### PR TITLE
fix(gitlab): handle include:file list syntax and deduplicate MR trigger logic

### DIFF
--- a/pkg/analysis/parser/gitlab.go
+++ b/pkg/analysis/parser/gitlab.go
@@ -479,44 +479,68 @@ func (p *GitLabParser) parseIncludes(raw interface{}) []GitLabInclude {
 				})
 			case map[string]interface{}:
 				// Array of objects: include: [{local: ...}, {remote: ...}]
-				includes = append(includes, p.parseIncludeMap(inc))
+				includes = append(includes, p.parseIncludeMap(inc)...)
 			}
 		}
 	case map[string]interface{}:
 		// Single object format: include: {local: '/path.yml'}
-		includes = append(includes, p.parseIncludeMap(v))
+		includes = append(includes, p.parseIncludeMap(v)...)
 	}
 
 	return includes
 }
 
-// parseIncludeMap parses a single include map into a typed GitLabInclude
-func (p *GitLabParser) parseIncludeMap(m map[string]interface{}) GitLabInclude {
-	inc := GitLabInclude{}
-
-	// Determine include type based on which key is present
+// parseIncludeMap parses a single include map into typed GitLabInclude entries.
+// Returns a slice because project includes with a file list expand into multiple entries.
+func (p *GitLabParser) parseIncludeMap(m map[string]interface{}) []GitLabInclude {
 	if local, ok := m["local"].(string); ok {
-		inc.Type = IncludeTypeLocal
-		inc.Path = local
-	} else if remote, ok := m["remote"].(string); ok {
-		inc.Type = IncludeTypeRemote
-		inc.Remote = remote
-	} else if project, ok := m["project"].(string); ok {
-		inc.Type = IncludeTypeProject
-		inc.Project = project
-		// Extract optional file and ref fields
-		if file, ok := m["file"].(string); ok {
-			inc.Path = file
-		}
-		if ref, ok := m["ref"].(string); ok {
-			inc.Ref = ref
-		}
-	} else if template, ok := m["template"].(string); ok {
-		inc.Type = IncludeTypeTemplate
-		inc.Template = template
+		return []GitLabInclude{{Type: IncludeTypeLocal, Path: local}}
 	}
 
-	return inc
+	if remote, ok := m["remote"].(string); ok {
+		return []GitLabInclude{{Type: IncludeTypeRemote, Remote: remote}}
+	}
+
+	if project, ok := m["project"].(string); ok {
+		ref, _ := m["ref"].(string)
+
+		// file can be a string or a list of strings
+		switch file := m["file"].(type) {
+		case string:
+			return []GitLabInclude{{
+				Type:    IncludeTypeProject,
+				Project: project,
+				Path:    file,
+				Ref:     ref,
+			}}
+		case []interface{}:
+			var includes []GitLabInclude
+			for _, f := range file {
+				if path, ok := f.(string); ok {
+					includes = append(includes, GitLabInclude{
+						Type:    IncludeTypeProject,
+						Project: project,
+						Path:    path,
+						Ref:     ref,
+					})
+				}
+			}
+			return includes
+		default:
+			// No file specified
+			return []GitLabInclude{{
+				Type:    IncludeTypeProject,
+				Project: project,
+				Ref:     ref,
+			}}
+		}
+	}
+
+	if template, ok := m["template"].(string); ok {
+		return []GitLabInclude{{Type: IncludeTypeTemplate, Template: template}}
+	}
+
+	return nil
 }
 
 // convert transforms a GitLabCI to generic NormalizedWorkflow

--- a/pkg/analysis/parser/gitlab_include_test.go
+++ b/pkg/analysis/parser/gitlab_include_test.go
@@ -1,0 +1,138 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIncludeMap_SingleFileProject(t *testing.T) {
+	p := &GitLabParser{}
+	m := map[string]interface{}{
+		"project": "devops/ci-cd/pipelines",
+		"ref":     "latest",
+		"file":    "terraform/terraform.yml",
+	}
+
+	result := p.parseIncludeMap(m)
+	require.Len(t, result, 1)
+	assert.Equal(t, IncludeTypeProject, result[0].Type)
+	assert.Equal(t, "devops/ci-cd/pipelines", result[0].Project)
+	assert.Equal(t, "terraform/terraform.yml", result[0].Path)
+	assert.Equal(t, "latest", result[0].Ref)
+}
+
+func TestParseIncludeMap_MultiFileProject(t *testing.T) {
+	p := &GitLabParser{}
+	m := map[string]interface{}{
+		"project": "devops/ci-cd/pipelines",
+		"ref":     "latest",
+		"file": []interface{}{
+			"terraform/terraform.yml",
+			"terraform/deploy/continuous.yml",
+		},
+	}
+
+	result := p.parseIncludeMap(m)
+	require.Len(t, result, 2)
+
+	assert.Equal(t, IncludeTypeProject, result[0].Type)
+	assert.Equal(t, "devops/ci-cd/pipelines", result[0].Project)
+	assert.Equal(t, "terraform/terraform.yml", result[0].Path)
+	assert.Equal(t, "latest", result[0].Ref)
+
+	assert.Equal(t, IncludeTypeProject, result[1].Type)
+	assert.Equal(t, "devops/ci-cd/pipelines", result[1].Project)
+	assert.Equal(t, "terraform/deploy/continuous.yml", result[1].Path)
+	assert.Equal(t, "latest", result[1].Ref)
+}
+
+func TestParseIncludeMap_ProjectNoFile(t *testing.T) {
+	p := &GitLabParser{}
+	m := map[string]interface{}{
+		"project": "devops/ci-cd/pipelines",
+		"ref":     "main",
+	}
+
+	result := p.parseIncludeMap(m)
+	require.Len(t, result, 1)
+	assert.Equal(t, IncludeTypeProject, result[0].Type)
+	assert.Equal(t, "devops/ci-cd/pipelines", result[0].Project)
+	assert.Equal(t, "", result[0].Path)
+	assert.Equal(t, "main", result[0].Ref)
+}
+
+func TestParseIncludeMap_Local(t *testing.T) {
+	p := &GitLabParser{}
+	m := map[string]interface{}{
+		"local": "/templates/build.yml",
+	}
+
+	result := p.parseIncludeMap(m)
+	require.Len(t, result, 1)
+	assert.Equal(t, IncludeTypeLocal, result[0].Type)
+	assert.Equal(t, "/templates/build.yml", result[0].Path)
+}
+
+func TestParseIncludeMap_Remote(t *testing.T) {
+	p := &GitLabParser{}
+	m := map[string]interface{}{
+		"remote": "https://example.com/ci/template.yml",
+	}
+
+	result := p.parseIncludeMap(m)
+	require.Len(t, result, 1)
+	assert.Equal(t, IncludeTypeRemote, result[0].Type)
+	assert.Equal(t, "https://example.com/ci/template.yml", result[0].Remote)
+}
+
+func TestParseIncludeMap_Template(t *testing.T) {
+	p := &GitLabParser{}
+	m := map[string]interface{}{
+		"template": "Auto-DevOps.gitlab-ci.yml",
+	}
+
+	result := p.parseIncludeMap(m)
+	require.Len(t, result, 1)
+	assert.Equal(t, IncludeTypeTemplate, result[0].Type)
+	assert.Equal(t, "Auto-DevOps.gitlab-ci.yml", result[0].Template)
+}
+
+func TestParseIncludes_MixedWithMultiFile(t *testing.T) {
+	p := &GitLabParser{}
+
+	// Simulates:
+	// include:
+	//   - local: /templates/build.yml
+	//   - project: devops/ci-cd/pipelines
+	//     ref: latest
+	//     file:
+	//       - terraform/terraform.yml
+	//       - terraform/deploy/continuous.yml
+	raw := []interface{}{
+		map[string]interface{}{
+			"local": "/templates/build.yml",
+		},
+		map[string]interface{}{
+			"project": "devops/ci-cd/pipelines",
+			"ref":     "latest",
+			"file": []interface{}{
+				"terraform/terraform.yml",
+				"terraform/deploy/continuous.yml",
+			},
+		},
+	}
+
+	result := p.parseIncludes(raw)
+	require.Len(t, result, 3)
+
+	assert.Equal(t, IncludeTypeLocal, result[0].Type)
+	assert.Equal(t, "/templates/build.yml", result[0].Path)
+
+	assert.Equal(t, IncludeTypeProject, result[1].Type)
+	assert.Equal(t, "terraform/terraform.yml", result[1].Path)
+
+	assert.Equal(t, IncludeTypeProject, result[2].Type)
+	assert.Equal(t, "terraform/deploy/continuous.yml", result[2].Path)
+}

--- a/pkg/gitlab/detections/common/common.go
+++ b/pkg/gitlab/detections/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/praetorian-inc/trajan/pkg/analysis/graph"
 )
@@ -77,6 +78,27 @@ func GetStepParentWorkflow(g *graph.Graph, step *graph.StepNode) *graph.Workflow
 	return nil
 }
 
+// GetJobParentWorkflow finds the parent workflow node for a job.
+// Returns nil if job has no parent workflow or parent is not a WorkflowNode.
+func GetJobParentWorkflow(g *graph.Graph, job *graph.JobNode) *graph.WorkflowNode {
+	if job == nil {
+		return nil
+	}
+
+	// Get parent workflow
+	wfNode, ok := g.GetNode(job.Parent())
+	if !ok {
+		return nil
+	}
+
+	// Type assert to WorkflowNode
+	if wf, ok := wfNode.(*graph.WorkflowNode); ok {
+		return wf
+	}
+
+	return nil
+}
+
 // IsRootWorkflow returns true if the workflow is a root (not included by another workflow).
 // Root workflows have no incoming EdgeIncludes edges.
 // These are typically main .gitlab-ci.yml files or standalone workflow files.
@@ -95,4 +117,113 @@ func IsRootWorkflow(g *graph.Graph, wf *graph.WorkflowNode) bool {
 	}
 
 	return true // No incoming includes, this is a root workflow
+}
+
+// HasMergeRequestTrigger checks if the workflow triggers on merge requests.
+// Uses DFS to also check job-level If conditions for MR references.
+func HasMergeRequestTrigger(wf *graph.WorkflowNode, g *graph.Graph) bool {
+	// Check tags for merge request indicators
+	for _, tag := range wf.Tags() {
+		if tag == graph.TagMergeRequest || tag == graph.TagExternalPullRequest {
+			return true
+		}
+	}
+
+	// Fallback: check if workflow has merge_request in triggers (case-insensitive)
+	for _, trigger := range wf.Triggers {
+		triggerLower := strings.ToLower(trigger)
+		if strings.Contains(triggerLower, "merge_request") ||
+			strings.Contains(triggerLower, "external_pull_request") {
+			return true
+		}
+	}
+
+	// Also check job-level If conditions for merge request references
+	foundMR := false
+	graph.DFS(g, wf.ID(), func(node graph.Node) bool {
+		if job, ok := node.(*graph.JobNode); ok {
+			if JobRunsOnMRExplicit(job) {
+				foundMR = true
+				return false // Stop DFS, we found it
+			}
+		}
+		return true
+	})
+
+	return foundMR
+}
+
+// JobRunsOnMRExplicit checks if a job explicitly mentions MR events in its If condition.
+func JobRunsOnMRExplicit(job *graph.JobNode) bool {
+	if job.If == "" {
+		return false
+	}
+
+	ifLower := strings.ToLower(job.If)
+	return strings.Contains(ifLower, "merge_request") ||
+		strings.Contains(ifLower, "external_pull_request")
+}
+
+// JobRunsOnMR checks if a job runs on merge request events.
+// This includes jobs that explicitly mention MR events OR jobs without If conditions
+// in workflows that have MR triggers.
+func JobRunsOnMR(job *graph.JobNode, wf *graph.WorkflowNode, g *graph.Graph) bool {
+	// If job explicitly mentions MR events, it runs on MR
+	if JobRunsOnMRExplicit(job) {
+		return true
+	}
+
+	// If job has an If condition but doesn't mention MR events, it doesn't run on MR
+	if job.If != "" {
+		return false
+	}
+
+	// Job has no If condition - check if workflow has MR trigger
+	return HasMergeRequestTrigger(wf, g)
+}
+
+// IsProtectedBranchOnly checks if a job is restricted to protected branches.
+// Returns false if the condition also includes MR trigger conditions,
+// since that means the job can still run on merge requests.
+func IsProtectedBranchOnly(job *graph.JobNode) bool {
+	if job.If == "" {
+		return false
+	}
+
+	ifLower := strings.ToLower(job.If)
+
+	// Check for protected branch patterns
+	protectedBranchPatterns := []string{
+		"== \"main\"",
+		"== \"master\"",
+		"== 'main'",
+		"== 'master'",
+		"=~ /^main$/",
+		"=~ /^master$/",
+		"ci_commit_branch == \"main\"",
+		"ci_commit_branch == \"master\"",
+		"ci_commit_branch == 'main'",
+		"ci_commit_branch == 'master'",
+		"ci_commit_ref_name == \"main\"",
+		"ci_commit_ref_name == \"master\"",
+		"ci_commit_ref_name == 'main'",
+		"ci_commit_ref_name == 'master'",
+	}
+
+	// Only return true if the condition ONLY restricts to protected branches
+	// and doesn't also include MR trigger conditions
+	hasMRCondition := strings.Contains(ifLower, "merge_request_event") ||
+		strings.Contains(ifLower, "external_pull_request_event")
+
+	if hasMRCondition {
+		return false
+	}
+
+	for _, pattern := range protectedBranchPatterns {
+		if strings.Contains(ifLower, pattern) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/gitlab/detections/common/common_test.go
+++ b/pkg/gitlab/detections/common/common_test.go
@@ -417,3 +417,216 @@ func TestIsRootWorkflow(t *testing.T) {
 		})
 	}
 }
+
+func TestGetJobParentWorkflow(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupGraph  func() (*graph.Graph, *graph.JobNode)
+		expectedID  string
+		expectedNil bool
+	}{
+		{
+			name: "valid job with parent workflow",
+			setupGraph: func() (*graph.Graph, *graph.JobNode) {
+				g := graph.NewGraph()
+				wf := graph.NewWorkflowNode("wf1", "main", ".gitlab-ci.yml", "test/repo", []string{"push"})
+				job := graph.NewJobNode("job1", "build", "docker")
+				g.AddNode(wf)
+				g.AddNode(job)
+				g.AddEdge(wf.ID(), job.ID(), graph.EdgeContains)
+				return g, job
+			},
+			expectedID:  "wf1",
+			expectedNil: false,
+		},
+		{
+			name: "nil job returns nil",
+			setupGraph: func() (*graph.Graph, *graph.JobNode) {
+				g := graph.NewGraph()
+				return g, nil
+			},
+			expectedNil: true,
+		},
+		{
+			name: "orphan job returns nil",
+			setupGraph: func() (*graph.Graph, *graph.JobNode) {
+				g := graph.NewGraph()
+				job := graph.NewJobNode("job1", "build", "docker")
+				g.AddNode(job)
+				return g, job
+			},
+			expectedNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, job := tt.setupGraph()
+			result := GetJobParentWorkflow(g, job)
+			if tt.expectedNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expectedID, result.ID())
+			}
+		})
+	}
+}
+
+func TestHasMergeRequestTrigger(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() (*graph.Graph, *graph.WorkflowNode)
+		expected bool
+	}{
+		{
+			name: "workflow with MR tag",
+			setup: func() (*graph.Graph, *graph.WorkflowNode) {
+				g := graph.NewGraph()
+				wf := graph.NewWorkflowNode("wf1", "main", ".gitlab-ci.yml", "test/repo", []string{})
+				wf.AddTag(graph.TagMergeRequest)
+				g.AddNode(wf)
+				return g, wf
+			},
+			expected: true,
+		},
+		{
+			name: "workflow with MR trigger string",
+			setup: func() (*graph.Graph, *graph.WorkflowNode) {
+				g := graph.NewGraph()
+				wf := graph.NewWorkflowNode("wf1", "main", ".gitlab-ci.yml", "test/repo", []string{"merge_request_event"})
+				g.AddNode(wf)
+				return g, wf
+			},
+			expected: true,
+		},
+		{
+			name: "workflow with no MR trigger",
+			setup: func() (*graph.Graph, *graph.WorkflowNode) {
+				g := graph.NewGraph()
+				wf := graph.NewWorkflowNode("wf1", "main", ".gitlab-ci.yml", "test/repo", []string{"push"})
+				g.AddNode(wf)
+				return g, wf
+			},
+			expected: false,
+		},
+		{
+			name: "workflow with job-level MR condition via DFS",
+			setup: func() (*graph.Graph, *graph.WorkflowNode) {
+				g := graph.NewGraph()
+				wf := graph.NewWorkflowNode("wf1", "main", ".gitlab-ci.yml", "test/repo", []string{"push"})
+				g.AddNode(wf)
+				job := graph.NewJobNode("job1", "test", "docker")
+				job.If = "$CI_PIPELINE_SOURCE == \"merge_request_event\""
+				job.SetParent(wf.ID())
+				g.AddNode(job)
+				g.AddEdge(wf.ID(), job.ID(), graph.EdgeContains)
+				return g, wf
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, wf := tt.setup()
+			result := HasMergeRequestTrigger(wf, g)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestJobRunsOnMRExplicit(t *testing.T) {
+	tests := []struct {
+		name     string
+		ifCond   string
+		expected bool
+	}{
+		{"empty If", "", false},
+		{"MR condition", "$CI_PIPELINE_SOURCE == \"merge_request_event\"", true},
+		{"external PR", "$CI_PIPELINE_SOURCE == \"external_pull_request_event\"", true},
+		{"branch condition", "$CI_COMMIT_BRANCH == \"main\"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := graph.NewJobNode("job1", "test", "docker")
+			job.If = tt.ifCond
+			assert.Equal(t, tt.expected, JobRunsOnMRExplicit(job))
+		})
+	}
+}
+
+func TestJobRunsOnMR(t *testing.T) {
+	tests := []struct {
+		name     string
+		ifCond   string
+		wfTags   []graph.Tag
+		expected bool
+	}{
+		{
+			name:     "explicit MR condition",
+			ifCond:   "$CI_PIPELINE_SOURCE == \"merge_request_event\"",
+			expected: true,
+		},
+		{
+			name:     "non-MR If condition with MR workflow",
+			ifCond:   "$CI_COMMIT_BRANCH == \"feature\"",
+			wfTags:   []graph.Tag{graph.TagMergeRequest},
+			expected: false,
+		},
+		{
+			name:     "no If condition with MR workflow",
+			ifCond:   "",
+			wfTags:   []graph.Tag{graph.TagMergeRequest},
+			expected: true,
+		},
+		{
+			name:     "no If condition without MR workflow",
+			ifCond:   "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.NewGraph()
+			wf := graph.NewWorkflowNode("wf1", "main", ".gitlab-ci.yml", "test/repo", []string{})
+			for _, tag := range tt.wfTags {
+				wf.AddTag(tag)
+			}
+			g.AddNode(wf)
+
+			job := graph.NewJobNode("job1", "test", "docker")
+			job.If = tt.ifCond
+			job.SetParent(wf.ID())
+			g.AddNode(job)
+			g.AddEdge(wf.ID(), job.ID(), graph.EdgeContains)
+
+			assert.Equal(t, tt.expected, JobRunsOnMR(job, wf, g))
+		})
+	}
+}
+
+func TestIsProtectedBranchOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		ifCond   string
+		expected bool
+	}{
+		{"empty If", "", false},
+		{"main branch", "$CI_COMMIT_BRANCH == \"main\"", true},
+		{"master branch", "$CI_COMMIT_BRANCH == \"master\"", true},
+		{"feature branch", "$CI_COMMIT_BRANCH == \"feature\"", false},
+		{"MR with main branch", "$CI_PIPELINE_SOURCE == \"merge_request_event\" && $CI_COMMIT_BRANCH == \"main\"", false},
+		{"main regex", "$CI_COMMIT_REF_NAME =~ /^main$/", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := graph.NewJobNode("job1", "test", "docker")
+			job.If = tt.ifCond
+			assert.Equal(t, tt.expected, IsProtectedBranchOnly(job))
+		})
+	}
+}

--- a/pkg/gitlab/detections/mrcheckout/mrcheckout.go
+++ b/pkg/gitlab/detections/mrcheckout/mrcheckout.go
@@ -60,7 +60,7 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 		}
 
 		// Check if workflow triggers on merge requests
-		if !hasMergeRequestTrigger(wf, g) {
+		if !common.HasMergeRequestTrigger(wf, g) {
 			continue
 		}
 
@@ -114,42 +114,6 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 	return findings, nil
 }
 
-func hasMergeRequestTrigger(wf *graph.WorkflowNode, g *graph.Graph) bool {
-	// Check tags for merge request indicators
-	for _, tag := range wf.Tags() {
-		if tag == graph.TagMergeRequest || tag == graph.TagExternalPullRequest {
-			return true
-		}
-	}
-
-	// Fallback: check if workflow has merge_request in triggers (case-insensitive)
-	for _, trigger := range wf.Triggers {
-		triggerLower := strings.ToLower(trigger)
-		if strings.Contains(triggerLower, "merge_request") ||
-			strings.Contains(triggerLower, "external_pull_request") {
-			return true
-		}
-	}
-
-	// Also check job-level If conditions for merge request references
-	foundMR := false
-	graph.DFS(g, wf.ID(), func(node graph.Node) bool {
-		if job, ok := node.(*graph.JobNode); ok {
-			if job.If != "" {
-				ifLower := strings.ToLower(job.If)
-				if strings.Contains(ifLower, "merge_request") ||
-					strings.Contains(ifLower, "external_pull_request") {
-					foundMR = true
-					return false // Stop DFS, we found it
-				}
-			}
-		}
-		return true
-	})
-
-	return foundMR
-}
-
 func hasUnsafeCheckout(script string) bool {
 	script = strings.ToLower(script)
 
@@ -182,7 +146,7 @@ func containsExecutionSink(script string) bool {
 
 func (d *Detection) createFinding(g *graph.Graph, checkoutStep *graph.StepNode, sinkStep *graph.StepNode, job *graph.JobNode, pathNodes []graph.Node) detections.Finding {
 	// Get the parent workflow for this step
-	wf := getJobParentWorkflow(g, job)
+	wf := common.GetJobParentWorkflow(g, job)
 	if wf == nil {
 		// Fallback to empty workflow info if parent not found
 		wf = &graph.WorkflowNode{}
@@ -309,25 +273,4 @@ func findCommandLineOffset(script string, pattern string) int {
 		}
 	}
 	return -1
-}
-
-// getJobParentWorkflow finds the parent workflow node for a job.
-// Returns nil if job has no parent workflow or parent is not a WorkflowNode.
-func getJobParentWorkflow(g *graph.Graph, job *graph.JobNode) *graph.WorkflowNode {
-	if job == nil {
-		return nil
-	}
-
-	// Get parent workflow
-	wfNode, ok := g.GetNode(job.Parent())
-	if !ok {
-		return nil
-	}
-
-	// Type assert to WorkflowNode
-	if wf, ok := wfNode.(*graph.WorkflowNode); ok {
-		return wf
-	}
-
-	return nil
 }

--- a/pkg/gitlab/detections/mrsecrets/mrsecrets.go
+++ b/pkg/gitlab/detections/mrsecrets/mrsecrets.go
@@ -69,7 +69,7 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 		}
 
 		// Check if workflow triggers on merge requests
-		if !hasMergeRequestTrigger(wf, g) {
+		if !common.HasMergeRequestTrigger(wf, g) {
 			continue
 		}
 
@@ -81,14 +81,14 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 			}
 
 			// Skip if job is restricted to protected branches only
-			if isProtectedBranchOnly(job) {
+			if common.IsProtectedBranchOnly(job) {
 				return true
 			}
 
 			// Check if job runs on merge request trigger
 			// Jobs without If conditions inherit the workflow's trigger context
 			// Only check jobs that explicitly mention MR events OR have no If condition (inherit from workflow)
-			if !jobRunsOnMR(job, wf, g) {
+			if !common.JobRunsOnMR(job, wf, g) {
 				return true
 			}
 
@@ -136,103 +136,6 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 	return findings, nil
 }
 
-// hasMergeRequestTrigger checks if the workflow triggers on merge requests
-func hasMergeRequestTrigger(wf *graph.WorkflowNode, g *graph.Graph) bool {
-	// Check tags for merge request indicators
-	for _, tag := range wf.Tags() {
-		if tag == graph.TagMergeRequest || tag == graph.TagExternalPullRequest {
-			return true
-		}
-	}
-
-	// Fallback: check if workflow has merge_request in triggers (case-insensitive)
-	for _, trigger := range wf.Triggers {
-		triggerLower := strings.ToLower(trigger)
-		if strings.Contains(triggerLower, "merge_request") ||
-			strings.Contains(triggerLower, "external_pull_request") {
-			return true
-		}
-	}
-
-	// Also check job-level If conditions for merge request references
-	foundMR := false
-	graph.DFS(g, wf.ID(), func(node graph.Node) bool {
-		if job, ok := node.(*graph.JobNode); ok {
-			if jobRunsOnMRExplicit(job) {
-				foundMR = true
-				return false // Stop DFS, we found it
-			}
-		}
-		return true
-	})
-
-	return foundMR
-}
-
-// jobRunsOnMRExplicit checks if a job explicitly mentions MR events in its If condition
-func jobRunsOnMRExplicit(job *graph.JobNode) bool {
-	if job.If == "" {
-		return false
-	}
-
-	ifLower := strings.ToLower(job.If)
-	return strings.Contains(ifLower, "merge_request") ||
-		strings.Contains(ifLower, "external_pull_request")
-}
-
-// jobRunsOnMR checks if a job runs on merge request events
-// This includes jobs that explicitly mention MR events OR jobs without If conditions
-// in workflows that have MR triggers
-func jobRunsOnMR(job *graph.JobNode, wf *graph.WorkflowNode, g *graph.Graph) bool {
-	// If job explicitly mentions MR events, it runs on MR
-	if jobRunsOnMRExplicit(job) {
-		return true
-	}
-
-	// If job has an If condition but doesn't mention MR events, it doesn't run on MR
-	if job.If != "" {
-		return false
-	}
-
-	// Job has no If condition - check if workflow has MR trigger
-	return hasMergeRequestTrigger(wf, g)
-}
-
-// isProtectedBranchOnly checks if a job is restricted to protected branches
-func isProtectedBranchOnly(job *graph.JobNode) bool {
-	if job.If == "" {
-		return false
-	}
-
-	ifLower := strings.ToLower(job.If)
-
-	// Check for protected branch patterns
-	protectedBranchPatterns := []string{
-		"== \"main\"",
-		"== \"master\"",
-		"== 'main'",
-		"== 'master'",
-		"=~ /^main$/",
-		"=~ /^master$/",
-		"ci_commit_branch == \"main\"",
-		"ci_commit_branch == \"master\"",
-		"ci_commit_branch == 'main'",
-		"ci_commit_branch == 'master'",
-		"ci_commit_ref_name == \"main\"",
-		"ci_commit_ref_name == \"master\"",
-		"ci_commit_ref_name == 'main'",
-		"ci_commit_ref_name == 'master'",
-	}
-
-	for _, pattern := range protectedBranchPatterns {
-		if strings.Contains(ifLower, pattern) {
-			return true
-		}
-	}
-
-	return false
-}
-
 // findSensitiveVariables finds sensitive variable references in a script
 func (d *Detection) findSensitiveVariables(script string) []string {
 	var sensitiveVars []string
@@ -275,7 +178,7 @@ func (d *Detection) isSensitiveVariable(varName string) bool {
 
 // createFinding creates a finding for secrets exposed in an MR pipeline
 func (d *Detection) createFinding(g *graph.Graph, job *graph.JobNode, step *graph.StepNode, exposedVars []string) detections.Finding {
-	wf := getJobParentWorkflow(g, job)
+	wf := common.GetJobParentWorkflow(g, job)
 	if wf == nil {
 		// Fallback to empty workflow info if parent not found
 		wf = &graph.WorkflowNode{}
@@ -331,25 +234,4 @@ func (d *Detection) createFinding(g *graph.Graph, job *graph.JobNode, step *grap
 			Metadata:    metadata,
 		},
 	}
-}
-
-// getJobParentWorkflow finds the parent workflow node for a job.
-// Returns nil if job has no parent workflow or parent is not a WorkflowNode.
-func getJobParentWorkflow(g *graph.Graph, job *graph.JobNode) *graph.WorkflowNode {
-	if job == nil {
-		return nil
-	}
-
-	// Get parent workflow
-	wfNode, ok := g.GetNode(job.Parent())
-	if !ok {
-		return nil
-	}
-
-	// Type assert to WorkflowNode
-	if wf, ok := wfNode.(*graph.WorkflowNode); ok {
-		return wf
-	}
-
-	return nil
 }

--- a/pkg/gitlab/detections/mrsecrets/mrsecrets_test.go
+++ b/pkg/gitlab/detections/mrsecrets/mrsecrets_test.go
@@ -71,7 +71,7 @@ func TestDetect_ProtectedBranchOnly(t *testing.T) {
 	findings, err := d.Detect(context.Background(), g)
 	require.NoError(t, err)
 
-	assert.Len(t, findings, 0, "Should not detect secrets in protected-branch-only jobs")
+	assert.Len(t, findings, 1, "Should detect secrets when job explicitly runs on MR events even if restricted to main branch")
 }
 
 // TestDetect_MultipleSecretsInMR tests detection of multiple sensitive variables

--- a/pkg/gitlab/detections/selfhostedrunner/selfhostedrunner.go
+++ b/pkg/gitlab/detections/selfhostedrunner/selfhostedrunner.go
@@ -69,13 +69,13 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 			}
 
 			// Skip if job is restricted to protected branches only
-			if isProtectedBranchOnly(job) {
+			if common.IsProtectedBranchOnly(job) {
 				return true
 			}
 
 			// Check if job runs on merge request trigger
 			// This checks both workflow-level and job-level triggers
-			if !jobRunsOnMR(job, wf) {
+			if !common.JobRunsOnMR(job, wf, g) {
 				return true
 			}
 
@@ -90,102 +90,6 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 	}
 
 	return findings, nil
-}
-
-// hasMergeRequestTrigger checks if the workflow triggers on merge requests
-func hasMergeRequestTrigger(wf *graph.WorkflowNode) bool {
-	// Check tags for merge request indicators
-	for _, tag := range wf.Tags() {
-		if tag == graph.TagMergeRequest || tag == graph.TagExternalPullRequest {
-			return true
-		}
-	}
-
-	// Fallback: check if workflow has merge_request in triggers (case-insensitive)
-	for _, trigger := range wf.Triggers {
-		triggerLower := strings.ToLower(trigger)
-		if strings.Contains(triggerLower, "merge_request") ||
-			strings.Contains(triggerLower, "external_pull_request") {
-			return true
-		}
-	}
-
-	return false
-}
-
-// jobRunsOnMR checks if a job runs on merge request events
-func jobRunsOnMR(job *graph.JobNode, wf *graph.WorkflowNode) bool {
-	// If job explicitly mentions MR events, it runs on MR
-	if jobRunsOnMRExplicit(job) {
-		return true
-	}
-
-	// If the workflow doesn't have MR trigger, job can't run on MR
-	if !hasMergeRequestTrigger(wf) {
-		return false
-	}
-
-	// Workflow has MR trigger
-	// Jobs inherit workflow triggers unless explicitly excluded
-	// The If condition adds constraints but doesn't remove the MR trigger
-	// (unless it's a protected branch condition, which is checked separately)
-	return true
-}
-
-// jobRunsOnMRExplicit checks if a job explicitly mentions MR events in its If condition
-func jobRunsOnMRExplicit(job *graph.JobNode) bool {
-	if job.If == "" {
-		return false
-	}
-
-	ifLower := strings.ToLower(job.If)
-	return strings.Contains(ifLower, "merge_request") ||
-		strings.Contains(ifLower, "external_pull_request")
-}
-
-// isProtectedBranchOnly checks if a job is restricted to protected branches
-func isProtectedBranchOnly(job *graph.JobNode) bool {
-	if job.If == "" {
-		return false
-	}
-
-	ifLower := strings.ToLower(job.If)
-
-	// Check for protected branch patterns
-	protectedBranchPatterns := []string{
-		"== \"main\"",
-		"== \"master\"",
-		"== 'main'",
-		"== 'master'",
-		"=~ /^main$/",
-		"=~ /^master$/",
-		"ci_commit_branch == \"main\"",
-		"ci_commit_branch == \"master\"",
-		"ci_commit_branch == 'main'",
-		"ci_commit_branch == 'master'",
-		"ci_commit_ref_name == \"main\"",
-		"ci_commit_ref_name == \"master\"",
-		"ci_commit_ref_name == 'main'",
-		"ci_commit_ref_name == 'master'",
-	}
-
-	// Only return true if the condition ONLY restricts to protected branches
-	// and doesn't also include MR trigger conditions
-	hasMRCondition := strings.Contains(ifLower, "merge_request_event") ||
-		strings.Contains(ifLower, "external_pull_request_event")
-
-	if hasMRCondition {
-		// If condition mentions both MR and protected branch, it's not safe
-		return false
-	}
-
-	for _, pattern := range protectedBranchPatterns {
-		if strings.Contains(ifLower, pattern) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // usesSelfHostedRunner checks if a job uses self-hosted or non-GitLab runners
@@ -217,7 +121,7 @@ func (d *Detection) usesSelfHostedRunner(runnerTags []string) bool {
 
 // createFinding creates a finding for self-hosted runner exposure
 func (d *Detection) createFinding(g *graph.Graph, job *graph.JobNode) detections.Finding {
-	wf := getJobParentWorkflow(g, job)
+	wf := common.GetJobParentWorkflow(g, job)
 	if wf == nil {
 		// Fallback to empty workflow info if parent not found
 		wf = &graph.WorkflowNode{}
@@ -282,25 +186,4 @@ func (d *Detection) createFinding(g *graph.Graph, job *graph.JobNode) detections
 			LineRanges: lineRanges,
 		},
 	}
-}
-
-// getJobParentWorkflow finds the parent workflow node for a job.
-// Returns nil if job has no parent workflow or parent is not a WorkflowNode.
-func getJobParentWorkflow(g *graph.Graph, job *graph.JobNode) *graph.WorkflowNode {
-	if job == nil {
-		return nil
-	}
-
-	// Get parent workflow
-	wfNode, ok := g.GetNode(job.Parent())
-	if !ok {
-		return nil
-	}
-
-	// Type assert to WorkflowNode
-	if wf, ok := wfNode.(*graph.WorkflowNode); ok {
-		return wf
-	}
-
-	return nil
 }

--- a/pkg/gitlab/detections/selfhostedrunner/selfhostedrunner_test.go
+++ b/pkg/gitlab/detections/selfhostedrunner/selfhostedrunner_test.go
@@ -344,7 +344,7 @@ func TestDetect_ProtectedBranchPatterns(t *testing.T) {
 		{
 			name:      "feature branch",
 			ifCond:    "$CI_COMMIT_BRANCH == \"feature-123\"",
-			shouldTag: true,
+			shouldTag: false,
 		},
 		{
 			name:      "MR with branch condition",


### PR DESCRIPTION
## Summary

- **LAB-1457**: Fix `parseIncludeMap` to handle `include:file` as a list of strings (the documented, recommended pattern for multi-file project includes). Previously, the `[]interface{}` case was silently dropped, leaving included templates invisible to the scanner.
- **LAB-1458**: Extract five duplicated helper functions (`getJobParentWorkflow`, `hasMergeRequestTrigger`, `jobRunsOnMR`, `jobRunsOnMRExplicit`, `isProtectedBranchOnly`) from `mrcheckout`, `mrsecrets`, and `selfhostedrunner` into the `common` package with the most correct canonical implementation for each.

### Behavioral changes (detection accuracy improvements)

| Detection | Before | After | Why |
|-----------|--------|-------|-----|
| selfhostedrunner | Jobs with non-MR `If` conditions (e.g. `$CI_COMMIT_BRANCH == "feature-123"`) flagged as running on MRs | Not flagged | `$CI_COMMIT_BRANCH` is not set in MR pipelines; these jobs cannot run on MRs |
| mrsecrets | Jobs with `merge_request_event && main` condition treated as "protected branch only" | Correctly flagged | Job explicitly runs on MR events; branch restriction does not prevent MR exploitation |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All 11 affected test packages pass (`go test -count=1`)
- [x] New unit tests for `parseIncludeMap` multi-file handling (7 test cases)
- [x] New unit tests for all 5 extracted common functions
- [x] Updated 2 existing test expectations to match corrected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)