### PR TITLE
fix: pin golangci-lint version and add install fallback in lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,9 @@ vet:
 lint:
 	@if command -v golangci-lint >/dev/null 2>&1; then \
 		golangci-lint run ./...; \
-	elif go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) 2>/dev/null; then \
-		golangci-lint run ./...; \
 	else \
-		echo "golangci-lint not available, running go vet..."; \
-		go vet ./...; \
+		echo "golangci-lint not found, running via go run $(GOLANGCI_LINT_VERSION)..."; \
+		go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) run ./...; \
 	fi
 
 ## deps: Download dependencies

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -s -w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.BuildDate=$(BUILD_DATE)
 
+GOLANGCI_LINT_VERSION ?= v2.12.2
+
 # Go commands
 GO := go
 GOFMT := gofmt
@@ -114,7 +116,14 @@ vet:
 
 ## lint: Run linters
 lint:
-	golangci-lint run ./...
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	elif go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) 2>/dev/null; then \
+		golangci-lint run ./...; \
+	else \
+		echo "golangci-lint not available, running go vet..."; \
+		go vet ./...; \
+	fi
 
 ## deps: Download dependencies
 deps:


### PR DESCRIPTION
## Summary
- Pin golangci-lint to v2.12.2 in lint target (was bare `golangci-lint run` with no install)
- Add 3-tier fallback: check installed → auto-install at pinned version → fall back to `go vet`
- Prevents supply chain attacks via compromised @latest releases

## Test plan
- [ ] `make -n lint` dry-run parses correctly
- [ ] `make lint` runs golangci-lint successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)