### PR TITLE
ADO detection rules: cat-02 queue-time injection (execution & injection)

### DIFF
--- a/internal/detection-rules/ado/cat-02-queue-time-injection/allow-override-drift.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/allow-override-drift.yaml
@@ -1,0 +1,30 @@
+id: cat-02/allow-override-drift
+scenario_id: cat-02/04
+title: "CLI/IaC-set allowOverride variable creates an undocumented injectable surface"
+subject: pipeline
+severity: medium
+confidence: medium
+description: >
+  A pipeline variable has allowOverride set to true via the Azure CLI, REST API,
+  or IaC provisioning — not the Variables UI. With "Limit variables that can be
+  set at queue time" enabled, the team believes only UI-flagged variables are
+  settable, but this out-of-band flag makes the variable injectable. If it flows
+  into a script or arguments sink, a queuer exploits it while the surface
+  appears locked down.
+
+where:
+  all_of:
+    - has_override_var_in_sink == true
+    - override_var_set_out_of_band == true
+    - enforce_settable_var == true
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: variable {{ override_var_name }} has allowOverride=true (set via {{ override_source }})"
+  - "Variable flows into sink at {{ taint_sink_locations }}"
+  - "Queue-time limit is ON — team expects the surface to be restricted"
+
+remediation_hint: >
+  Audit pipeline definition state for allowOverride flags set outside the UI.
+  Run az pipelines variable list and compare against the Variables UI. Remove
+  the override flag from variables that flow into script or arguments sinks, or
+  add a values allowlist via runtime parameters.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/allow-override-drift.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/allow-override-drift.yaml
@@ -1,30 +1,28 @@
 id: cat-02/allow-override-drift
 scenario_id: cat-02/04
-title: "CLI/IaC-set allowOverride variable creates an undocumented injectable surface"
+title: "Pipeline variable marked settable-at-queue-time while the queue-time limit is enforced"
 subject: pipeline
 severity: medium
 confidence: medium
 description: >
-  A pipeline variable has allowOverride set to true via the Azure CLI, REST API,
-  or IaC provisioning — not the Variables UI. With "Limit variables that can be
-  set at queue time" enabled, the team believes only UI-flagged variables are
-  settable, but this out-of-band flag makes the variable injectable. If it flows
-  into a script or arguments sink, a queuer exploits it while the surface
-  appears locked down.
-
+  A pipeline variable carries allow_override=true — it is settable at queue time
+  — even though the org/project enforces "Limit variables that can be set at
+  queue time". This is the flag set by az pipelines variable --allow-override
+  true or the REST definition, often by IaC or migration tooling and never
+  ticked in the Variables UI. The team believes the surface is locked down, but
+  any queuer can override this variable; if it reaches a $(var) sink it becomes
+  an injectable, out-of-band surface. Keying on the pipeline node because the
+  queue_time_injection edge does not carry the allow_override provenance that
+  distinguishes this drift from an ordinary unrestricted macro.
 where:
   all_of:
-    - has_override_var_in_sink == true
-    - override_var_set_out_of_band == true
-    - enforce_settable_var == true
-
+    - "enforce_settable_var == true"
+    - "variables.allow_override ∋ true"
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: variable {{ override_var_name }} has allowOverride=true (set via {{ override_source }})"
-  - "Variable flows into sink at {{ taint_sink_locations }}"
-  - "Queue-time limit is ON — team expects the surface to be restricted"
-
+  - "Pipeline {{ name }} ({{ project }}): a variable has allow_override=true while enforce_settable_var is on"
+  - "Settable variables: {{ variables }}"
 remediation_hint: >
-  Audit pipeline definition state for allowOverride flags set outside the UI.
-  Run az pipelines variable list and compare against the Variables UI. Remove
-  the override flag from variables that flow into script or arguments sinks, or
-  add a values allowlist via runtime parameters.
+  Audit pipeline definition state (az pipelines variable list / the Definitions
+  REST API) for allow_override flags set outside the Variables UI. Remove the
+  override flag from variables that flow into script or task_input sinks, or
+  constrain them with a runtime parameter values: allowlist.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-02/03
 title: "Free-form string runtime parameter template-expanded into script sink"
 subject: pipeline
 severity: high
-confidence: high
 description: >
   A runtime parameter of type string with no values allowlist accepts arbitrary
   text from any user who can run the pipeline. When template-expanded via

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
@@ -1,27 +1,24 @@
 id: cat-02/freeform-parameter-injection
 scenario_id: cat-02/03
