### PR TITLE
Add ADO detection rules for cat-12: AI task & agent abuse

### DIFF
--- a/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
@@ -1,28 +1,29 @@
 id: cat-12/generate-then-execute
 scenario_id: cat-12/05
-title: "Agent-generated script or YAML executed in the same run without human review"
-subject: pipeline
+title: "Agent-generated output executed in the same run without human review"
+subject: agent_injection
 severity: high
+confidence: high
 description: >
-  A pipeline step invokes an agent to generate a build script, pipeline
-  fragment, or remediation patch, then a subsequent step executes that
-  output in the same run. Because the agent's output is shaped by
-  attacker-controlled input (PR text, file contents) and is never reviewed,
-  the generation step becomes a code-injection sink — the model is an
-  unsanitized code source.
+  A pipeline invokes an AI agent to generate a build script, pipeline
+  fragment, or remediation patch shaped by attacker-controlled input, then
+  a later step executes that output in the same run. The generate→execute
+  coupling turns the model into an unsanitized code source: an injection in
+  the prompt flows straight into executed code with no review gate. This is
+  the `via == generate_then_execute` wiring of the agent-injection edge.
 
 where:
   all_of:
-    - has_generate_then_execute_edge == true
-    - prompt_ingests_untrusted == true
+    - via == 'generate_then_execute'
+    - gate_state == 'absent'
 
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: step {{ generator_step }} generates output consumed by step {{ executor_step }}"
-  - "Generator prompt includes untrusted input from {{ untrusted_source_fields }}"
-  - "Executor step has access to: {{ executor_credentials }}"
+  - "Project {{ project }} pipeline {{ pipeline_id }} job {{ job }}: {{ vendor }} agent generates then executes"
+  - "Source: {{ source_kind }}; capabilities: {{ capabilities }}; gate_state: {{ gate_state }}"
+  - "No review gate between generation and execution (identity scope {{ identity_scope }})"
 
 remediation_hint: >
   Never execute agent-generated output in the same run. If generation and
-  execution must be coupled, insert a human review gate (approval check on
-  an environment) between the generate and execute stages. Store generated
-  artifacts for review before any privileged step consumes them.
+  execution must be coupled, insert a human review gate (an environment
+  approval check) between the generate and execute stages, and store the
+  generated artifact for review before any privileged step consumes it.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
@@ -1,0 +1,29 @@
+id: cat-12/generate-then-execute
+scenario_id: cat-12/05
+title: "Agent-generated script or YAML executed in the same run without human review"
+subject: pipeline
+severity: high
+confidence: high
+description: >
+  A pipeline step invokes an agent to generate a build script, pipeline
+  fragment, or remediation patch, then a subsequent step executes that
+  output in the same run. Because the agent's output is shaped by
+  attacker-controlled input (PR text, file contents) and is never reviewed,
+  the generation step becomes a code-injection sink — the model is an
+  unsanitized code source.
+
+where:
+  all_of:
+    - has_generate_then_execute_edge == true
+    - prompt_ingests_untrusted == true
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: step {{ generator_step }} generates output consumed by step {{ executor_step }}"
+  - "Generator prompt includes untrusted input from {{ untrusted_source_fields }}"
+  - "Executor step has access to: {{ executor_credentials }}"
+
+remediation_hint: >
+  Never execute agent-generated output in the same run. If generation and
+  execution must be coupled, insert a human review gate (approval check on
+  an environment) between the generate and execute stages. Store generated
+  artifacts for review before any privileged step consumes them.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-12/05
 title: "Agent-generated script or YAML executed in the same run without human review"
 subject: pipeline
 severity: high
-confidence: high
 description: >
   A pipeline step invokes an agent to generate a build script, pipeline
   fragment, or remediation patch, then a subsequent step executes that

--- a/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
@@ -1,31 +1,30 @@
 id: cat-12/indirect-injection-agentic-rce
 scenario_id: cat-12/03
-title: "Indirect prompt injection from changed files drives agentic tool-use into RCE"
-subject: pipeline
+title: "Injected AI agent holds tool/shell execution — indirect-injection RCE on the build host"
+subject: agent_injection
 severity: high
+confidence: high
 description: >
