### PR TITLE
ADO detection rules: cat-01 build-validation (execution & injection)

### DIFF
--- a/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
@@ -1,30 +1,36 @@
 id: cat-01/build-validation-secret-exposure
 scenario_id: cat-01/01
-title: "Build validation runs PR merge-commit code with collection token and secrets"
-subject: chain
+title: "Untrusted-triggered pipeline job runs attacker code with the system access token"
+subject: pipeline_poisoning
 severity: critical
+confidence: medium
 description: >
-  A build-validation branch policy queues a pipeline on the PR merge commit,
-  executing attacker-controlled code with the pipeline's job access token and
-  every authorized secret before any reviewer approves the PR. When the job
-  authorization scope is collection-wide, the token reaches every repo and
-  project in the organization.
-
-chain_of:
-  join: build-validation-exposure
-  for_each: authorized_resources
-  where:
-    all_of:
-      - is_secret_bearing == true
-
+  A job runs on an untrusted trigger — a Build validation branch policy that
+  queues on PR create/update, or a CI push to a branch an attacker can reach —
+  and that job exposes the pipeline's System.AccessToken. Attacker-controlled
+  code in the PR merge commit (or the pushed branch) executes with the build
+  identity's OAuth token before any reviewer approves, letting it call the ADO
+  REST API as the pipeline. On Azure Repos there is no fork boundary: the branch
+  policy runs the untrusted code as a side effect of validating it. A
+  collection-scoped identity extends the blast radius to every project.
+where:
+  all_of:
+    - "technique == 'pipeline_poisoning'"
+    - "exposes_system_access_token == true"
+    - any_of:
+        - "via == 'build_validation'"
+        - "via == 'branch_queue'"
+        - "via == 'ci_trigger'"
+        - "trigger == 'build_validation'"
+        - "trigger == 'ci_push'"
+        - "trigger == 'manual_queue'"
+        - "identity_scope == 'collection'"
 evidence:
-  - "Build validation policy on {{ branch }} triggers pipeline {{ pipeline_name }}"
-  - "Job authorization scope: {{ job_auth_scope }} (collection = cross-project blast radius)"
-  - "Pipeline consumes secret-bearing resources: {{ authorized_resource_names }}"
-  - "Attacker population: any identity with Contribute or CreateBranch on the repo"
-
+  - "Pipeline {{ pipeline_id }} job {{ job }} in {{ project }} poisoned via {{ via }} (trigger {{ trigger }})"
+  - "Sink {{ sink_kind }}/{{ sink_form }} exposes System.AccessToken; identity scope {{ identity_scope }}"
+  - "Gate state: {{ gate_state }}; confidence {{ confidence }}"
 remediation_hint: >
-  Separate build-validation pipelines from secret-consuming pipelines. Scope job
-  authorization to current project. Place approval checks and branch-control
-  checks on every secret-bearing resource (variable group, service connection,
-  secure file) so validation builds cannot decrypt them without review.
+  Do not expose System.AccessToken in jobs reachable by PR build validation or
+  by pushes to shared branches. Restrict job authorization scope to the current
+  project, gate the pipeline behind an approval/branch-control check, and split
+  validation builds from any job that needs the build identity's token.

--- a/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-01/01
 title: "Build validation runs PR merge-commit code with collection token and secrets"
 subject: chain
 severity: critical
-confidence: high
 description: >
   A build-validation branch policy queues a pipeline on the PR merge commit,
   executing attacker-controlled code with the pipeline's job access token and