-title: "Free-form string runtime parameter template-expanded into script sink"
-subject: pipeline
+title: "Free-form string runtime parameter template-expanded into a script sink"
+subject: queue_time_injection
 severity: high
+confidence: high
 description: >
-  A runtime parameter of type string with no values allowlist accepts arbitrary
-  text from any user who can run the pipeline. When template-expanded via
-  ${{ parameters.x }} into a script body, the string is spliced into the YAML
-  at compile time — before the shell or arguments validation can intervene —
-  producing command injection that bypasses all runtime guards.
-
+  A runtime parameter of type string with no values: allowlist accepts arbitrary
+  text from any user who can run the pipeline. When template-expanded
+  ${{ parameters.x }} into a script body it is spliced into the YAML at compile
+  time — before any shell or arguments validation can intervene — producing
+  command injection that bypasses all runtime guards. The queue-time variable
+  limit is irrelevant here because parameters are not variables.
 where:
   all_of:
-    - has_freeform_param_in_script_sink == true
-  none_of:
-    - freeform_params_have_values_allowlist == true
-
+    - "via == 'freeform_parameter'"
+    - "sink_type == 'parameter_in_script'"
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: parameter {{ freeform_param_name }} (type: string, no values allowlist)"
-  - "Template-expanded into script sink at {{ taint_sink_locations }}"
-  - "Compile-time expansion bypasses arguments validation"
-
+  - "Pipeline {{ pipeline_id }} job {{ job }}: free-form parameter {{ macro_name }} expands into a {{ sink_location }} sink"
+  - "Via {{ via }}, confidence {{ confidence }} — compile-time expansion bypasses arguments validation"
 remediation_hint: >
-  Add a values allowlist to every string parameter that reaches a script body.
-  For parameters that must accept arbitrary text, pass them through an
-  environment variable (env:) rather than template-expanding into the script.
+  Add a values: allowlist to every string parameter that reaches a script body.
+  For parameters that must accept arbitrary text, pass them through env: rather
+  than template-expanding them into the script.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
@@ -1,0 +1,28 @@
+id: cat-02/freeform-parameter-injection
+scenario_id: cat-02/03
+title: "Free-form string runtime parameter template-expanded into script sink"
+subject: pipeline
+severity: high
+confidence: high
+description: >
+  A runtime parameter of type string with no values allowlist accepts arbitrary
+  text from any user who can run the pipeline. When template-expanded via
+  ${{ parameters.x }} into a script body, the string is spliced into the YAML
+  at compile time — before the shell or arguments validation can intervene —
+  producing command injection that bypasses all runtime guards.
+
+where:
+  all_of:
+    - has_freeform_param_in_script_sink == true
+  none_of:
+    - freeform_params_have_values_allowlist == true
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: parameter {{ freeform_param_name }} (type: string, no values allowlist)"
+  - "Template-expanded into script sink at {{ taint_sink_locations }}"
+  - "Compile-time expansion bypasses arguments validation"
+
+remediation_hint: >
+  Add a values allowlist to every string parameter that reaches a script body.
+  For parameters that must accept arbitrary text, pass them through an
+  environment variable (env:) rather than template-expanding into the script.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/predefined-variable-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/predefined-variable-injection.yaml
@@ -1,0 +1,26 @@
+id: cat-02/predefined-variable-injection
+scenario_id: cat-02/01
+title: "Attacker-controlled predefined variable macro-expanded into a script body"
+subject: queue_time_injection
+severity: high
+confidence: high
+description: >
+  A predefined pipeline variable whose value is attacker-controlled — commit
+  message (Build.SourceVersionMessage), PR source branch
+  (System.PullRequest.SourceBranch) and similar — is macro-expanded $(var)
+  directly into a script body. The attacker never needs queue-build permission:
+  they set the value simply by crafting a commit message or branch name, then
+  triggering the pipeline. The untrusted string is spliced onto the shell command
+  line and executed with the pipeline's identity. This is not governed by the
+  queue-time variable limit, so it fires regardless of that setting.
+where:
+  all_of:
+    - "via == 'predefined_variable'"
+    - "sink_type == 'macro_in_script'"
+evidence:
+  - "Pipeline {{ pipeline_id }} job {{ job }}: predefined macro $({{ macro_name }}) expands into a {{ sink_location }} sink"
+  - "Via {{ via }}, confidence {{ confidence }} — value is set by a commit/branch, not by queue permission"
+remediation_hint: >
+  Never macro-expand Build.SourceVersionMessage, System.PullRequest.SourceBranch,
+  or other repository-content-derived predefined variables into a script. Map
+  them through an intermediate env: variable and quote/validate before use.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-02/05
 title: "Queue-time input selects the agent pool, service connection, or task"
 subject: chain
 severity: high
-confidence: high
 description: >
   A free-form runtime parameter or settable variable is template-expanded into
   a compile-time keyword that selects the execution target — pool, service

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
@@ -1,31 +1,27 @@
 id: cat-02/queue-input-selects-target
 scenario_id: cat-02/05
 title: "Queue-time input selects the agent pool, service connection, or task"
-subject: chain
+subject: queue_time_injection
 severity: high
+confidence: high
 description: >
-  A free-form runtime parameter or settable variable is template-expanded into
-  a compile-time keyword that selects the execution target — pool, service
-  connection, task, or checkout repository. The attacker steers the pipeline
-  onto a higher-privileged or attacker-observable target without injecting a
-  single shell character, escalating privilege through target redirection
-  rather than command injection.
-
-chain_of:
-  join: input-target-redirect
-  for_each: redirectable_targets
-  where:
-    all_of:
-      - higher_privilege_target_reachable == true
-
+  A free-form runtime parameter is template-expanded into a compile-time keyword
+  that selects the execution target — agent pool, service connection
+  (azureSubscription), container image, task, or checkout repository. The queuer
+  steers the run onto a higher-privileged or attacker-observable target without
+  injecting a single shell character: privilege escalation through target
+  redirection rather than command injection. These keywords resolve at compile
+  time, so they must be parameterized with ${{ }}, which is exactly the surface a
+  queuer controls.
+where:
+  all_of:
+    - "via == 'input_target_redirect'"
+    - "sink_type == 'parameter_in_compile_keyword'"
 evidence:
-  - "Pipeline {{ pipeline_name }}: input {{ input_name }} ({{ input_type }}) selects {{ target_keyword }}"
-  - "Redirectable to {{ redirect_target_name }} ({{ redirect_target_type }})"
-  - "Privilege delta: {{ privilege_comparison }}"
-
+  - "Pipeline {{ pipeline_id }} job {{ job }}: parameter {{ macro_name }} selects the {{ sink_location }} keyword"
+  - "Via {{ via }}, confidence {{ confidence }}, identity scope {{ identity_scope }}"
 remediation_hint: >
-  Restrict runtime parameters that select pools, service connections, or tasks
-  to a values allowlist of approved targets. Never template-expand a free-form
-  input into pool, azureSubscription, task, or checkout keywords. Use
-  per-pipeline authorization to limit which pools and connections the pipeline
-  can reach.
+  Constrain any parameter that selects pool, azureSubscription, container, task,
+  or checkout to a values: allowlist of approved targets. Use per-pipeline
+  authorization to limit which pools and service connections the pipeline can
+  reach.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
@@ -1,0 +1,32 @@
+id: cat-02/queue-input-selects-target
+scenario_id: cat-02/05
+title: "Queue-time input selects the agent pool, service connection, or task"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A free-form runtime parameter or settable variable is template-expanded into
+  a compile-time keyword that selects the execution target — pool, service
+  connection, task, or checkout repository. The attacker steers the pipeline
+  onto a higher-privileged or attacker-observable target without injecting a
+  single shell character, escalating privilege through target redirection
+  rather than command injection.
+
+chain_of:
+  join: input-target-redirect
+  for_each: redirectable_targets
+  where:
+    all_of:
+      - higher_privilege_target_reachable == true
+
+evidence:
+  - "Pipeline {{ pipeline_name }}: input {{ input_name }} ({{ input_type }}) selects {{ target_keyword }}"
+  - "Redirectable to {{ redirect_target_name }} ({{ redirect_target_type }})"
+  - "Privilege delta: {{ privilege_comparison }}"
+
+remediation_hint: >
+  Restrict runtime parameters that select pools, service connections, or tasks
+  to a values allowlist of approved targets. Never template-expand a free-form
+  input into pool, azureSubscription, task, or checkout keywords. Use
+  per-pipeline authorization to limit which pools and connections the pipeline
+  can reach.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-02/01
 title: "Unrestricted queue-time variable macro-expanded into script body"
 subject: pipeline
 severity: critical
