### PR TITLE
ci: pin claude + gemini reviewers to public-workflows v2.6.0

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@ba1070edddbce95c1a5974fc72c24c60457145cf  # v2.5.1
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@gemini'))
-    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@7c1302bdef0a72e7f5743738baa45272c8e1f8d7  # v2.1.0  # v2.1.0
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Unifies the claude-code.yml and gemini-code.yml reviewer pins onto public-workflows `v2.6.0` (`23254e12`), matching the codex pin already on main. claude-code.yml@v2.5.1 is byte-identical to v2.6.0; v2.1.0/v2.0.12 callers gain opus-4-8, T-AI-1 approve-path hardening, CVE-2025-32955 (disable-sudo-and-containers), checkout v6, ready_for_review trigger. gemini gains PR-review (event=COMMENT) posting. Behavior-positive; no approve path introduced.