--- a/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
@@ -1,0 +1,31 @@
+id: cat-01/build-validation-secret-exposure
+scenario_id: cat-01/01
+title: "Build validation runs PR merge-commit code with collection token and secrets"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  A build-validation branch policy queues a pipeline on the PR merge commit,
+  executing attacker-controlled code with the pipeline's job access token and
+  every authorized secret before any reviewer approves the PR. When the job
+  authorization scope is collection-wide, the token reaches every repo and
+  project in the organization.
+
+chain_of:
+  join: build-validation-exposure
+  for_each: authorized_resources
+  where:
+    all_of:
+      - is_secret_bearing == true
+
+evidence:
+  - "Build validation policy on {{ branch }} triggers pipeline {{ pipeline_name }}"
+  - "Job authorization scope: {{ job_auth_scope }} (collection = cross-project blast radius)"
+  - "Pipeline consumes secret-bearing resources: {{ authorized_resource_names }}"
+  - "Attacker population: any identity with Contribute or CreateBranch on the repo"
+
+remediation_hint: >
+  Separate build-validation pipelines from secret-consuming pipelines. Scope job
+  authorization to current project. Place approval checks and branch-control
+  checks on every secret-bearing resource (variable group, service connection,
+  secure file) so validation builds cannot decrypt them without review.

--- a/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
@@ -1,0 +1,29 @@
+id: cat-01/open-access-secret-reachable
+scenario_id: cat-01/05
+title: "Open-access resource reachable from any PR-buildable or attacker-creatable pipeline"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A variable group, secure file, or service connection has "Grant access
+  permission to all pipelines" enabled, making it decryptable by any pipeline in
+  the project. Combined with build-validation policies or the default ability for
+  Contributors to create pipelines, an attacker who controls any pipeline's
+  YAML can exfiltrate the resource's secrets without ever being granted access.
+
+chain_of:
+  join: open-access-pipeline-reach
+  for_each: reachable_pipelines
+  where:
+    all_of:
+      - attacker_can_influence_yaml == true
+
+evidence:
+  - "Resource {{ resource_name }} ({{ resource_type }}) has grant_all_pipelines = true"
+  - "Reachable via pipeline {{ pipeline_name }} ({{ attacker_vector }})"
+  - "Attacker influence: {{ attacker_vector_detail }}"
+
+remediation_hint: >
+  Disable "Grant access permission to all pipelines" on every secret-bearing
+  resource. Use per-pipeline authorization and add approval or branch-control
+  checks so that only reviewed, trusted builds can consume the resource.

--- a/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
@@ -1,28 +1,33 @@
 id: cat-01/open-access-secret-reachable
 scenario_id: cat-01/05
-title: "Open-access resource reachable from any PR-buildable or attacker-creatable pipeline"
-subject: chain
+title: "Ungated pipeline job is poisonable by an untrusted trigger"
+subject: pipeline_poisoning
 severity: high
+confidence: medium
 description: >
-  A variable group, secure file, or service connection has "Grant access
-  permission to all pipelines" enabled, making it decryptable by any pipeline in
-  the project. Combined with build-validation policies or the default ability for
-  Contributors to create pipelines, an attacker who controls any pipeline's
-  YAML can exfiltrate the resource's secrets without ever being granted access.
-
-chain_of:
-  join: open-access-pipeline-reach
-  for_each: reachable_pipelines
-  where:
-    all_of:
-      - attacker_can_influence_yaml == true
-
+  A job with a privileged sink is reachable by an untrusted trigger (Build
+  validation on PR create/update, or a CI push to an attacker-reachable branch)
+  with no approval or branch-control gate protecting it. Any resource authorized
+  to the pipeline — an open-access variable group, service connection, or secure
+  file the pipeline merely names — is decrypted into the attacker-authored build,
+  so an attacker who controls the pipeline's YAML exfiltrates secrets they were
+  never granted. This is the general "poisonable, ungated pipeline" condition;
+  it does not depend on the System.AccessToken being exposed.
+where:
+  all_of:
+    - "technique == 'pipeline_poisoning'"
+    - "gate_state == 'absent'"
+    - any_of:
+        - "trigger == 'build_validation'"
+        - "trigger == 'ci_push'"
+        - "via == 'build_validation'"
+        - "via == 'ci_trigger'"
 evidence:
