### PR TITLE
ci(claude): bump claude-code reviewer to public-workflows v2.11.3

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   claude-code-action:
-    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@0c602372f3d0d038912dd08e159ecc83954a4995  # v2.9.3
+    uses: praetorian-inc/public-workflows/.github/workflows/claude-code.yml@3fb9ffbace86c9e93a7b92170241dd54b5031608  # v2.11.3
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Bumps the **Claude PR Assistant** reviewer pin from `public-workflows` to **v2.11.3**, realigning it with the codex/gemini reviewers (already on v2.11.3).

**Safety**: v2.11.3 dereferences to commit `3fb9ffbace86c9e93a7b92170241dd54b5031608`. The reusable's `workflow_call` interface is unchanged from the prior pin — inputs (`prompt`/`require_tests`/`max_turns`) are optional and the only required secret is `ANTHROPIC_API_KEY`, which this caller already passes. No-break pin advance.

Part of an org-wide reviewer-pin alignment sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)