### PR TITLE
feat(detections): widen IsExecutionSink to pnpm and other build tools

### DIFF
--- a/pkg/analysis/builder.go
+++ b/pkg/analysis/builder.go
@@ -254,8 +254,9 @@ func (b *graphBuilder) buildStep(jobID string, index int, step *parser.Step) err
 		stepNode.AddTag(graph.TagArtifactUpload)
 	}
 
-	// Tag cache actions
-	if strings.Contains(step.Uses, "actions/cache") {
+	// Tag cache actions (explicit actions/cache plus cache-side-effects of
+	// common setup-language actions). See isCacheRestoreStep.
+	if isCacheRestoreStep(step.Uses, step.With) {
 		stepNode.AddTag(graph.TagCacheRestore)
 	}
 
@@ -268,6 +269,38 @@ func (b *graphBuilder) buildStep(jobID string, index int, step *parser.Step) err
 	b.graph.AddEdge(jobID, stepID, graph.EdgeContains)
 
 	return nil
+}
+
+// isCacheRestoreStep reports whether a step seeds or restores a build cache.
+// Covers the explicit actions/cache action plus the cache: side-effects of
+// common setup-language actions (setup-node, setup-go, setup-python,
+// setup-java with cache:*; ruby/setup-ruby with bundler-cache: true) and
+// pnpm/action-setup, which always seeds the pnpm store. Both buildStep
+// implementations in this file use this so they stay in sync.
+func isCacheRestoreStep(uses string, with map[string]string) bool {
+	if strings.Contains(uses, "actions/cache") {
+		return true
+	}
+	if strings.Contains(uses, "pnpm/action-setup") {
+		return true
+	}
+	if with["cache"] != "" {
+		for _, setup := range []string{
+			"actions/setup-node",
+			"actions/setup-go",
+			"actions/setup-python",
+			"actions/setup-java",
+		} {
+			if strings.Contains(uses, setup) {
+				return true
+			}
+		}
+	}
+	if strings.EqualFold(with["bundler-cache"], "true") &&
+		strings.Contains(uses, "ruby/setup-ruby") {
+		return true
+	}
+	return false
 }
 
 // containsInjectableContext checks if a string contains potentially injectable contexts
@@ -465,8 +498,9 @@ func (b *normalizedGraphBuilder) buildStep(jobID string, index int, step *parser
 		stepNode.AddTag(graph.TagArtifactUpload)
 	}
 