-  - "Resource {{ resource_name }} ({{ resource_type }}) has grant_all_pipelines = true"
-  - "Reachable via pipeline {{ pipeline_name }} ({{ attacker_vector }})"
-  - "Attacker influence: {{ attacker_vector_detail }}"
-
+  - "Pipeline {{ pipeline_id }} job {{ job }} in {{ project }} poisoned via {{ via }} (trigger {{ trigger }})"
+  - "Sink {{ sink_kind }}/{{ sink_form }}; gate state {{ gate_state }}; identity scope {{ identity_scope }}"
+  - "Confidence {{ confidence }}"
 remediation_hint: >
   Disable "Grant access permission to all pipelines" on every secret-bearing
-  resource. Use per-pipeline authorization and add approval or branch-control
-  checks so that only reviewed, trusted builds can consume the resource.
+  resource and use per-pipeline authorization. Add an approval or branch-control
+  check to any pipeline reachable by PR build validation or by pushes to shared
+  branches, so only reviewed, trusted builds run its jobs.

--- a/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-01/05
 title: "Open-access resource reachable from any PR-buildable or attacker-creatable pipeline"
 subject: chain
 severity: high
-confidence: high
 description: >
   A variable group, secure file, or service connection has "Grant access
   permission to all pipelines" enabled, making it decryptable by any pipeline in

--- a/internal/detection-rules/ado/cat-01-build-validation/self-hosted-pool-pr-build-pivot.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/self-hosted-pool-pr-build-pivot.yaml
@@ -1,29 +1,33 @@
 id: cat-01/self-hosted-pool-pr-build-pivot
 scenario_id: cat-01/06
-title: "PR build on a shared non-ephemeral self-hosted pool exposes residual secrets"
-subject: chain
+title: "Privileged job runs on a self-hosted agent pool that persists state between builds"
+subject: job
 severity: high
 confidence: medium
 description: >
-  A PR-buildable pipeline targets a non-ephemeral self-hosted agent pool that
-  also runs privileged pipelines. The attacker's PR code executes on an agent
-  that retains working directories, cached credentials, and environment state
-  from prior privileged runs, enabling secret harvesting and lateral movement
-  even when the PR pipeline itself carries no secrets.
-
-chain_of:
-  join: shared-pool-exposure
-  for_each: privileged_co_tenants
-  where:
-    all_of:
-      - uses_secrets_or_connections == true
-
+  A job runs on a self-hosted agent pool (a named pool with no Microsoft-hosted
+  vm_image) and either exposes the System.AccessToken or consumes a service
+  connection. Self-hosted agents are non-ephemeral: working directories, cached
+  credentials, and environment state survive between jobs. If the same pool ever
+  runs an attacker-influenced PR/validation build, that build harvests the
+  residue of this privileged job and pivots into the in-network machine — the
+  prize is everything the agent has touched, not just this pipeline's secrets.
+  Microsoft-hosted pools are immune because their agents are destroyed after
+  each run.
+where:
+  all_of:
+    - "pool.name != ''"
+    - "pool.name != 'server'"
+    - "pool.vm_image == ''"
+    - any_of:
+        - "exposes_system_access_token == true"
+        - "service_connection_usages != []"
 evidence:
-  - "PR-buildable pipeline {{ pr_pipeline }} targets self-hosted pool {{ pool_name }} (ephemeral={{ pool_ephemeral }})"
-  - "Pool also runs privileged pipeline {{ co_tenant_pipeline }} which uses {{ secret_resource_names }}"
-
+  - "Job {{ _id }} in {{ project }} runs on self-hosted pool {{ pool.name }}"
+  - "Exposes System.AccessToken: {{ exposes_system_access_token }}"
+  - "Service connections used: {{ service_connection_usages.connection_name }}"
 remediation_hint: >
