### PR TITLE
fix(ado): use IsHosted API field for self-hosted agent pool detection

### DIFF
--- a/cmd/trajan/ado/scan.go
+++ b/cmd/trajan/ado/scan.go
@@ -3,6 +3,7 @@ package ado
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/praetorian-inc/trajan/internal/cmdutil"
 	"github.com/praetorian-inc/trajan/internal/registry"
+	"github.com/praetorian-inc/trajan/pkg/azuredevops"
 	"github.com/praetorian-inc/trajan/pkg/detections"
 	outputpkg "github.com/praetorian-inc/trajan/pkg/output"
 	"github.com/praetorian-inc/trajan/pkg/platforms"
@@ -169,6 +171,16 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	executor := scanner.NewDetectionExecutor(allPlugins, scanConcurrency)
 	executor.SetMetadata("platform", "azuredevops")
+
+	if adoPlatform, ok := platform.(*azuredevops.Platform); ok {
+		pools, poolErr := adoPlatform.Client().ListAgentPools(ctx)
+		if poolErr != nil {
+			slog.Warn("could not fetch agent pools for detection enrichment", "error", poolErr)
+		} else {
+			executor.SetMetadata("ado_agent_pools", pools)
+		}
+	}
+
 	execResult, err := executor.Execute(ctx, result.Workflows)
 	if err != nil {
 		return fmt.Errorf("executing plugins: %w", err)

--- a/pkg/azuredevops/detections/agentsecurity/agentsecurity.go
+++ b/pkg/azuredevops/detections/agentsecurity/agentsecurity.go
@@ -34,7 +34,7 @@ func New() *Detection {
 func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Finding, error) {
 	var findings []detections.Finding
 
-	hostedPools := buildHostedPoolSet(g)
+	poolMap := buildPoolMap(g)
 
 	workflows := g.GetNodesByType(graph.NodeTypeWorkflow)
 
@@ -45,7 +45,7 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 			if node.Type() == graph.NodeTypeJob {
 				job := node.(*graph.JobNode)
 
-				if isSelfHostedPool(job.RunsOn, hostedPools) {
+				if isSelfHostedPool(job.RunsOn, poolMap) {
 					findings = append(findings, detections.Finding{
 						Type:        detections.VulnSelfHostedAgent,
 						Platform:    platforms.PlatformAzureDevOps,
@@ -76,49 +76,55 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 	return findings, nil
 }
 
-// buildHostedPoolSet reads agent pool metadata from the graph (set by the scan
-// command via ListAgentPools) and returns a set of lowercase pool names that
-// are Microsoft-hosted. Returns nil when no pool metadata is available (offline mode).
-func buildHostedPoolSet(g *graph.Graph) map[string]bool {
+// buildPoolMap reads agent pool metadata from the graph (set by the scan
+// command via ListAgentPools) and returns a map of lowercase pool name to
+// IsHosted status. Returns nil when no pool metadata is available (offline mode).
+func buildPoolMap(g *graph.Graph) map[string]bool {
 	data, ok := g.GetMetadata("ado_agent_pools")
 	if !ok {
 		return nil
 	}
 	pools, ok := data.([]azuredevops.AgentPool)
-	if !ok {
+	if !ok || len(pools) == 0 {
 		return nil
 	}
-	hosted := make(map[string]bool, len(pools))
+	m := make(map[string]bool, len(pools))
 	for _, p := range pools {
-		if p.IsHosted {
-			hosted[strings.ToLower(p.Name)] = true
-		}
+		m[strings.ToLower(p.Name)] = p.IsHosted
 	}
-	return hosted
+	return m
 }
 
 // isSelfHostedPool checks if the RunsOn value indicates a self-hosted agent pool.
-// When hostedPools is non-nil (API data available), pool names are checked against
-// the API's IsHosted field. When nil (offline mode), a vmImage heuristic is used.
-func isSelfHostedPool(runsOn string, hostedPools map[string]bool) bool {
+// When poolMap is non-nil (API data available), pool names are checked against
+// the API's IsHosted field first. The vmImage heuristic is only used for pool
+// names not found in the API data, or in offline mode.
+func isSelfHostedPool(runsOn string, poolMap map[string]bool) bool {
 	if runsOn == "" {
 		return false
 	}
 
 	runsOnLower := strings.ToLower(runsOn)
 
-	// vmImage values are always Microsoft-hosted regardless of API data
+	// When API pool data is available, it is authoritative
+	if poolMap != nil {
+		if isHosted, known := poolMap[runsOnLower]; known {
+			return !isHosted
+		}
+	}
+
+	// For pool names not in the API (or offline mode), use vmImage heuristic
 	if isVMImage(runsOnLower) {
 		return false
 	}
 
-	// When API pool data is available, use IsHosted for accurate classification
-	if hostedPools != nil {
-		return !hostedPools[runsOnLower]
+	// Offline fallback for non-vmImage pool names
+	if poolMap == nil {
+		return runsOnLower != "azure pipelines"
 	}
 
-	// Offline fallback: "Azure Pipelines" is the only well-known hosted pool name
-	return runsOnLower != "azure pipelines"
+	// API available but pool not listed -- conservative: flag as self-hosted
+	return true
 }
 
 // isVMImage returns true if the RunsOn value (already lowercased) is a

--- a/pkg/azuredevops/detections/agentsecurity/agentsecurity.go
+++ b/pkg/azuredevops/detections/agentsecurity/agentsecurity.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/praetorian-inc/trajan/internal/registry"
 	"github.com/praetorian-inc/trajan/pkg/analysis/graph"
+	"github.com/praetorian-inc/trajan/pkg/azuredevops"
 	"github.com/praetorian-inc/trajan/pkg/detections"
 	"github.com/praetorian-inc/trajan/pkg/detections/base"
 	"github.com/praetorian-inc/trajan/pkg/platforms"
@@ -33,18 +34,18 @@ func New() *Detection {
 func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Finding, error) {
 	var findings []detections.Finding
 
-	// Get all workflow nodes
+	hostedPools := buildHostedPoolSet(g)
+
 	workflows := g.GetNodesByType(graph.NodeTypeWorkflow)
 
 	for _, wfNode := range workflows {
 		wf := wfNode.(*graph.WorkflowNode)
 
-		// DFS through all jobs to check agent pools
 		graph.DFS(g, wf.ID(), func(node graph.Node) bool {
 			if node.Type() == graph.NodeTypeJob {
 				job := node.(*graph.JobNode)
 
-				if isSelfHostedPool(job.RunsOn) {
+				if isSelfHostedPool(job.RunsOn, hostedPools) {
 					findings = append(findings, detections.Finding{
 						Type:        detections.VulnSelfHostedAgent,
 						Platform:    platforms.PlatformAzureDevOps,
@@ -75,40 +76,63 @@ func (d *Detection) Detect(ctx context.Context, g *graph.Graph) ([]detections.Fi
 	return findings, nil
 }
 
-// isSelfHostedPool checks if the RunsOn value indicates a self-hosted agent pool
-func isSelfHostedPool(runsOn string) bool {
-	// Empty RunsOn means no pool specified — uses project default, not definitively self-hosted
+// buildHostedPoolSet reads agent pool metadata from the graph (set by the scan
+// command via ListAgentPools) and returns a set of lowercase pool names that
+// are Microsoft-hosted. Returns nil when no pool metadata is available (offline mode).
+func buildHostedPoolSet(g *graph.Graph) map[string]bool {
+	data, ok := g.GetMetadata("ado_agent_pools")
+	if !ok {
+		return nil
+	}
+	pools, ok := data.([]azuredevops.AgentPool)
+	if !ok {
+		return nil
+	}
+	hosted := make(map[string]bool, len(pools))
+	for _, p := range pools {
+		if p.IsHosted {
+			hosted[strings.ToLower(p.Name)] = true
+		}
+	}
+	return hosted
+}
+
+// isSelfHostedPool checks if the RunsOn value indicates a self-hosted agent pool.
+// When hostedPools is non-nil (API data available), pool names are checked against
+// the API's IsHosted field. When nil (offline mode), a vmImage heuristic is used.
+func isSelfHostedPool(runsOn string, hostedPools map[string]bool) bool {
 	if runsOn == "" {
 		return false
 	}
 
 	runsOnLower := strings.ToLower(runsOn)
 
-	// Microsoft-hosted pools (safe)
-	microsoftHostedPools := []string{
-		"ubuntu-latest",
-		"ubuntu-24.04",
-		"ubuntu-22.04",
-		"ubuntu-20.04",
-		"windows-latest",
-		"windows-2025",
-		"windows-2022",
-		"windows-2019",
-		"macos-latest",
-		"macos-15",
-		"macos-14",
-		"macos-13",
-		"macos-12",
-		"azure pipelines",
-		"vmimage:",
+	// vmImage values are always Microsoft-hosted regardless of API data
+	if isVMImage(runsOnLower) {
+		return false
 	}
 
-	for _, hostedPool := range microsoftHostedPools {
-		if strings.Contains(runsOnLower, hostedPool) {
-			return false
+	// When API pool data is available, use IsHosted for accurate classification
+	if hostedPools != nil {
+		return !hostedPools[runsOnLower]
+	}
+
+	// Offline fallback: "Azure Pipelines" is the only well-known hosted pool name
+	return runsOnLower != "azure pipelines"
+}
+
+// isVMImage returns true if the RunsOn value (already lowercased) is a
+// Microsoft-hosted vmImage string. These follow predictable naming conventions
+// and don't need API validation.
+func isVMImage(runsOnLower string) bool {
+	if strings.HasPrefix(runsOnLower, "vmimage:") {
+		return true
+	}
+	vmImagePrefixes := []string{"ubuntu-", "windows-", "macos-"}
+	for _, prefix := range vmImagePrefixes {
+		if strings.HasPrefix(runsOnLower, prefix) {
+			return true
 		}
 	}
-
-	// If it doesn't match any Microsoft-hosted pool, it's self-hosted
-	return true
+	return false
 }

--- a/pkg/azuredevops/detections/agentsecurity/agentsecurity_test.go
+++ b/pkg/azuredevops/detections/agentsecurity/agentsecurity_test.go
@@ -217,6 +217,30 @@ func TestAgentSecurityDetection_Detect_APIDataHostedPoolNotFlagged(t *testing.T)
 	assert.Empty(t, findings, "Pool marked IsHosted by API should not be flagged")
 }
 
+func TestAgentSecurityDetection_Detect_APIOverridesVMImageHeuristic(t *testing.T) {
+	d := New()
+	ctx := context.Background()
+
+	g := graph.NewGraph()
+	g.SetMetadata("ado_agent_pools", []azuredevops.AgentPool{
+		{ID: 1, Name: "Azure Pipelines", IsHosted: true},
+		{ID: 2, Name: "ubuntu-builders", IsHosted: false},
+	})
+
+	wf := graph.NewWorkflowNode("wf1", "pipeline.yml", "pipeline.yml", "owner/repo", nil)
+	g.AddNode(wf)
+
+	job := graph.NewJobNode("job1", "build", "ubuntu-builders")
+	job.SetParent(wf.ID())
+	g.AddNode(job)
+	g.AddEdge(wf.ID(), job.ID(), graph.EdgeContains)
+
+	findings, err := d.Detect(ctx, g)
+	require.NoError(t, err)
+	require.Len(t, findings, 1, "Self-hosted pool with ubuntu prefix must be detected when API says IsHosted=false")
+	assert.Contains(t, findings[0].Evidence, "ubuntu-builders")
+}
+
 func TestAgentSecurityDetection_Detect_AzurePipelinesPoolOffline(t *testing.T) {
 	d := New()
 	ctx := context.Background()
@@ -240,13 +264,15 @@ func TestIsSelfHostedPool(t *testing.T) {
 	apiPools := map[string]bool{
 		"azure pipelines":    true,
 		"hosted ubuntu 1604": true,
+		"ubuntu-builders":    false,
+		"shire-self-hosted":  false,
 	}
 
 	tests := []struct {
-		name        string
-		runsOn      string
-		hostedPools map[string]bool
-		want        bool
+		name    string
+		runsOn  string
+		poolMap map[string]bool
+		want    bool
 	}{
 		{"empty runsOn", "", nil, false},
 		{"vmImage ubuntu-latest", "ubuntu-latest", nil, false},
@@ -256,13 +282,16 @@ func TestIsSelfHostedPool(t *testing.T) {
 		{"offline: Azure Pipelines pool", "Azure Pipelines", nil, false},
 		{"offline: unknown pool is self-hosted", "my-pool", nil, true},
 		{"API: hosted pool not flagged", "Hosted Ubuntu 1604", apiPools, false},
-		{"API: unknown pool flagged", "my-pool", apiPools, true},
+		{"API: unknown pool flagged as self-hosted", "my-pool", apiPools, true},
 		{"API: vmImage still safe", "ubuntu-latest", apiPools, false},
+		{"API: self-hosted pool with ubuntu prefix detected", "ubuntu-builders", apiPools, true},
+		{"API: self-hosted pool by name", "shire-self-hosted", apiPools, true},
+		{"API: hosted pool with Azure Pipelines name", "Azure Pipelines", apiPools, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isSelfHostedPool(tt.runsOn, tt.hostedPools)
+			got := isSelfHostedPool(tt.runsOn, tt.poolMap)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/azuredevops/detections/agentsecurity/agentsecurity_test.go
+++ b/pkg/azuredevops/detections/agentsecurity/agentsecurity_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/praetorian-inc/trajan/pkg/analysis/graph"
+	"github.com/praetorian-inc/trajan/pkg/azuredevops"
 	"github.com/praetorian-inc/trajan/pkg/detections"
 	"github.com/praetorian-inc/trajan/pkg/platforms"
 )
@@ -148,13 +149,11 @@ func TestAgentSecurityDetection_Detect_MultipleJobsMixed(t *testing.T) {
 	wf := graph.NewWorkflowNode("wf1", "pipeline.yml", "pipeline.yml", "owner/repo", nil)
 	g.AddNode(wf)
 
-	// Safe job with ubuntu-latest
 	job1 := graph.NewJobNode("job1", "build", "ubuntu-latest")
 	job1.SetParent(wf.ID())
 	g.AddNode(job1)
 	g.AddEdge(wf.ID(), job1.ID(), graph.EdgeContains)
 
-	// Unsafe job with self-hosted pool
 	job2 := graph.NewJobNode("job2", "deploy", "custom-pool")
 	job2.SetParent(wf.ID())
 	g.AddNode(job2)
@@ -163,4 +162,108 @@ func TestAgentSecurityDetection_Detect_MultipleJobsMixed(t *testing.T) {
 	findings, err := d.Detect(ctx, g)
 	require.NoError(t, err)
 	assert.Len(t, findings, 1, "Expected exactly 1 finding for self-hosted pool")
+}
+
+func TestAgentSecurityDetection_Detect_WithAPIPoolData(t *testing.T) {
+	d := New()
+	ctx := context.Background()
+
+	g := graph.NewGraph()
+	g.SetMetadata("ado_agent_pools", []azuredevops.AgentPool{
+		{ID: 1, Name: "Azure Pipelines", IsHosted: true},
+		{ID: 2, Name: "Hosted Ubuntu 1604", IsHosted: true},
+		{ID: 3, Name: "shire-self-hosted", IsHosted: false},
+	})
+
+	wf := graph.NewWorkflowNode("wf1", "pipeline.yml", "pipeline.yml", "owner/repo", nil)
+	g.AddNode(wf)
+
+	jobHosted := graph.NewJobNode("job1", "build", "Hosted Ubuntu 1604")
+	jobHosted.SetParent(wf.ID())
+	g.AddNode(jobHosted)
+	g.AddEdge(wf.ID(), jobHosted.ID(), graph.EdgeContains)
+
+	jobSelfHosted := graph.NewJobNode("job2", "deploy", "shire-self-hosted")
+	jobSelfHosted.SetParent(wf.ID())
+	g.AddNode(jobSelfHosted)
+	g.AddEdge(wf.ID(), jobSelfHosted.ID(), graph.EdgeContains)
+
+	findings, err := d.Detect(ctx, g)
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Contains(t, findings[0].Evidence, "shire-self-hosted")
+}
+
+func TestAgentSecurityDetection_Detect_APIDataHostedPoolNotFlagged(t *testing.T) {
+	d := New()
+	ctx := context.Background()
+
+	g := graph.NewGraph()
+	g.SetMetadata("ado_agent_pools", []azuredevops.AgentPool{
+		{ID: 1, Name: "Azure Pipelines", IsHosted: true},
+		{ID: 2, Name: "My Custom Hosted", IsHosted: true},
+	})
+
+	wf := graph.NewWorkflowNode("wf1", "pipeline.yml", "pipeline.yml", "owner/repo", nil)
+	g.AddNode(wf)
+
+	job := graph.NewJobNode("job1", "build", "My Custom Hosted")
+	job.SetParent(wf.ID())
+	g.AddNode(job)
+	g.AddEdge(wf.ID(), job.ID(), graph.EdgeContains)
+
+	findings, err := d.Detect(ctx, g)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "Pool marked IsHosted by API should not be flagged")
+}
+
+func TestAgentSecurityDetection_Detect_AzurePipelinesPoolOffline(t *testing.T) {
+	d := New()
+	ctx := context.Background()
+
+	g := graph.NewGraph()
+
+	wf := graph.NewWorkflowNode("wf1", "pipeline.yml", "pipeline.yml", "owner/repo", nil)
+	g.AddNode(wf)
+
+	job := graph.NewJobNode("job1", "build", "Azure Pipelines")
+	job.SetParent(wf.ID())
+	g.AddNode(job)
+	g.AddEdge(wf.ID(), job.ID(), graph.EdgeContains)
+
+	findings, err := d.Detect(ctx, g)
+	require.NoError(t, err)
+	assert.Empty(t, findings, "Azure Pipelines pool should not be flagged in offline mode")
+}
+
+func TestIsSelfHostedPool(t *testing.T) {
+	apiPools := map[string]bool{
+		"azure pipelines":    true,
+		"hosted ubuntu 1604": true,
+	}
+
+	tests := []struct {
+		name        string
+		runsOn      string
+		hostedPools map[string]bool
+		want        bool
+	}{
+		{"empty runsOn", "", nil, false},
+		{"vmImage ubuntu-latest", "ubuntu-latest", nil, false},
+		{"vmImage windows-2022", "windows-2022", nil, false},
+		{"vmImage macos-15", "macos-15", nil, false},
+		{"vmImage prefix", "vmimage:ubuntu-22.04", nil, false},
+		{"offline: Azure Pipelines pool", "Azure Pipelines", nil, false},
+		{"offline: unknown pool is self-hosted", "my-pool", nil, true},
+		{"API: hosted pool not flagged", "Hosted Ubuntu 1604", apiPools, false},
+		{"API: unknown pool flagged", "my-pool", apiPools, true},
+		{"API: vmImage still safe", "ubuntu-latest", apiPools, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSelfHostedPool(tt.runsOn, tt.hostedPools)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded pool name allowlist in `agent-security` detection with the `ListAgentPools()` API's `IsHosted` field for accurate classification
- When API data is unavailable (offline/`--path` mode), fall back to vmImage prefix matching and the well-known "Azure Pipelines" pool name
- Pipe agent pool metadata from `scan.go` into the detection via graph metadata, following the same pattern GitHub's runner detection uses

## Test plan
- [ ] Verify all existing agentsecurity detection tests still pass
- [ ] Verify new API-enriched tests pass (hosted pool not flagged, self-hosted pool flagged, custom-named hosted pool recognized via API)
- [ ] Verify offline fallback tests pass (vmImage patterns, "Azure Pipelines" pool name)
- [ ] Run `trajan ado scan --org <org> --repo <repo>` against test org to confirm real API enrichment works
- [ ] Run `trajan ado scan --path <local-yaml>` to confirm offline mode still detects self-hosted pools correctly