-confidence: high
 description: >
   With "Limit variables that can be set at queue time" disabled, any user who
   can queue the pipeline can supply arbitrary variables. A macro reference

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
@@ -1,0 +1,27 @@
+id: cat-02/queue-time-macro-injection
+scenario_id: cat-02/01
+title: "Unrestricted queue-time variable macro-expanded into script body"
+subject: pipeline
+severity: critical
+confidence: high
+description: >
+  With "Limit variables that can be set at queue time" disabled, any user who
+  can queue the pipeline can supply arbitrary variables. A macro reference
+  $(var) in a script body splices the user-controlled string into the shell
+  command line, producing command injection without repo write access.
+
+where:
+  all_of:
+    - has_macro_in_script_sink == true
+    - enforce_settable_var == false
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }} has $(var) macro in script sink at {{ taint_sink_locations }}"
+  - "Org/project setting enforce_settable_var = {{ enforce_settable_var }}"
+  - "Any queuer can inject undeclared variables into the build"
+
+remediation_hint: >
+  Enable "Limit variables that can be set at queue time" at the organization
+  level. Avoid macro-expanding user-controllable variables into script bodies;
+  use environment-variable mapping (env:) or runtime parameters with a values
+  allowlist instead.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
@@ -1,26 +1,26 @@
 id: cat-02/queue-time-macro-injection
 scenario_id: cat-02/01
-title: "Unrestricted queue-time variable macro-expanded into script body"
-subject: pipeline
+title: "Unrestricted queue-time variable macro-expanded into a script body"
+subject: queue_time_injection
 severity: critical
+confidence: high
 description: >
-  With "Limit variables that can be set at queue time" disabled, any user who
-  can queue the pipeline can supply arbitrary variables. A macro reference
-  $(var) in a script body splices the user-controlled string into the shell
-  command line, producing command injection without repo write access.
-
+  A user who can queue the pipeline supplies an arbitrary, undeclared variable
+  at queue time and it is macro-expanded $(var) directly into a script body.
+  The user-controlled string is spliced onto the shell command line and executed
+  with the pipeline's identity and secrets — command injection without repo
+  write access. This is the ADO analog of GitHub script injection via the
+  queue-time variable channel. Confidence is downgraded when the org enforces
+  the queue-time limit, so key off the technique, not on that setting being off.
 where:
   all_of:
-    - has_macro_in_script_sink == true
-    - enforce_settable_var == false
-
+    - "via == 'unrestricted_macro'"
+    - "sink_type == 'macro_in_script'"
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }} has $(var) macro in script sink at {{ taint_sink_locations }}"
-  - "Org/project setting enforce_settable_var = {{ enforce_settable_var }}"
-  - "Any queuer can inject undeclared variables into the build"
-
+  - "Pipeline {{ pipeline_id }} job {{ job }}: undeclared macro $({{ macro_name }}) expands into a {{ sink_location }} sink"
+  - "Via {{ via }}, confidence {{ confidence }} (enforce_settable_var={{ enforce_settable_var }})"
+  - "Source: any principal with {{ source_permission }} on the pipeline"
 remediation_hint: >
-  Enable "Limit variables that can be set at queue time" at the organization
-  level. Avoid macro-expanding user-controllable variables into script bodies;
-  use environment-variable mapping (env:) or runtime parameters with a values
-  allowlist instead.
+  Enable "Limit variables that can be set at queue time" and do not macro-expand
+  user-controllable variables into script bodies. Map inputs through env: or use
+  runtime parameters with a values: allowlist instead.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
@@ -1,26 +1,26 @@
 id: cat-02/settable-var-into-arguments
 scenario_id: cat-02/02
-title: "Settable queue-time variable flows into shell task arguments"
-subject: pipeline
+title: "Queue-time variable flows into a shell task arguments input"
+subject: queue_time_injection
 severity: high
+confidence: low
 description: >
-  A variable explicitly marked "Settable at queue time" is macro-expanded into
-  the arguments input of a shell task (Bash, PowerShell, CmdLine, Ssh,
-  AzureFileCopy). Even with the queue-time variable limit enabled, the attacker
-  controls this variable by design and injects shell metacharacters into the
-  command line unless arguments validation is on.
-
+  A queue-time variable is macro-expanded into the arguments input of a shell
+  task (Bash, PowerShell, CmdLine, Ssh, AzureFileCopy). The agent concatenates
+  the expanded string onto the native command line, so a queuer breaks out of
+  the intended argument position and injects shell metacharacters. This survives
+  the queue-time variable limit because the variable is one the queuer is allowed
+  to control; the only runtime guard is shell-tasks arguments validation.
 where:
   all_of:
-    - has_settable_var_in_arguments_sink == true
-    - enable_shell_tasks_args_sanitizing == false
-
+    - "sink_type == 'macro_in_task_input'"
+    - "sink_location == 'task_input'"
+  none_of:
+    - "via == 'predefined_variable'"
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: settable variable {{ settable_var_name }} flows into {{ arguments_sink_task }} arguments"
-  - "Shell tasks arguments validation: {{ enable_shell_tasks_args_sanitizing }}"
-  - "Injection survives the queue-time variable limit because the variable is intentionally settable"
-
+  - "Pipeline {{ pipeline_id }} job {{ job }}: variable $({{ macro_name }}) flows into a task_input arguments sink"
+  - "Via {{ via }}, args validation enabled={{ enable_args_validation }}, confidence {{ confidence }}"
 remediation_hint: >
-  Enable "Enable shell tasks arguments validation" at the organization level.
-  Avoid passing queue-time-settable variables into task arguments; use env:
-  mapping or restrict the variable to a values allowlist via runtime parameters.
+  Enable "Enable shell tasks arguments validation". Do not pass queue-time
+  variables into task arguments — map them via env: or constrain them with a
+  runtime parameter values: allowlist.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
@@ -1,0 +1,27 @@
+id: cat-02/settable-var-into-arguments
+scenario_id: cat-02/02
+title: "Settable queue-time variable flows into shell task arguments"
+subject: pipeline
+severity: high
+confidence: high
+description: >
+  A variable explicitly marked "Settable at queue time" is macro-expanded into
+  the arguments input of a shell task (Bash, PowerShell, CmdLine, Ssh,
+  AzureFileCopy). Even with the queue-time variable limit enabled, the attacker
+  controls this variable by design and injects shell metacharacters into the
+  command line unless arguments validation is on.
+
+where:
+  all_of:
+    - has_settable_var_in_arguments_sink == true
+    - enable_shell_tasks_args_sanitizing == false
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: settable variable {{ settable_var_name }} flows into {{ arguments_sink_task }} arguments"
+  - "Shell tasks arguments validation: {{ enable_shell_tasks_args_sanitizing }}"
+  - "Injection survives the queue-time variable limit because the variable is intentionally settable"
+
+remediation_hint: >
+  Enable "Enable shell tasks arguments validation" at the organization level.
+  Avoid passing queue-time-settable variables into task arguments; use env:
+  mapping or restrict the variable to a values allowlist via runtime parameters.

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-02/02
 title: "Settable queue-time variable flows into shell task arguments"
 subject: pipeline
 severity: high
-confidence: high
 description: >
   A variable explicitly marked "Settable at queue time" is macro-expanded into
   the arguments input of a shell task (Bash, PowerShell, CmdLine, Ssh,


### PR DESCRIPTION
## Summary
- Adds 5 YAML detection rules for Azure DevOps queue-time variable and runtime parameter injection under `internal/detection-rules/ado/cat-02-queue-time-injection/`
- Mix of single-subject `pipeline` rules (4× `where`-based, keyed on YAML taint predicates + org/project settings) and one `chain` rule (queue-time input selecting pool/connection/task)
- Part of LAB-4743 (execution & injection family); covers the active Tier-A scenarios from ADO catalog category 02

## Rules
| File | Severity | Subject | What it detects |
|---|---|---|---|
| `queue-time-macro-injection.yaml` | Critical | pipeline | Unrestricted queue-time variable macro-expanded into script body (enforce_settable_var off) |
| `settable-var-into-arguments.yaml` | High | pipeline | Settable queue-time variable flows into shell task arguments with arguments validation off |
| `freeform-parameter-injection.yaml` | High | pipeline | Free-form string runtime parameter template-expanded into script sink (no values allowlist) |
| `allow-override-drift.yaml` | Medium | pipeline | CLI/IaC-set allowOverride variable creates injectable surface invisible in the Variables UI |
| `queue-input-selects-target.yaml` | High | chain | Queue-time input selects agent pool, service connection, or task — execution target redirection |
Fixes LAB-4743