-  Use Microsoft-hosted pools for PR/fork validation builds. If self-hosted pools
-  are required, maintain a dedicated pool for untrusted builds with ephemeral
-  agents that do not persist state between jobs. Never share a non-ephemeral
-  pool between PR-validation and secret-consuming pipelines.
+  Run PR/fork validation builds on Microsoft-hosted pools. If self-hosted pools
+  are required, keep a dedicated pool with ephemeral agents for untrusted builds
+  and never share a non-ephemeral pool between validation builds and jobs that
+  hold secrets, service connections, or the build identity's token.

--- a/internal/detection-rules/ado/cat-01-build-validation/self-hosted-pool-pr-build-pivot.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/self-hosted-pool-pr-build-pivot.yaml
@@ -1,0 +1,29 @@
+id: cat-01/self-hosted-pool-pr-build-pivot
+scenario_id: cat-01/06
+title: "PR build on a shared non-ephemeral self-hosted pool exposes residual secrets"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  A PR-buildable pipeline targets a non-ephemeral self-hosted agent pool that
+  also runs privileged pipelines. The attacker's PR code executes on an agent
+  that retains working directories, cached credentials, and environment state
+  from prior privileged runs, enabling secret harvesting and lateral movement
+  even when the PR pipeline itself carries no secrets.
+
+chain_of:
+  join: shared-pool-exposure
+  for_each: privileged_co_tenants
+  where:
+    all_of:
+      - uses_secrets_or_connections == true
+
+evidence:
+  - "PR-buildable pipeline {{ pr_pipeline }} targets self-hosted pool {{ pool_name }} (ephemeral={{ pool_ephemeral }})"
+  - "Pool also runs privileged pipeline {{ co_tenant_pipeline }} which uses {{ secret_resource_names }}"
+
+remediation_hint: >
+  Use Microsoft-hosted pools for PR/fork validation builds. If self-hosted pools
+  are required, maintain a dedicated pool for untrusted builds with ephemeral
+  agents that do not persist state between jobs. Never share a non-ephemeral
+  pool between PR-validation and secret-consuming pipelines.

--- a/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-01/07
 title: "YAML trigger declaration overridden by branch policy or UI — false-safe state"
 subject: chain
 severity: medium
-confidence: high
 description: >
   The pipeline's YAML declares pr: none or trigger: none, but the effective
   trigger is set by a branch-policy Build validation rule (Azure Repos ignores

--- a/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
@@ -1,0 +1,31 @@
+id: cat-01/trigger-override-false-safe
+scenario_id: cat-01/07
+title: "YAML trigger declaration overridden by branch policy or UI — false-safe state"
+subject: chain
+severity: medium
+confidence: high
+description: >
+  The pipeline's YAML declares pr: none or trigger: none, but the effective
+  trigger is set by a branch-policy Build validation rule (Azure Repos ignores
+  the YAML pr: trigger entirely) or by the pipeline UI's "Override the YAML
+  trigger from here" setting. The in-repo safety declaration is decorative,
+  and the pipeline builds attacker PRs despite appearing hardened.
+
+chain_of:
+  join: trigger-divergence
+  for_each: override_sources
+  where:
+    all_of:
+      - effective_trigger_active == true
+
+evidence:
+  - "Pipeline {{ pipeline_name }} YAML declares {{ yaml_trigger_declaration }}"
+  - "Effective trigger source: {{ override_source }} ({{ override_detail }})"
+  - "Divergence: YAML says inert but pipeline IS PR-triggerable"
+
+remediation_hint: >
+  Do not rely on YAML pr:/trigger: declarations for Azure Repos pipelines —
+  they are ignored. Audit the branch-policy Build validation settings and
+  pipeline UI trigger overrides as the authoritative trigger controls. Remove
+  build-validation policies from pipelines that should not run on PRs. Disable
+  the "Override YAML trigger" option when YAML should be the source of truth.

--- a/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
@@ -1,30 +1,29 @@
 id: cat-01/trigger-override-false-safe
 scenario_id: cat-01/07
-title: "YAML trigger declaration overridden by branch policy or UI — false-safe state"
-subject: chain
+title: "Non-blocking Build validation policy — false-safe PR gate"
+subject: branch_policy
 severity: medium
+confidence: medium
 description: >
-  The pipeline's YAML declares pr: none or trigger: none, but the effective
-  trigger is set by a branch-policy Build validation rule (Azure Repos ignores
-  the YAML pr: trigger entirely) or by the pipeline UI's "Override the YAML
-  trigger from here" setting. The in-repo safety declaration is decorative,
-  and the pipeline builds attacker PRs despite appearing hardened.
-
-chain_of:
-  join: trigger-divergence
-  for_each: override_sources
-  where:
-    all_of:
-      - effective_trigger_active == true
-
+  A Build validation branch policy exists but is not blocking, so it queues the
+  pipeline on every PR yet never prevents the PR from completing. On Azure Repos
+  the branch policy — not the YAML pr: trigger, which is ignored — is what drives
+  PR builds, so this policy still runs attacker-authored PR code on the merge
+  commit. Because it is non-blocking, defenders see "a validation policy exists"
+  and assume PRs are gated, while it neither blocks merge nor prevents the
+  untrusted build from running. The in-repo pr:/trigger: declaration is
+  decorative; the real control lives here and is toothless.
+where:
+  all_of:
+    - "policy_type == 'Build'"
+    - "is_enabled == true"
+    - "is_blocking == false"
 evidence:
-  - "Pipeline {{ pipeline_name }} YAML declares {{ yaml_trigger_declaration }}"
-  - "Effective trigger source: {{ override_source }} ({{ override_detail }})"
-  - "Divergence: YAML says inert but pipeline IS PR-triggerable"
-
+  - "Non-blocking Build validation policy {{ config_id }} in {{ project }}"
+  - "Blocking: {{ is_blocking }}; enabled: {{ is_enabled }}"
+  - "Scope: {{ scope }}"
 remediation_hint: >
-  Do not rely on YAML pr:/trigger: declarations for Azure Repos pipelines —
-  they are ignored. Audit the branch-policy Build validation settings and
-  pipeline UI trigger overrides as the authoritative trigger controls. Remove
-  build-validation policies from pipelines that should not run on PRs. Disable
-  the "Override YAML trigger" option when YAML should be the source of truth.
+  Make Build validation policies blocking so a failing/pending validation build
+  prevents merge, and do not rely on YAML pr:/trigger: declarations for Azure
+  Repos — they are ignored. Audit branch-policy Build validation and pipeline
+  trigger-override settings as the authoritative PR-trigger controls.


### PR DESCRIPTION
## Summary
- Adds 4 YAML detection rules for Azure DevOps build-validation / PR-trigger scenarios under `internal/detection-rules/ado/cat-01-build-validation/`
- All chain-based rules joining branch-policy, pipeline, resource-authorization, and org-setting control-plane state — the vulnerability only exists at the intersection and is invisible to YAML-only scanning
- Part of LAB-4743 (execution & injection family); covers the active Tier-A/B scenarios from the ADO catalog's category 01

## Rules
| File | Severity | Subject | What it detects |
|---|---|---|---|
| `build-validation-secret-exposure.yaml` | Critical | chain | Build-validation policy runs PR merge-commit code with collection token and authorized secrets before review |
| `open-access-secret-reachable.yaml` | High | chain | Open-access resource (grant all pipelines) reachable from any PR-buildable or attacker-creatable pipeline |
| `self-hosted-pool-pr-build-pivot.yaml` | High | chain | PR build on a shared non-ephemeral self-hosted pool exposes residual secrets from privileged co-tenants |
| `trigger-override-false-safe.yaml` | Medium | chain | YAML pr:/trigger: declaration overridden by branch policy or UI — pipeline appears inert but builds PRs |
Fixes LAB-4743