-  The agent is given shell/tool-use over the build agent and instructed to
-  operate on PR-derived file contents (review, test, fix). A poisoned file
-  in the PR carries indirect prompt injection that makes the agent run
-  attacker commands on the host — full RCE with the agent's token, secrets,
-  and network position. The merge commit is checked out before review.
+  The agent processes attacker-controlled input and is granted tool/shell
+  execution (tool_exec) over the build agent. A poisoned PR file, work-item
+  field, or PR text carries an injection that makes the agent run attacker
+  commands on the host — full RCE with the run's token, mapped secrets, and
+  network position — with no approval gate in between. tool_exec is the
+  capability that converts prompt injection into arbitrary code execution.
 
 where:
   all_of:
-    - executes_checked_out_code == true
-    - has_agent_tool_use == true
-    - prompt_ingests_untrusted == true
-  any_of:
-    - trigger_is_build_validation == true
-    - trigger_is_pr == true
+    - technique == 'prompt_injection'
+    - gate_state == 'absent'
+    - capabilities ∋ 'tool_exec'
 
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: agent operates on checked-out PR files with {{ agent_tool_type }} tool"
-  - "Checkout of attacker-controlled merge commit + agentic shell/tool-use = RCE sink"
-  - "Secrets in scope: {{ secret_resource_names }}"
+  - "Project {{ project }} pipeline {{ pipeline_id }} job {{ job }}: {{ vendor }} agent has tool_exec on {{ source_kind }}"
+  - "Capabilities: {{ capabilities }}; via={{ via }}; gate_state={{ gate_state }}"
+  - "tool_exec + attacker-controlled prompt = RCE with the run's identity ({{ identity_scope }})"
 
 remediation_hint: >
-  Do not give agents shell/exec tools when processing untrusted file contents.
+  Do not grant agents shell/exec tools when they process untrusted input.
   If agentic tool-use is required, run it in a sandboxed container with no
-  secrets, no service connections, and a project-scoped token. Gate any
-  generated actions behind human review.
+  secrets, no service connections, and a project-scoped token, and gate any
+  generated action behind a human approval check.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-12/03
 title: "Indirect prompt injection from changed files drives agentic tool-use into RCE"
 subject: pipeline
 severity: high
-confidence: high
 description: >
   The agent is given shell/tool-use over the build agent and instructed to
   operate on PR-derived file contents (review, test, fix). A poisoned file

--- a/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
@@ -1,0 +1,32 @@
+id: cat-12/indirect-injection-agentic-rce
+scenario_id: cat-12/03
+title: "Indirect prompt injection from changed files drives agentic tool-use into RCE"
+subject: pipeline
+severity: high
+confidence: high
+description: >
+  The agent is given shell/tool-use over the build agent and instructed to
+  operate on PR-derived file contents (review, test, fix). A poisoned file
+  in the PR carries indirect prompt injection that makes the agent run
+  attacker commands on the host — full RCE with the agent's token, secrets,
+  and network position. The merge commit is checked out before review.
+
+where:
+  all_of:
+    - executes_checked_out_code == true
+    - has_agent_tool_use == true
+    - prompt_ingests_untrusted == true
+  any_of:
+    - trigger_is_build_validation == true
+    - trigger_is_pr == true
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: agent operates on checked-out PR files with {{ agent_tool_type }} tool"
+  - "Checkout of attacker-controlled merge commit + agentic shell/tool-use = RCE sink"
+  - "Secrets in scope: {{ secret_resource_names }}"
+
+remediation_hint: >
+  Do not give agents shell/exec tools when processing untrusted file contents.
+  If agentic tool-use is required, run it in a sandboxed container with no
+  secrets, no service connections, and a project-scoped token. Gate any
+  generated actions behind human review.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
@@ -1,31 +1,32 @@
 id: cat-12/overscoped-ai-extension
 scenario_id: cat-12/04
-title: "Org-wide marketplace AI extension requests over-broad OAuth scopes"
+title: "Org-installed third-party extension holds over-broad write scopes"
 subject: extension
 severity: high
+confidence: medium
 description: >
-  A marketplace AI extension installed org-wide requests OAuth scopes far
-  exceeding its stated purpose — e.g. vso.code_manage (read/write/delete
-  code + create/complete PRs org-wide), vso.work_write, or
-  vso.serviceendpoint_query. A single prompt injection activates the full
-  granted scope, and a backdoored auto-update wields it deterministically
-  with no LLM-compliance dependency.
+  A non-Microsoft extension installed org-wide requests OAuth scopes far
+  exceeding a review/assist function — write/manage over code, work items,
+  build execution, or service endpoints — so its task runs with those
+  scopes in every project. For an AI extension a single prompt injection
+  activates the full granted scope; for any extension a backdoored
+  auto-update wields it deterministically. Read-only assistants should hold
+  only vso.code / vso.threads scopes; write/manage grants are the risk.
 
 where:
   all_of:
     - org_installed == true
