### PR TITLE
fix(ado): check ref update response for silent branch create/delete failures

### DIFF
--- a/pkg/azuredevops/attacks/extractconnections/extractconnections_test.go
+++ b/pkg/azuredevops/attacks/extractconnections/extractconnections_test.go
@@ -465,7 +465,7 @@ func TestCleanupWithClient(t *testing.T) {
 			deletedBranch = true
 			resp := azuredevops.GitRefList{
 				Value: []azuredevops.GitRef{
-					{Name: "refs/heads/trajan-extract-conn-test", ObjectID: "0000000000000000000000000000000000000000"},
+					{Name: "refs/heads/trajan-extract-conn-test", ObjectID: "0000000000000000000000000000000000000000", Success: true, UpdateStatus: "succeeded"},
 				},
 				Count: 1,
 			}

--- a/pkg/azuredevops/attacks/extractsecurefiles/extractsecurefiles_test.go
+++ b/pkg/azuredevops/attacks/extractsecurefiles/extractsecurefiles_test.go
@@ -285,8 +285,10 @@ func TestCleanup(t *testing.T) {
 		if r.Method == "POST" && strings.Contains(r.URL.Path, "/refs") {
 			deletedBranches = append(deletedBranches, r.URL.Path)
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"value": []interface{}{},
-				"count": 0,
+				"value": []map[string]interface{}{
+					{"name": "refs/heads/deleted", "objectId": "0000000000000000000000000000000000000000", "success": true, "updateStatus": "succeeded"},
+				},
+				"count": 1,
 			})
 			return
 		}