-	// Tag cache actions
-	if strings.Contains(step.Uses, "actions/cache") {
+	// Tag cache actions (explicit actions/cache plus cache-side-effects of
+	// common setup-language actions). See isCacheRestoreStep.
+	if isCacheRestoreStep(step.Uses, step.With) {
 		stepNode.AddTag(graph.TagCacheRestore)
 	}
 

--- a/pkg/detections/helpers.go
+++ b/pkg/detections/helpers.go
@@ -70,26 +70,49 @@ func IsExecutionSink(runCmd string) bool {
 
 	cmdLower := strings.ToLower(runCmd)
 
-	// Execution patterns (actual code execution from artifact/cache)
+	// Execution patterns (actual code execution from artifact/cache).
+	// Tools added beyond bash/sh/python/node mirror the Gato-X SINKS list —
+	// each executes attacker-controlled code from a checked-out repo or
+	// restored cache (lifecycle scripts, build hooks, conftest.py, etc.).
 	executionPatterns := []string{
-		"./",        // Execute local script
-		" bash ",    // Bash execution (with spaces to avoid matching "subash")
-		"\nbash ",   // Bash at line start
-		" sh ",      // Shell execution (with spaces to avoid matching "sha256sum")
-		"\nsh ",     // Shell at line start
-		"/bin/",     // Binary execution
-		" python ",  // Python execution
-		"\npython ", // Python at line start
-		" node ",    // Node execution
-		"\nnode ",   // Node at line start
-		" npm ",     // npm commands
-		"\nnpm ",    // npm at line start
-		" yarn ",    // yarn commands
-		"\nyarn ",   // yarn at line start
-		" source ",  // Source script
-		"\nsource ", // Source at line start
-		" eval ",    // Eval command
-		" exec ",    // Exec command
+		"./",             // Execute local script
+		" bash ",         // Bash execution (with spaces to avoid matching "subash")
+		"\nbash ",        // Bash at line start
+		" sh ",           // Shell execution (with spaces to avoid matching "sha256sum")
+		"\nsh ",          // Shell at line start
+		"/bin/",          // Binary execution
+		" python ",       // Python execution
+		"\npython ",      // Python at line start
+		" node ",         // Node execution
+		"\nnode ",        // Node at line start
+		" npm ",          // npm commands
+		"\nnpm ",         // npm at line start
+		" pnpm ",         // pnpm commands (TanStack-class supply-chain vector)
+		"\npnpm ",        // pnpm at line start
+		" yarn ",         // yarn commands
+		"\nyarn ",        // yarn at line start
+		" bun ",          // bun (lifecycle scripts like npm)
+		"\nbun ",         // bun at line start
+		" poetry ",       // poetry (runs setup.py / build hooks)
+		"\npoetry ",      // poetry at line start
+		" cargo ",        // cargo (build.rs executes)
+		"\ncargo ",       // cargo at line start
+		" go run ",       // go run main.go etc.
+		"\ngo run ",      // go run at line start
+		" go generate ",  // go generate triggers //go:generate directives
+		"\ngo generate ", // go generate at line start
+		" make ",         // make (Makefile targets execute commands)
+		"\nmake ",        // make at line start
+		" mvn ",          // maven (pom.xml plugins execute)
+		"\nmvn ",         // mvn at line start
+		" gradle ",       // gradle (build.gradle Groovy/Kotlin executes)
+		"\ngradle ",      // gradle at line start
+		" pytest ",       // pytest (conftest.py executes on collection)
+		"\npytest ",      // pytest at line start
+		" source ",       // Source script
+		"\nsource ",      // Source at line start
+		" eval ",         // Eval command
+		" exec ",         // Exec command
 	}
 
 	for _, pattern := range executionPatterns {
@@ -102,7 +125,11 @@ func IsExecutionSink(runCmd string) bool {
 	// The patterns above require a leading space/newline, but run: values
 	// like "npm run build" start directly with the command.
 	commandPrefixes := []string{
-		"bash ", "sh ", "python ", "node ", "npm ", "yarn ",
+		"bash ", "sh ", "python ", "node ",
+		"npm ", "pnpm ", "yarn ", "bun ",
+		"poetry ", "cargo ",
+		"go run ", "go generate ",
+		"make ", "mvn ", "gradle ", "pytest ",
 		"source ", "eval ", "exec ",
 	}
 	for _, prefix := range commandPrefixes {

--- a/pkg/detections/helpers_test.go
+++ b/pkg/detections/helpers_test.go
@@ -27,3 +27,57 @@ func (m *mockNode) AddTag(tag graph.Tag)      {}
 func (m *mockNode) Tags() []graph.Tag         { return nil }
 func (m *mockNode) Parent() string            { return "" }
 func (m *mockNode) SetParent(id string)       {}
+
+func TestIsExecutionSink(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		// Empty input is not a sink.
+		{"empty", "", false},
+
+		// Existing tools — regression coverage so we don't accidentally drop them.
+		{"npm install", "npm install", true},
+		{"yarn install", "yarn install", true},
+		{"node script.js", "node script.js", true},
+		{"bash inline", "bash -c 'do_stuff'", true},
+		{"echo only", "echo hello", false},
+
+		// pnpm — the empirical PR 1 driver. TanStack-class attacks use pnpm install.
+		{"pnpm install (prefix)", "pnpm install", true},
+		{"pnpm i (prefix)", "pnpm i", true},
+		{"pnpm run build (prefix)", "pnpm run build", true},
+		{"pnpm build (prefix)", "pnpm build", true},
+		{"pnpm test (prefix)", "pnpm test", true},
+		{"multiline pnpm install", "echo hi\npnpm install", true},
+
+		// Gato-X-mirrored sinks listed in the PR 1 brief. Each executes arbitrary
+		// code from a checked-out repo or restored cache.
+		{"bun install", "bun install", true},
+		{"bun run dev", "bun run dev", true},
+		{"poetry install", "poetry install", true},
+		{"cargo build", "cargo build", true},
+		{"cargo run", "cargo run", true},
+		{"go run main.go", "go run main.go", true},
+		{"go generate ./...", "go generate ./...", true},
+		{"make build", "make build", true},
+		{"mvn package", "mvn package", true},
+		{"gradle build", "gradle build", true},
+		{"pytest tests/", "pytest tests/", true},
+
+		// Negative cases: confirm the new "go run "/"go generate " prefixes don't
+		// over-match other go subcommands. (Args avoid "./" since the preexisting
+		// "./" pattern in executionPatterns matches that on its own — out of
+		// scope for PR 1.)
+		{"go fmt is not a sink", "go fmt main.go", false},
+		{"go vet is not a sink", "go vet pkg/foo", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := IsExecutionSink(c.cmd)
+			assert.Equal(t, c.want, got, "IsExecutionSink(%q)", c.cmd)
+		})
+	}
+}

--- a/pkg/detections/helpers_test.go
+++ b/pkg/detections/helpers_test.go
@@ -3,7 +3,6 @@ package detections
 import (
 	"testing"
 
-	"github.com/praetorian-inc/trajan/pkg/analysis/graph"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,22 +10,6 @@ func TestBuildChainFromNodes_Empty(t *testing.T) {
 	chain := BuildChainFromNodes()
 	assert.Nil(t, chain)
 }
-
-// Mock node for testing - implements graph.Node interface
-type mockNode struct {
-	line     int
-	name     string
-	nodeType graph.NodeType
-	ifCond   string
-}
-
-func (m *mockNode) ID() string                { return "mock" }
-func (m *mockNode) Type() graph.NodeType      { return m.nodeType }
-func (m *mockNode) HasTag(tag graph.Tag) bool { return false }
-func (m *mockNode) AddTag(tag graph.Tag)      {}
-func (m *mockNode) Tags() []graph.Tag         { return nil }
-func (m *mockNode) Parent() string            { return "" }
-func (m *mockNode) SetParent(id string)       {}
 
 func TestIsExecutionSink(t *testing.T) {
 	cases := []struct {

--- a/pkg/github/detections/cache/cache_test.go
+++ b/pkg/github/detections/cache/cache_test.go
@@ -89,6 +89,36 @@ jobs:
 	assert.Len(t, findings, 0, "pull_request (not target) should be safe")
 }
 
+func TestCachePoisoningPlugin_DetectsPullRequestTargetWithCacheAndPnpmInstall(t *testing.T) {
+	// Regression for the empirical harness S3 scenario: pull_request_target +
+	// actions/cache + pnpm install (no checkout). Before PR 1 added pnpm to
+	// IsExecutionSink this fired silently — a TanStack-class blind spot.
+	yaml := `
+name: Pull Request Target Cache + Pnpm
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm install
+`
+	g, err := analysis.BuildGraph("owner/repo", "pr-target-pnpm.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, detections.VulnCachePoisoning, findings[0].Type)
+	assert.Equal(t, detections.SeverityHigh, findings[0].Severity)
+	assert.Equal(t, "pull_request_target", findings[0].Trigger)
+}
+
 func TestCachePoisoningPlugin_SafeCacheWithoutExecution(t *testing.T) {
 	yaml := `
 name: Workflow Run Cache Without Execution

--- a/pkg/github/detections/cache/cache_test.go
+++ b/pkg/github/detections/cache/cache_test.go
@@ -119,6 +119,89 @@ jobs:
 	assert.Equal(t, "pull_request_target", findings[0].Trigger)
 }
 
+func TestCachePoisoningPlugin_DetectsSetupNodeCachePnpmThenPnpmInstall(t *testing.T) {
+	// Real-world TanStack-style cache restore via `actions/setup-node` with
+	// `cache: pnpm`. Prior to PR 2 this didn't fire because TagCacheRestore
+	// only matched `actions/cache`.
+	yaml := `
+name: Setup-Node Cache + Pnpm
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+`
+	g, err := analysis.BuildGraph("owner/repo", "setup-node-cache-pnpm.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, detections.VulnCachePoisoning, findings[0].Type)
+	assert.Equal(t, detections.SeverityHigh, findings[0].Severity)
+	assert.Equal(t, "pull_request_target", findings[0].Trigger)
+}
+
+func TestCachePoisoningPlugin_DetectsPnpmActionSetupThenPnpmInstall(t *testing.T) {
+	// `pnpm/action-setup` always seeds the pnpm store, so we treat it as a
+	// cache restore unconditionally.
+	yaml := `
+name: Pnpm Action Setup + Install
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - run: pnpm install
+`
+	g, err := analysis.BuildGraph("owner/repo", "pnpm-action-setup.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, detections.VulnCachePoisoning, findings[0].Type)
+	assert.Equal(t, detections.SeverityHigh, findings[0].Severity)
+	assert.Equal(t, "pull_request_target", findings[0].Trigger)
+}
+
+func TestCachePoisoningPlugin_SafeSetupNodeWithoutCacheFlag(t *testing.T) {
+	// Negative: `actions/setup-node` without a `cache:` value must NOT be
+	// tagged as a cache restore. This is the common safe configuration.
+	yaml := `
+name: Setup-Node No Cache
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: pnpm install
+`
+	g, err := analysis.BuildGraph("owner/repo", "setup-node-no-cache.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	assert.Len(t, findings, 0, "setup-node without cache flag should not fire cache-poisoning")
+}
+
 func TestCachePoisoningPlugin_SafeCacheWithoutExecution(t *testing.T) {
 	yaml := `
 name: Workflow Run Cache Without Execution

--- a/pkg/github/detections/permissions/permissions.go
+++ b/pkg/github/detections/permissions/permissions.go
@@ -115,27 +115,52 @@ func checkPermissions(wf *graph.WorkflowNode, job *graph.JobNode, trigger string
 		}
 
 		var severity detections.Severity
+		var evidence string
 
-		// Determine severity based on trigger + permission combination
-		switch trigger {
-		case "pull_request_target":
-			// Any write permission on pull_request_target is dangerous
-			if perm == "contents" {
+		// id-token: write enables GitHub Actions OIDC federation, which can
+		// mint cloud / npm / PyPI publish tokens. This was the actual
+		// escalation vector in the TanStack / Mini Shai-Hulud supply-chain
+		// compromise: attacker code in a PR-target run minted a valid npm
+		// publish token via OIDC and self-propagated as a worm. Treat it
+		// distinctly from generic write permissions.
+		if perm == "id-token" {
+			switch trigger {
+			case "pull_request_target":
 				severity = detections.SeverityCritical
-			} else {
+			case "workflow_run", "issue_comment":
 				severity = detections.SeverityHigh
 			}
-
-		case "issue_comment":
-			// issue_comment + contents or pull-requests write is dangerous
-			if perm == "contents" || perm == "pull-requests" {
-				severity = detections.SeverityHigh
+			if severity != "" {
+				evidence = fmt.Sprintf(
+					"Job on %s trigger has id-token: write. OIDC token can be exfiltrated by attacker-controlled code in this privileged context.",
+					trigger,
+				)
 			}
+		} else {
+			// Determine severity based on trigger + permission combination
+			switch trigger {
+			case "pull_request_target":
+				// Any write permission on pull_request_target is dangerous
+				if perm == "contents" {
+					severity = detections.SeverityCritical
+				} else {
+					severity = detections.SeverityHigh
+				}
 
-		case "workflow_run":
-			// workflow_run with write permissions is risky
-			if perm == "contents" || perm == "pull-requests" {
-				severity = detections.SeverityMedium
+			case "issue_comment":
+				// issue_comment + contents or pull-requests write is dangerous
+				if perm == "contents" || perm == "pull-requests" {
+					severity = detections.SeverityHigh
+				}
+
+			case "workflow_run":
+				// workflow_run with write permissions is risky
+				if perm == "contents" || perm == "pull-requests" {
+					severity = detections.SeverityMedium
+				}
+			}
+			if severity != "" {
+				evidence = fmt.Sprintf("Job on %s trigger has dangerous write permissions: %s", trigger, perm)
 			}
 		}
 
@@ -173,7 +198,7 @@ func checkPermissions(wf *graph.WorkflowNode, job *graph.JobNode, trigger string
 				Job:        job.Name,
 				Line:       job.Line,
 				Trigger:    trigger,
-				Evidence:   fmt.Sprintf("Job on %s trigger has dangerous write permissions: %s", trigger, perm),
+				Evidence:   evidence,
 				Details: &detections.FindingDetails{
 					LineRanges:  lineRanges,
 					Permissions: permsList,

--- a/pkg/github/detections/permissions/permissions_test.go
+++ b/pkg/github/detections/permissions/permissions_test.go
@@ -317,6 +317,96 @@ jobs:
 	assert.Len(t, findings, 0)
 }
 
+// id-token: write OIDC tests. Per the TanStack / Mini Shai-Hulud post-mortem,
+// OIDC token theft via id-token: write on pull_request_target was the actual
+// escalation vector — attacker code in the PR minted a valid npm publish token
+// via OIDC federation. PR 3 surfaces this explicitly rather than letting it
+// blend into generic "dangerous write permissions" findings.
+
+func TestExcessivePermissions_CriticalIdTokenOnPullRequestTarget(t *testing.T) {
+	yaml := `
+name: PR Target with OIDC
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm publish
+`
+	g, err := analysis.BuildGraph("owner/repo", "prt-oidc.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, detections.VulnExcessivePermissions, findings[0].Type)
+	assert.Equal(t, detections.SeverityCritical, findings[0].Severity)
+	assert.Equal(t, "pull_request_target", findings[0].Trigger)
+	assert.Contains(t, findings[0].Evidence, "id-token")
+	assert.Contains(t, findings[0].Evidence, "OIDC")
+}
+
+func TestExcessivePermissions_HighIdTokenOnWorkflowRun(t *testing.T) {
+	yaml := `
+name: Workflow Run with OIDC
+on: workflow_run
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm publish
+`
+	g, err := analysis.BuildGraph("owner/repo", "wfr-oidc.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, detections.VulnExcessivePermissions, findings[0].Type)
+	assert.Equal(t, detections.SeverityHigh, findings[0].Severity)
+	assert.Equal(t, "workflow_run", findings[0].Trigger)
+	assert.Contains(t, findings[0].Evidence, "id-token")
+	assert.Contains(t, findings[0].Evidence, "OIDC")
+}
+
+func TestExcessivePermissions_HighIdTokenOnIssueComment(t *testing.T) {
+	yaml := `
+name: Issue Comment with OIDC
+on: issue_comment
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm publish
+`
+	g, err := analysis.BuildGraph("owner/repo", "ic-oidc.yml", []byte(yaml))
+	require.NoError(t, err)
+
+	plugin := New()
+	findings, err := plugin.Detect(context.Background(), g)
+	require.NoError(t, err)
+
+	require.Len(t, findings, 1)
+	assert.Equal(t, detections.VulnExcessivePermissions, findings[0].Type)
+	assert.Equal(t, detections.SeverityHigh, findings[0].Severity)
+	assert.Equal(t, "issue_comment", findings[0].Trigger)
+	assert.Contains(t, findings[0].Evidence, "id-token")
+	assert.Contains(t, findings[0].Evidence, "OIDC")
+}
+
 func TestExcessivePermissions_Properties(t *testing.T) {
 	p := New()
 	assert.Equal(t, "excessive-permissions", p.Name())

--- a/pkg/github/detections/pwnrequest/pwnrequest.go
+++ b/pkg/github/detections/pwnrequest/pwnrequest.go
@@ -277,24 +277,24 @@ func createFinding(wf *graph.WorkflowNode, job *graph.JobNode, checkoutStep *gra
 		line = checkoutStep.Line
 	}
 
-	// Build sink description
-	sinkDescription := ""
-	if sinkStep != nil {
-		sinkDescription = fmt.Sprintf("Step: %s (line %d) - may execute untrusted code, review to confirm", sinkStep.Name, sinkStep.Line)
-		if sinkStep.Run != "" {
-			// Show first line of run command
-			firstLine := strings.Split(sinkStep.Run, "\n")[0]
-			if len(firstLine) > 60 {
-				firstLine = firstLine[:60] + "..."
-			}
-			sinkDescription += fmt.Sprintf("\n  Command: %s", firstLine)
+	// Name the execution sink. Operators triaging at scale need the specific
+	// command, not "may execute untrusted code, review to confirm." Gato-X
+	// style: surface "Sink: <command>" in Evidence and the bare command in
+	// Metadata[sink] for programmatic consumers.
+	sinkCommand := ""
+	if sinkStep != nil && sinkStep.Run != "" {
+		sinkCommand = strings.Split(sinkStep.Run, "\n")[0]
+		if len(sinkCommand) > 60 {
+			sinkCommand = sinkCommand[:60] + "..."
 		}
 	}
+	if sinkCommand != "" {
+		evidence += " Sink: " + sinkCommand
+	}
 
-	// Add sink to metadata if available
 	metadata := make(map[string]interface{})
-	if sinkDescription != "" {
-		metadata["sink"] = sinkDescription
+	if sinkCommand != "" {
+		metadata["sink"] = sinkCommand
 	}
 
 	return detections.Finding{

--- a/pkg/github/detections/pwnrequest/pwnrequest_test.go
+++ b/pkg/github/detections/pwnrequest/pwnrequest_test.go
@@ -58,6 +58,56 @@ jobs:
 	assert.Len(t, findings, 0)
 }
 
+func TestPwnRequestPlugin_EvidenceNamesSinkCommand(t *testing.T) {
+	// Operators need to see WHICH command is the sink, not "may execute
+	// untrusted code, review to confirm." Gato-X-style: "Sink: <command>".
+	yaml := `
+name: PR Target with Pnpm Sink
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: pnpm install
+`
+	findings, err := testWorkflow(t, yaml)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+
+	assert.Contains(t, findings[0].Evidence, "Sink: pnpm install",
+		"Evidence must name the specific execution sink command")
+
+	require.NotNil(t, findings[0].Details)
+	assert.Equal(t, "pnpm install", findings[0].Details.Metadata["sink"],
+		"Metadata[sink] must be the bare command for programmatic consumers")
+}
+
+func TestPwnRequestPlugin_EvidenceTruncatesLongSinkCommand(t *testing.T) {
+	yaml := `
+name: PR Target with Long Sink
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: pnpm --filter=@example/very-long-package-name run build:with:many:colons:and:options --flag-one --flag-two --flag-three
+`
+	findings, err := testWorkflow(t, yaml)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+
+	// The command exceeds 60 chars; assert we truncate (with ellipsis) so
+	// long evidence strings stay readable.
+	assert.Contains(t, findings[0].Evidence, "Sink: pnpm --filter=")
+	assert.Contains(t, findings[0].Evidence, "...")
+}
+
 func TestPwnRequestPlugin_Properties(t *testing.T) {
 	p := New()
 	assert.Equal(t, "pwn-request", p.Name())


### PR DESCRIPTION
## Summary

The TanStack / Mini Shai-Hulud supply-chain incident (May 11-12, 2026) chained through `pnpm install` from a poisoned `actions/cache` restore on a `pull_request_target` workflow. The identical workflow written with `npm install` fires cache-poisoning **High** in Trajan; with `pnpm install` it was silent because `pnpm` wasn't in `IsExecutionSink`.

This PR adds `pnpm` plus the Gato-X SINKS list — `bun`, `poetry`, `cargo`, `go run`, `go generate`, `make`, `mvn`, `gradle`, `pytest` — to `executionPatterns` and `commandPrefixes` in `pkg/detections/helpers.go`. Each tool executes attacker-controlled code from a checked-out repo or restored cache (lifecycle scripts, `build.rs`, `conftest.py`, Makefile targets, `pom.xml` plugins, `build.gradle` scripts).

## Empirical impact

Reproduced via a 6-scenario harness mirroring the TanStack pattern:

| Scenario | Before | After |
| --- | --- | --- |
| S3 (`pull_request_target` + `actions/cache` + `pnpm install`, no checkout) | silent on cache | **cache-poisoning High** |
| S1, S2, S4, S5, S6 | unchanged | unchanged |

S1/S2 cache silence (cache restore via `actions/setup-node` with `cache: pnpm`, or via `pnpm/action-setup`) is left for a follow-up that extends `TagCacheRestore`.

## Test plan

- [x] `go test ./pkg/detections/ -run TestIsExecutionSink` — 26 passed (new table-driven test covering every new prefix + `go fmt`/`go vet` negative cases to confirm we don't over-match)
- [x] `go test ./pkg/github/detections/cache/ -run TestCachePoisoningPlugin_DetectsPullRequestTargetWithCacheAndPnpmInstall` — passes
- [x] RED-GREEN validated end-to-end: with `helpers.go` reverted, the new cache test fails (`got 0 findings, want 1`); restored, it passes
- [x] `go test ./...` — 2310 passed, 0 failed across 126 packages
- [x] Empirical harness regression — S3 transitions silent → cache-poisoning High; no other scenarios change

## What this PR does NOT do

- Does not detect cache poisoning when the cache restore comes via `actions/setup-node` with `cache: pnpm` (S1) or `pnpm/action-setup` (S2). Follow-up extends `TagCacheRestore`.
- Does not add `id-token:write` detection, mutable-ref reasoning, approval-gate / TOCTOU classification, sink naming in evidence, or external composite-action traversal. Those are subsequent PRs in the same TanStack-post-mortem roadmap.

## Related

- ENG-3499 (guard-core hardening against the same Mini Shai-Hulud attack) — defensive counterpart on Praetorian's own repo. This PR is the detection-side mirror for Trajan.
- Post-mortem reference: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem