### PR TITLE
fix(ci): bump Claude reusables to public-workflows v2.6.4 (opus-4-8 thinking fix)

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@23254e12b026871dd9bbf2bad4ef6fee29910fb1  # v2.6.0
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@2d4ebcb9a35f353647701eb4caa8ecbd46c32052  # v2.6.4
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   drift-check:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@25c08fbd15a931e275f207ecee1758c931f89ea5  # v2.3.1
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-md-drift.yml@2d4ebcb9a35f353647701eb4caa8ecbd46c32052  # v2.6.4
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Fleet P0: the Claude PR reviewer fails with `thinking.type.enabled is not supported for this model` (HTTP 400) — opus-4-8 now requires adaptive thinking. public-workflows **v2.6.4** bumps claude-code-action v1.0.101→v1.0.135 (bundled Claude Code CLI 2.1.114→2.1.162). Verified end-to-end on titus (job executed, posted a Claude Review, no 400). Changed: `claude-code.yml,claude-md-drift.yml`. See public-workflows#93.