### PR TITLE
ci: release on tag push (v*) instead of every commit to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*'
 
 concurrency:
   group: release
@@ -12,43 +13,8 @@ permissions:
   contents: write
 
 jobs:
-  create-tag:
-    name: Create Tag
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      tag_created: ${{ steps.tag.outputs.tag_created }}
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        fetch-depth: 0
-
-    - name: Fetch all tags
-      run: git fetch --tags --force
-
-    - name: Calculate version
-      id: version
-      run: |
-        NEW_VERSION=$(make -s version)
-        echo "New version: $NEW_VERSION"
-        echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-    - name: Create and push tag
-      id: tag
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
-        git push origin "${{ steps.version.outputs.version }}"
-        echo "tag_created=true" >> "$GITHUB_OUTPUT"
-      env:
-        GH_TOKEN: ${{ github.token }}
-
   goreleaser:
     name: GoReleaser
-    needs: [create-tag]
     environment: production
     runs-on: ubuntu-latest
 
@@ -57,7 +23,7 @@ jobs:
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
-        ref: ${{ needs.create-tag.outputs.version }}
+        ref: ${{ github.ref_name }}
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -72,21 +38,3 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  cleanup-on-failure:
-    name: Cleanup on Failure
-    needs: [create-tag, goreleaser]
-    if: failure() && needs.create-tag.outputs.tag_created == 'true'
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-    - name: Delete release and tag
-      run: |
-        echo "Cleaning up failed release ${{ needs.create-tag.outputs.version }}"
-        gh release delete "${{ needs.create-tag.outputs.version }}" --yes || true
-        git push --delete origin "${{ needs.create-tag.outputs.version }}" || true
-      env:
-        GH_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ WASM_LDFLAGS := -s -w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT)
 # Safety: delete partial outputs on error
 .DELETE_ON_ERROR:
 
-.PHONY: all build test test-short test-coverage clean fmt vet lint deps help version wasm wasm-dist wasm-serve jenkins-test-up jenkins-test-down jenkins-integration
+.PHONY: all build test test-short test-coverage clean fmt vet lint deps help wasm wasm-dist wasm-serve jenkins-test-up jenkins-test-down jenkins-integration
 
 all: build
 
@@ -80,23 +80,6 @@ wasm-dist: wasm
 wasm-serve: wasm
 	@echo "Starting dev server at http://localhost:8080"
 	@cd $(WASM_DIR) && $(GO) run server.go
-
-## version: Calculate next semantic version from git tags and commit message
-version:
-	@tag=$$(git tag -l 'v*' --sort=-v:refname | head -n1); \
-	if [ -z "$$tag" ]; then latest="0.0.0"; else latest=$$(echo "$$tag" | sed 's/^v//'); fi; \
-	msg=$$(git log -1 --format=%s); \
-	major=$$(echo "$$latest" | cut -d. -f1); \
-	minor=$$(echo "$$latest" | cut -d. -f2); \
-	patch=$$(echo "$$latest" | cut -d. -f3); \
-	if echo "$$msg" | grep -q '\[major-release\]'; then \
-		major=$$((major + 1)); minor=0; patch=0; \
-	elif echo "$$msg" | grep -q '\[minor-release\]'; then \
-		minor=$$((minor + 1)); patch=0; \
-	else \
-		patch=$$((patch + 1)); \
-	fi; \
-	echo "v$$major.$$minor.$$patch"
 
 ## clean: Remove build artifacts
 clean:


### PR DESCRIPTION
## What

Switch the release pipeline from **auto-releasing on every push to `main`** to **releasing only when a `v*` tag is pushed**. The version is now supplied by whoever pushes the tag, rather than computed in CI.

## Why

Every merge to `main` currently cuts a release (auto-incrementing the patch version and pushing a tag). Moving to tag-driven releases gives the releaser explicit control over *when* a release happens and *what version* it gets.

## Changes

**`.github/workflows/release.yaml`**
- Trigger changed from `push: branches: [main]` → `push: tags: ['v*']`.
- Removed the **`create-tag`** job — it computed the next semver via `make version` and auto-created/pushed the tag. The releaser now creates the tag.
- The **`goreleaser`** job now checks out the triggering tag (`ref: ${{ github.ref_name }}`); GoReleaser derives `{{.Version}}` from that tag automatically.
- Removed the **`cleanup-on-failure`** job — it existed to delete the *auto-created* tag/release on failure. Now that a human owns the tag, auto-deleting it on failure is no longer appropriate (and it depended on `create-tag`'s outputs).

**`Makefile`**
- Removed the `version` target (and its `.PHONY` entry) — it only existed for CI to compute the next release version. The `VERSION` variable is **kept** (still used for local `make build` and the goreleaser `make wasm-dist` before-hook; it derives from `git describe --tags`).

## How to release now

```
git tag -a v1.2.3 -m "Release v1.2.3"
git push origin v1.2.3
```

## Verification

- `release.yaml` parses; only the `goreleaser` job remains.
- `make help` no longer lists `version`; `make version` now errors (target removed).
- `make build` still succeeds with version stamped from `git describe --tags`.

## Note for reviewers

Dropping `cleanup-on-failure` means a failed GoReleaser run will leave the pushed tag in place (it won't be auto-deleted). That's intentional given the tag is now human-created — if you'd prefer a release-only cleanup (delete a partial GitHub release but keep the tag), I can add that back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
CLOSES LAB-4266