-    - auto_update == true
-    - scopes ∋ {vso.code_manage, vso.code_write, vso.work_write, vso.serviceendpoint_query, vso.build_execute}
-  none_of:
-    - scopes ⊆ {vso.code, vso.threads_full, vso.code_status}
+    - is_builtin == false
+    - scopes ∋ {vso.code_write, vso.code_manage, vso.work_write, vso.build_execute, vso.serviceendpoint_manage, vso.serviceendpoint_query, vso.variablegroups_write, vso.tokens}
 
 evidence:
-  - "Extension {{ extension_name }} (publisher: {{ publisher }}) installed org-wide"
+  - "Extension {{ extension_name }} (publisher {{ publisher_name }}) installed org-wide, builtin={{ is_builtin }}"
   - "Granted scopes: {{ scopes }}"
-  - "Auto-update: {{ auto_update }}"
+  - "Auto-update: {{ auto_update }}; pipeline decorator: {{ has_pipeline_decorator_contribution }}"
 
 remediation_hint: >
-  Audit the extension's vss-extension.json for requested scopes. Remove
-  scopes that exceed the extension's stated function. Disable auto-update
-  for extensions with write scopes so new versions require re-consent.
-  Prefer extensions that request only vso.code (read) and vso.threads_full.
+  Audit the extension's requested scopes in its vss-extension.json. Remove
+  scopes that exceed its stated function; a review/assist extension needs
+  only vso.code (read) and vso.threads. Disable auto-update for extensions
+  with write/manage scopes so new versions require re-consent, and prefer
+  publishers you trust.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
@@ -1,0 +1,32 @@
+id: cat-12/overscoped-ai-extension
+scenario_id: cat-12/04
+title: "Org-wide marketplace AI extension requests over-broad OAuth scopes"
+subject: extension
+severity: high
+confidence: high
+description: >
+  A marketplace AI extension installed org-wide requests OAuth scopes far
+  exceeding its stated purpose — e.g. vso.code_manage (read/write/delete
+  code + create/complete PRs org-wide), vso.work_write, or
+  vso.serviceendpoint_query. A single prompt injection activates the full
+  granted scope, and a backdoored auto-update wields it deterministically
+  with no LLM-compliance dependency.
+
+where:
+  all_of:
+    - org_installed == true
+    - auto_update == true
+    - scopes ∋ {vso.code_manage, vso.code_write, vso.work_write, vso.serviceendpoint_query, vso.build_execute}
+  none_of:
+    - scopes ⊆ {vso.code, vso.threads_full, vso.code_status}
+
+evidence:
+  - "Extension {{ extension_name }} (publisher: {{ publisher }}) installed org-wide"
+  - "Granted scopes: {{ scopes }}"
+  - "Auto-update: {{ auto_update }}"
+
+remediation_hint: >
+  Audit the extension's vss-extension.json for requested scopes. Remove
+  scopes that exceed the extension's stated function. Disable auto-update
+  for extensions with write scopes so new versions require re-consent.
+  Prefer extensions that request only vso.code (read) and vso.threads_full.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-12/04
 title: "Org-wide marketplace AI extension requests over-broad OAuth scopes"
 subject: extension
 severity: high
-confidence: high
 description: >
   A marketplace AI extension installed org-wide requests OAuth scopes far
   exceeding its stated purpose — e.g. vso.code_manage (read/write/delete

--- a/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
@@ -1,0 +1,33 @@
+id: cat-12/pr-text-prompt-injection
+scenario_id: cat-12/01
+title: "PR title/description injected into agent prompt with Build Service token"
+subject: pipeline
+severity: high
+confidence: high
+description: >
+  An AI-review pipeline interpolates the PR's free-text fields (title,
+  description, source-version message) directly into the agent prompt. The
+  agent holds System.AccessToken (collection-scoped by default) and has
+  tool-use or shell execution enabled. A Contributor's PR text becomes the
+  agent's instructions, executing before any reviewer acts because build
+  validation fires on PR creation.
+
+where:
+  all_of:
+    - prompt_ingests_untrusted == true
+    - exposes_system_access_token == true
+    - has_agent_tool_use == true
+  any_of:
+    - trigger_is_build_validation == true
+    - trigger_is_pr == true
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: prompt ingests untrusted PR text ({{ untrusted_source_fields }})"
+  - "Agent has tool-use/shell execution enabled ({{ agent_tool_type }})"
+  - "System.AccessToken exposed; job auth scope: {{ job_auth_scope }}"
+
+remediation_hint: >
+  Never interpolate raw PR text into agent prompts. Use a sanitization layer
+  that strips instruction-like content. Scope the job authorization to
+  current project. Remove write tools from the agent or gate agent actions
+  behind a human approval step.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
@@ -1,32 +1,33 @@
 id: cat-12/pr-text-prompt-injection
 scenario_id: cat-12/01