--- a/pkg/azuredevops/client_git.go
+++ b/pkg/azuredevops/client_git.go
@@ -51,7 +51,10 @@ func (c *Client) CreateBranch(ctx context.Context, projectNameOrID, repoNameOrID
 	if err := c.postJSON(ctx, path, updates, &result); err != nil {
 		return fmt.Errorf("creating branch: %w", err)
 	}
-	if len(result.Value) > 0 && !result.Value[0].Success {
+	if len(result.Value) == 0 {
+		return fmt.Errorf("creating branch %q: API returned empty response", branchName)
+	}
+	if !result.Value[0].Success {
 		return fmt.Errorf("creating branch %q: %s", branchName, result.Value[0].UpdateStatus)
 	}
 	return nil
@@ -74,7 +77,10 @@ func (c *Client) DeleteBranch(ctx context.Context, projectNameOrID, repoNameOrID
 	if err := c.postJSON(ctx, path, updates, &result); err != nil {
 		return fmt.Errorf("deleting branch: %w", err)
 	}
-	if len(result.Value) > 0 && !result.Value[0].Success {
+	if len(result.Value) == 0 {
+		return fmt.Errorf("deleting branch %q: API returned empty response", branchName)
+	}
+	if !result.Value[0].Success {
 		return fmt.Errorf("deleting branch %q: %s", branchName, result.Value[0].UpdateStatus)
 	}
 	return nil

--- a/pkg/azuredevops/client_git.go
+++ b/pkg/azuredevops/client_git.go
@@ -51,6 +51,9 @@ func (c *Client) CreateBranch(ctx context.Context, projectNameOrID, repoNameOrID
 	if err := c.postJSON(ctx, path, updates, &result); err != nil {
 		return fmt.Errorf("creating branch: %w", err)
 	}
+	if len(result.Value) > 0 && !result.Value[0].Success {
+		return fmt.Errorf("creating branch %q: %s", branchName, result.Value[0].UpdateStatus)
+	}
 	return nil
 }
 
@@ -70,6 +73,9 @@ func (c *Client) DeleteBranch(ctx context.Context, projectNameOrID, repoNameOrID
 	var result GitRefList
 	if err := c.postJSON(ctx, path, updates, &result); err != nil {
 		return fmt.Errorf("deleting branch: %w", err)
+	}
+	if len(result.Value) > 0 && !result.Value[0].Success {
+		return fmt.Errorf("deleting branch %q: %s", branchName, result.Value[0].UpdateStatus)
 	}
 	return nil
 }

--- a/pkg/azuredevops/client_test.go
+++ b/pkg/azuredevops/client_test.go
@@ -141,6 +141,38 @@ func TestCreateBranch_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCreateBranch_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitRefList{Value: []GitRef{}, Count: 0}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.CreateBranch(context.Background(), "project", "repo", "test-branch", "abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
+func TestDeleteBranch_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitRefList{Value: []GitRef{}, Count: 0}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.DeleteBranch(context.Background(), "project", "repo", "test-branch", "abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty response")
+}
+
 func TestCreateBranch_Rejected(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := GitRefList{

--- a/pkg/azuredevops/client_test.go
+++ b/pkg/azuredevops/client_test.go
@@ -1,6 +1,10 @@
 package azuredevops
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -104,4 +108,140 @@ func TestClient_PrepareRequest_JSONAcceptHeader(t *testing.T) {
 		"JSON requests should use application/json Accept header")
 	assert.Contains(t, req.Header.Get("Authorization"), "Basic",
 		"Authorization header should use Basic auth")
+}
+
+func TestCreateBranch_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Contains(t, r.URL.Path, "/_apis/git/repositories/")
+
+		var updates []GitRefUpdate
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&updates))
+		assert.Len(t, updates, 1)
+		assert.Equal(t, "refs/heads/feature-branch", updates[0].Name)
+
+		resp := GitRefList{
+			Value: []GitRef{{
+				Name:         "refs/heads/feature-branch",
+				ObjectID:     "abc123",
+				Success:      true,
+				UpdateStatus: "succeeded",
+			}},
+			Count: 1,
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.CreateBranch(context.Background(), "project", "repo", "feature-branch", "abc123")
+	require.NoError(t, err)
+}
+
+func TestCreateBranch_Rejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitRefList{
+			Value: []GitRef{{
+				Name:         "refs/heads/protected-branch",
+				ObjectID:     "",
+				Success:      false,
+				UpdateStatus: "rejectedByPolicy",
+			}},
+			Count: 1,
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.CreateBranch(context.Background(), "project", "repo", "protected-branch", "abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "protected-branch")
+	assert.Contains(t, err.Error(), "rejectedByPolicy")
+}
+
+func TestDeleteBranch_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+
+		var updates []GitRefUpdate
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&updates))
+		assert.Len(t, updates, 1)
+		assert.Equal(t, "0000000000000000000000000000000000000000", updates[0].NewObjectID)
+
+		resp := GitRefList{
+			Value: []GitRef{{
+				Name:         "refs/heads/stale-branch",
+				ObjectID:     "0000000000000000000000000000000000000000",
+				Success:      true,
+				UpdateStatus: "succeeded",
+			}},
+			Count: 1,
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.DeleteBranch(context.Background(), "project", "repo", "stale-branch", "abc123")
+	require.NoError(t, err)
+}
+
+func TestDeleteBranch_Rejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitRefList{
+			Value: []GitRef{{
+				Name:         "refs/heads/main",
+				ObjectID:     "abc123",
+				Success:      false,
+				UpdateStatus: "rejectedByPolicy",
+			}},
+			Count: 1,
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.DeleteBranch(context.Background(), "project", "repo", "main", "abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "main")
+	assert.Contains(t, err.Error(), "rejectedByPolicy")
+}
+
+func TestDeleteBranch_LockConflict(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := GitRefList{
+			Value: []GitRef{{
+				Name:         "refs/heads/locked-branch",
+				ObjectID:     "abc123",
+				Success:      false,
+				UpdateStatus: "lock",
+			}},
+			Count: 1,
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-pat",
+		WithHTTPClient(server.Client()))
+
+	err := client.DeleteBranch(context.Background(), "project", "repo", "locked-branch", "abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked-branch")
+	assert.Contains(t, err.Error(), "lock")
 }

--- a/pkg/azuredevops/types_extended.go
+++ b/pkg/azuredevops/types_extended.go
@@ -232,6 +232,8 @@ type GitRef struct {
 		DisplayName string `json:"displayName"`
 		UniqueName  string `json:"uniqueName"` // email
 	} `json:"creator"`
+	Success      bool   `json:"success"`
+	UpdateStatus string `json:"updateStatus"`
 }
 
 // GitRefList represents the response from listing refs


### PR DESCRIPTION
## Summary
- ADO's ref update API returns `Success` and `UpdateStatus` fields in the response, but `CreateBranch` and `DeleteBranch` never checked them. Failed operations (rejected by policy, locked, stale ref) silently reported success, leaving stale attack branches as forensic evidence after engagements.
- Added `Success` and `UpdateStatus` fields to `GitRef`, and validation in both `CreateBranch` and `DeleteBranch` that returns a descriptive error when the API reports failure.

## Changes
- `types_extended.go`: Added `Success bool` and `UpdateStatus string` to `GitRef`
- `client_git.go`: Added response validation in `CreateBranch` and `DeleteBranch`
- `client_test.go`: 5 new tests (create success, create rejected, delete success, delete rejected, delete lock conflict)
- `extractconnections_test.go`: Fixed mock to include `Success: true` in branch deletion response

Closes LAB-3930

🤖 Generated with [Claude Code](https://claude.com/claude-code)