-title: "PR title/description injected into agent prompt with Build Service token"
-subject: pipeline
+title: "Untrusted input reaches an AI agent step holding a privileged capability with no review gate"
+subject: agent_injection
 severity: high
+confidence: high
 description: >
-  An AI-review pipeline interpolates the PR's free-text fields (title,
-  description, source-version message) directly into the agent prompt. The
-  agent holds System.AccessToken (collection-scoped by default) and has
-  tool-use or shell execution enabled. A Contributor's PR text becomes the
-  agent's instructions, executing before any reviewer acts because build
-  validation fires on PR creation.
+  An AI-agent pipeline step ingests attacker-controlled text — a PR
+  title/description, work-item field, commit message, or changed-file
+  content — into the agent prompt, and the agent is granted a dangerous
+  capability: tool/shell execution, network egress, an ID token, or the
+  ability to auto-commit / auto-open PRs. No approval gate stands between
+  the untrusted input and that capability, so a Contributor's text becomes
+  the agent's instructions and runs before any human reviews it. This is
+  the base injection primitive underlying the AI-task category.
 
 where:
   all_of:
-    - prompt_ingests_untrusted == true
-    - exposes_system_access_token == true
-    - has_agent_tool_use == true
-  any_of:
-    - trigger_is_build_validation == true
-    - trigger_is_pr == true
+    - technique == 'prompt_injection'
+    - gate_state == 'absent'
+    - capabilities ∋ {tool_exec, egress, id_token, auto_commit, auto_pr}
 
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: prompt ingests untrusted PR text ({{ untrusted_source_fields }})"
-  - "Agent has tool-use/shell execution enabled ({{ agent_tool_type }})"
-  - "System.AccessToken exposed; job auth scope: {{ job_auth_scope }}"
+  - "Project {{ project }} pipeline {{ pipeline_id }} job {{ job }}: {{ vendor }} agent ingests {{ source_kind }}"
+  - "Injection wiring: via={{ via }}, capabilities={{ capabilities }}, gate_state={{ gate_state }}"
+  - "Identity scope: {{ identity_scope }}; confidence: {{ confidence }}"
 
 remediation_hint: >
-  Never interpolate raw PR text into agent prompts. Use a sanitization layer
-  that strips instruction-like content. Scope the job authorization to
-  current project. Remove write tools from the agent or gate agent actions
-  behind a human approval step.
+  Never interpolate raw PR/work-item/file text into agent prompts. Strip
+  instruction-like content, and put a human approval gate (an environment
+  check) between the untrusted input and any privileged agent action.
+  Remove write/exec/egress tools from agents that process untrusted text,
+  and scope the job authorization to the current project.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-12/01
 title: "PR title/description injected into agent prompt with Build Service token"
 subject: pipeline
 severity: high
-confidence: high
 description: >
   An AI-review pipeline interpolates the PR's free-text fields (title,
   description, source-version message) directly into the agent prompt. The

--- a/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
@@ -1,32 +1,31 @@
 id: cat-12/secret-exfil-via-injection
 scenario_id: cat-12/07
-title: "Injected agent exfiltrates secrets, service-connection credentials, and System.AccessToken"
-subject: pipeline
+title: "Injected AI agent has an exfiltration channel for the run's secrets and token"
+subject: agent_injection
 severity: high
+confidence: high
 description: >
-  An AI agent is instructed to review attacker-controlled text and, via
-  prompt injection, is steered to read and transmit the run's secrets —
+  An AI agent processes attacker-controlled text and holds a capability
+  that can move data out of the run — network egress, or the ability to
+  auto-commit / auto-open a PR (posting stolen values into a branch or PR
+  comment). Via injection it can read and transmit the run's secrets:
   secret variables, variable-group values, service-connection credentials,
-  and System.AccessToken — to an attacker endpoint. Exfiltration-only (no
-  merge needed), so it bypasses every reviewer gate entirely. The lowest
-  precondition stack of the injection scenarios.
+  and System.AccessToken. Exfiltration needs no merge, so it bypasses every
+  reviewer gate — the lowest precondition stack of the injection scenarios.
 
 where:
   all_of:
-    - prompt_ingests_untrusted == true
-    - exposes_system_access_token == true
-  any_of:
-    - has_agent_tool_use == true
-    - has_agent_network_egress == true
+    - technique == 'prompt_injection'
+    - gate_state == 'absent'
+    - capabilities ∋ {egress, auto_commit, auto_pr}
 
 evidence:
-  - "Pipeline {{ _provenance.pipeline_name }}: agent prompt includes {{ untrusted_source_fields }}"
-  - "Secrets in run environment: {{ secret_resource_names }}"
-  - "Agent egress capability: {{ agent_egress_type }}"
-  - "System.AccessToken scope: {{ job_auth_scope }}"
+  - "Project {{ project }} pipeline {{ pipeline_id }} job {{ job }}: {{ vendor }} agent has exfil channel"
+  - "Capabilities: {{ capabilities }}; source: {{ source_kind }}; gate_state: {{ gate_state }}"
+  - "Injected agent can transmit secrets / System.AccessToken with no merge required"
 
 remediation_hint: >
   Do not map secrets or System.AccessToken into agent steps that process
   untrusted input. Run AI review steps in a job with no secret variables,
-  no service connections, and a project-scoped read-only token. Restrict
-  agent network egress.
+  no service connections, and a project-scoped read-only token, and remove
+  the agent's network-egress and auto-commit/auto-PR capabilities.

--- a/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-12/07
 title: "Injected agent exfiltrates secrets, service-connection credentials, and System.AccessToken"
 subject: pipeline
 severity: high
-confidence: high
 description: >
   An AI agent is instructed to review attacker-controlled text and, via
   prompt injection, is steered to read and transmit the run's secrets —

--- a/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
@@ -1,0 +1,33 @@
+id: cat-12/secret-exfil-via-injection
+scenario_id: cat-12/07
+title: "Injected agent exfiltrates secrets, service-connection credentials, and System.AccessToken"
+subject: pipeline
+severity: high
+confidence: high
+description: >
+  An AI agent is instructed to review attacker-controlled text and, via
+  prompt injection, is steered to read and transmit the run's secrets —
+  secret variables, variable-group values, service-connection credentials,
+  and System.AccessToken — to an attacker endpoint. Exfiltration-only (no
+  merge needed), so it bypasses every reviewer gate entirely. The lowest
+  precondition stack of the injection scenarios.
+
+where:
+  all_of:
+    - prompt_ingests_untrusted == true
+    - exposes_system_access_token == true
+  any_of:
+    - has_agent_tool_use == true
+    - has_agent_network_egress == true
+
+evidence:
+  - "Pipeline {{ _provenance.pipeline_name }}: agent prompt includes {{ untrusted_source_fields }}"
+  - "Secrets in run environment: {{ secret_resource_names }}"
+  - "Agent egress capability: {{ agent_egress_type }}"
+  - "System.AccessToken scope: {{ job_auth_scope }}"
+
+remediation_hint: >
+  Do not map secrets or System.AccessToken into agent steps that process
+  untrusted input. Run AI review steps in a job with no secret variables,
+  no service connections, and a project-scoped read-only token. Restrict
+  agent network egress.


### PR DESCRIPTION
## Summary
- Adds 5 YAML detection rules for Azure DevOps AI task and agent abuse
  under `internal/detection-rules/ado/cat-12-ai-tasks/`
- Covers prompt injection, indirect injection via checked-out code,
  overscoped marketplace extensions, generate-then-execute patterns,
  and secret exfiltration via injected agent behavior
- Part of LAB-4743 (execution & injection family)

## Rules
| File | Severity | Subject | What it detects |
|---|---|---|---|
| `pr-text-prompt-injection.yaml` | High | pipeline | PR text injected into AI task prompt with System.AccessToken exposed and agent tool-use enabled |
| `indirect-injection-agentic-rce.yaml` | High | pipeline | Agentic task executes checked-out code from attacker merge commit during build validation |
| `overscoped-ai-extension.yaml` | High | extension | Org-wide AI extension with auto-update requests OAuth scopes far exceeding its stated purpose |
| `generate-then-execute.yaml` | High | pipeline | AI task generates code/config from untrusted prompt, then a later step executes the output |
| `secret-exfil-via-injection.yaml` | High | pipeline | Prompt injection exfiltrates System.AccessToken or mapped secrets via agent tool-use or network egress |

Fixes LAB-4743