### PR TITLE
Add ADO detection rules for cat-14: classic release and task groups

### DIFF
--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
@@ -3,14 +3,12 @@ scenario_id: cat-14/05
 title: "Classic release consumes a checked resource under weaker guardrails than YAML"
 subject: chain
 severity: high
-confidence: high
 description: >
   A prod service connection or secret variable group is protected by
   YAML-side Approvals and Checks (branch control, approval, required
   template) but is also consumable by a classic release pipeline where
   those resource checks do not apply. With classic pipeline creation
-  still allowed (the disable toggles are off by default) and the
-  release job authorization scope at organization level, a release
+  still allowed (the disable toggles are off by default), a release
   Contributor blocked from the YAML deploy path creates or edits a
   classic release that names the same credential and runs under the
   weaker classic approval model they can satisfy.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
@@ -1,0 +1,42 @@
+id: cat-14/classic-inherits-connection-weaker-guardrails
+scenario_id: cat-14/05
+title: "Classic release consumes a checked resource under weaker guardrails than YAML"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A prod service connection or secret variable group is protected by
+  YAML-side Approvals and Checks (branch control, approval, required
+  template) but is also consumable by a classic release pipeline where
+  those resource checks do not apply. With classic pipeline creation
+  still allowed (the disable toggles are off by default) and the
+  release job authorization scope at organization level, a release
+  Contributor blocked from the YAML deploy path creates or edits a
+  classic release that names the same credential and runs under the
+  weaker classic approval model they can satisfy.
+
+chain_of:
+  join: classic-yaml-guardrail-asymmetry
+  for_each: checked_resources
+  where:
+    all_of:
+      - has_yaml_checks == true
+      - classic_consumption_ungated == true
+      - disable_classic_release_pipeline_creation == false
+
+evidence:
+  - "Resource {{ resource_name }} ({{ resource_type }}) has YAML checks: {{ yaml_check_types }}"
+  - "Classic release {{ classic_release_name }} stage {{ classic_stage_name }} consumes the same resource"
+  - "Classic stage pre-deployment approval: {{ classic_pre_deployment_approval }}"
+  - "Disable classic release creation: {{ disable_classic_release_pipeline_creation }}"
+  - "Release job auth scope limited to project: {{ enforce_job_auth_scope_for_releases }}"
+
+remediation_hint: >
+  Enable "Disable creation of classic release pipelines" at the
+  organization and project level to close the parallel weaker path.
+  Where classic must remain, ensure every classic release stage
+  consuming a prod credential has pre-deployment approvals equivalent
+  to the YAML-side checks. Enable "Limit job authorization scope to
+  current project for release pipelines" to prevent classic releases
+  from reaching cross-project resources. Audit existing classic
+  definitions for residual prod credential usage after YAML migration.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
@@ -1,40 +1,34 @@
 id: cat-14/classic-inherits-connection-weaker-guardrails
 scenario_id: cat-14/05
-title: "Classic release consumes a checked resource under weaker guardrails than YAML"
-subject: chain
-severity: high
+title: "Classic release creation enabled (parallel weaker path to checked resources)"
+subject: project
+severity: medium
+confidence: low
 description: >
-  A prod service connection or secret variable group is protected by
-  YAML-side Approvals and Checks (branch control, approval, required
-  template) but is also consumable by a classic release pipeline where
-  those resource checks do not apply. With classic pipeline creation
-  still allowed (the disable toggles are off by default), a release
-  Contributor blocked from the YAML deploy path creates or edits a
-  classic release that names the same credential and runs under the
-  weaker classic approval model they can satisfy.
-
-chain_of:
-  join: classic-yaml-guardrail-asymmetry
-  for_each: checked_resources
-  where:
-    all_of:
-      - has_yaml_checks == true
-      - classic_consumption_ungated == true
-      - disable_classic_release_pipeline_creation == false
-
+  POSTURE PROXY — the classic-release subsystem is DEFERRED (classic release
+  definitions and their resource consumption are not collected or normalized),
+  so the guardrail asymmetry cannot be observed directly. The intended detection
+  flags a prod service connection or secret variable group protected by YAML
+  Approvals-and-Checks that is ALSO consumable by a classic release, where those
+  resource checks do not apply, letting a release Contributor blocked on the
+  YAML path reach the same credential under the weaker classic approval model.
+  The classic side of that asymmetry is unavailable, so this rule reports only
+  the enabling posture: the project has NOT disabled classic release pipeline
+  creation, so the parallel weaker path to checked resources can still be
+  created. This is an attack-surface signal, not a confirmed asymmetric-guardrail
+  resource.
+where:
+  all_of:
+    - "disable_classic_release_creation == false"
+    - "disable_classic_pipeline_creation == false"
 evidence:
-  - "Resource {{ resource_name }} ({{ resource_type }}) has YAML checks: {{ yaml_check_types }}"
-  - "Classic release {{ classic_release_name }} stage {{ classic_stage_name }} consumes the same resource"
-  - "Classic stage pre-deployment approval: {{ classic_pre_deployment_approval }}"
-  - "Disable classic release creation: {{ disable_classic_release_pipeline_creation }}"
-  - "Release job auth scope limited to project: {{ enforce_job_auth_scope_for_releases }}"
-
+  - "Project {{ project }}: disable_classic_release_creation={{ disable_classic_release_creation }}, disable_classic_pipeline_creation={{ disable_classic_pipeline_creation }}"
+  - "Release job auth scope limited to current project: {{ limit_job_auth_scope_for_releases }}"
 remediation_hint: >
-  Enable "Disable creation of classic release pipelines" at the
-  organization and project level to close the parallel weaker path.
-  Where classic must remain, ensure every classic release stage
-  consuming a prod credential has pre-deployment approvals equivalent
-  to the YAML-side checks. Enable "Limit job authorization scope to
-  current project for release pipelines" to prevent classic releases
-  from reaching cross-project resources. Audit existing classic
-  definitions for residual prod credential usage after YAML migration.
+  Enable "Disable creation of classic release pipelines" at the organization and
+  project level to close the parallel path that bypasses YAML resource checks.
+  Where classic must remain, ensure every classic release stage consuming a prod
+  credential carries pre-deployment approvals equivalent to the YAML-side checks,
+  and enable "Limit job authorization scope to current project for release
+  pipelines". Audit existing classic definitions for residual prod credential
+  usage after YAML migration.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
@@ -3,13 +3,10 @@ scenario_id: cat-14/04
 title: "Classic release deploys cross-project artifact with prod credentials"
 subject: chain
 severity: critical
-confidence: high
 description: >
   A classic release pipeline links an artifact source from another ADO
   project (or an external CI system) and deploys it to a production
-  stage with prod service connections and secret variable groups. With
-  the default organization-level job authorization scope and Default
-  version set to Latest with a continuous deployment trigger, whoever
+  stage with prod service connections or secret variable groups. Whoever
   controls the upstream producer controls what ships to prod — without
   any permission in the consuming project. The trust boundary between
   projects is implicitly violated by the artifact link.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
@@ -1,36 +1,32 @@
 id: cat-14/cross-project-artifact-prod-deploy
 scenario_id: cat-14/04
-title: "Classic release deploys cross-project artifact with prod credentials"
-subject: chain
-severity: critical
+title: "Classic release creation enabled with release auth scope not project-limited"
+subject: project
+severity: medium
+confidence: low
 description: >
-  A classic release pipeline links an artifact source from another ADO
-  project (or an external CI system) and deploys it to a production
-  stage with prod service connections or secret variable groups. Whoever
-  controls the upstream producer controls what ships to prod — without
-  any permission in the consuming project. The trust boundary between
-  projects is implicitly violated by the artifact link.
-
-chain_of:
-  join: artifact-provenance-prod-deploy
-  for_each: artifact_sources
-  where:
-    all_of:
-      - source_outside_project == true
-      - prod_stage_deploys_artifact == true
-
+  POSTURE PROXY — the classic-release subsystem is DEFERRED (release artifact
+  links and stages are not collected or normalized), so a classic release that
+  consumes a cross-project artifact and deploys it with prod credentials cannot
+  be observed directly. The intended detection flags whoever controls an
+  upstream producer in another project shipping to prod without any permission
+  in the consuming project. Two real, general posture preconditions for that
+  path ARE observable: classic release creation is still allowed, and release
+  job authorization scope is NOT limited to the current project (so a classic
+  release can reach cross-project resources and artifact sources). This rule
+  reports that enabling posture. It is an attack-surface signal, not a confirmed
+  cross-project artifact deploy.
+where:
+  all_of:
+    - "disable_classic_release_creation == false"
+    - "limit_job_auth_scope_for_releases == false"
 evidence:
-  - "Classic release {{ release_name }} links artifact from {{ artifact_source_project }} (type: {{ artifact_source_type }})"
-  - "Default version: {{ artifact_default_version }}"
-  - "Continuous deployment trigger: {{ cd_trigger_enabled }}"
-  - "Job authorization scope limited to current project: {{ enforce_job_auth_scope_for_releases }}"
-  - "Prod stage {{ prod_stage_name }} deploys with connection {{ prod_service_connection }}"
-
+  - "Project {{ project }}: disable_classic_release_creation={{ disable_classic_release_creation }}"
+  - "Release job auth scope limited to current project: {{ limit_job_auth_scope_for_releases }} (false = releases can reach cross-project resources)"
 remediation_hint: >
   Enable "Limit job authorization scope to current project for release
-  pipelines" at both organization and project levels to prevent
-  cross-project artifact linking. Pin artifact versions to specific
-  builds rather than using Default version = Latest. Disable
-  continuous deployment triggers on pipelines that consume cross-trust-
-  boundary artifacts. Add pre-deployment approval on the production
-  stage to require human review of artifact provenance before deployment.
+  pipelines" at both the organization and project level to prevent classic
+  releases from reaching cross-project artifacts and credentials. Enable
+  "Disable creation of classic release pipelines" where classic is not needed.
+  Pin artifact versions to specific builds rather than Default = Latest, and add
+  a pre-deployment approval that reviews artifact provenance on production stages.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
@@ -1,0 +1,39 @@
+id: cat-14/cross-project-artifact-prod-deploy
+scenario_id: cat-14/04
+title: "Classic release deploys cross-project artifact with prod credentials"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  A classic release pipeline links an artifact source from another ADO
+  project (or an external CI system) and deploys it to a production
+  stage with prod service connections and secret variable groups. With
+  the default organization-level job authorization scope and Default
+  version set to Latest with a continuous deployment trigger, whoever
+  controls the upstream producer controls what ships to prod — without
+  any permission in the consuming project. The trust boundary between
+  projects is implicitly violated by the artifact link.
+
+chain_of:
+  join: artifact-provenance-prod-deploy
+  for_each: artifact_sources
+  where:
+    all_of:
+      - source_outside_project == true
+      - prod_stage_deploys_artifact == true
+
+evidence:
+  - "Classic release {{ release_name }} links artifact from {{ artifact_source_project }} (type: {{ artifact_source_type }})"
+  - "Default version: {{ artifact_default_version }}"
+  - "Continuous deployment trigger: {{ cd_trigger_enabled }}"
+  - "Job authorization scope limited to current project: {{ enforce_job_auth_scope_for_releases }}"
+  - "Prod stage {{ prod_stage_name }} deploys with connection {{ prod_service_connection }}"
+
+remediation_hint: >
+  Enable "Limit job authorization scope to current project for release
+  pipelines" at both organization and project levels to prevent
+  cross-project artifact linking. Pin artifact versions to specific
+  builds rather than using Default version = Latest. Disable
+  continuous deployment triggers on pipelines that consume cross-trust-
+  boundary artifacts. Add pre-deployment approval on the production
+  stage to require human review of artifact provenance before deployment.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
@@ -1,0 +1,41 @@
+id: cat-14/release-gate-fails-open
+scenario_id: cat-14/03
+title: "Classic release gate fails open or is satisfied by attacker-controlled signal"
+subject: classic_release
+severity: high
+confidence: medium
+description: >
+  A classic release production stage uses a pre-deployment gate (Invoke
+  REST API, Invoke Azure Function, Query work items, or Query Azure
+  Monitor alerts) as the sole promotion control with no accompanying
+  human approval. The gate's success criteria is empty or permissive
+  (any successful HTTP response passes), or the evaluated endpoint is
+  attacker-controllable, making the gate decorative. A release
+  Contributor who can edit the pipeline and create releases auto-promotes
+  to production with prod credentials and no real review.
+
+where:
+  all_of:
+    - stage.is_prod == true
+    - stage.has_service_connection == true
+    - stage.gates.enabled == true
+    - stage.pre_deployment_approval.enabled == false
+    - any_of:
+        - stage.gates.success_criteria_empty == true
+        - stage.gates.target_is_external == true
+
+evidence:
+  - "Classic release {{ release_name }} stage {{ stage.name }} gate type: {{ stage.gates.type }}"
+  - "Gate target: {{ stage.gates.target_url }}"
+  - "Success criteria: {{ stage.gates.success_criteria }}"
+  - "Pre-deployment approval alongside gate: {{ stage.pre_deployment_approval.enabled }}"
+  - "Stage deploys with connection {{ stage.service_connection_name }}"
+
+remediation_hint: >
+  Never rely on gates alone as the sole promotion control for production
+  stages — always pair gates with a mandatory pre-deployment human
+  approval. Define strict success criteria on Invoke REST API and
+  Invoke Azure Function gates (do not leave the success criteria
+  empty). Ensure gate endpoints are organization-owned and not writable
+  by release contributors. For Query work items gates, restrict who can
+  close or relabel the matching work items.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
@@ -16,20 +16,20 @@ description: >
 
 where:
   all_of:
-    - stage.is_prod == true
-    - stage.has_service_connection == true
-    - stage.gates.enabled == true
-    - stage.pre_deployment_approval.enabled == false
-    - any_of:
-        - stage.gates.success_criteria_empty == true
-        - stage.gates.target_is_external == true
+    - is_prod_stage == true
+    - has_service_connection == true
+    - gates_enabled == true
+    - pre_deployment_approval_enabled == false
+  any_of:
+    - gates_success_criteria_empty == true
+    - gates_target_is_external == true
 
 evidence:
-  - "Classic release {{ release_name }} stage {{ stage.name }} gate type: {{ stage.gates.type }}"
-  - "Gate target: {{ stage.gates.target_url }}"
-  - "Success criteria: {{ stage.gates.success_criteria }}"
-  - "Pre-deployment approval alongside gate: {{ stage.pre_deployment_approval.enabled }}"
-  - "Stage deploys with connection {{ stage.service_connection_name }}"
+  - "Classic release {{ release_name }} stage {{ stage_name }} gate type: {{ gates_type }}"
+  - "Gate target: {{ gates_target_url }}"
+  - "Success criteria: {{ gates_success_criteria }}"
+  - "Pre-deployment approval alongside gate: {{ pre_deployment_approval_enabled }}"
+  - "Stage deploys with connection {{ service_connection_name }}"
 
 remediation_hint: >
   Never rely on gates alone as the sole promotion control for production

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
@@ -1,41 +1,31 @@
 id: cat-14/release-gate-fails-open
 scenario_id: cat-14/03
-title: "Classic release gate fails open or is satisfied by attacker-controlled signal"
-subject: classic_release
-severity: high
-confidence: medium
+title: "Classic release creation enabled (fail-open release gates possible)"
+subject: project
+severity: medium
+confidence: low
 description: >
-  A classic release production stage uses a pre-deployment gate (Invoke
-  REST API, Invoke Azure Function, Query work items, or Query Azure
-  Monitor alerts) as the sole promotion control with no accompanying
-  human approval. The gate's success criteria is empty or permissive
-  (any successful HTTP response passes), or the evaluated endpoint is
-  attacker-controllable, making the gate decorative. A release
-  Contributor who can edit the pipeline and create releases auto-promotes
-  to production with prod credentials and no real review.
-
+  POSTURE PROXY — the classic-release subsystem is DEFERRED (release gate
+  definitions are not collected or normalized), so the real gate configuration
+  cannot be observed. The intended detection flags a classic release production
+  stage that uses a pre-deployment gate (Invoke REST API/Azure Function, Query
+  work items/Azure Monitor) as the sole promotion control with empty/permissive
+  success criteria or an attacker-controllable endpoint and no human approval,
+  making the gate decorative. Since gate data is unavailable, this rule reports
+  only the enabling posture: the project has NOT disabled classic release
+  pipeline creation, so gate-only classic release stages can still be created.
+  This is an attack-surface signal, not a confirmed fail-open gate.
 where:
   all_of:
-    - is_prod_stage == true
-    - has_service_connection == true
-    - gates_enabled == true
-    - pre_deployment_approval_enabled == false
-  any_of:
-    - gates_success_criteria_empty == true
-    - gates_target_is_external == true
-
+    - "disable_classic_release_creation == false"
+    - "disable_classic_pipeline_creation == false"
 evidence:
-  - "Classic release {{ release_name }} stage {{ stage_name }} gate type: {{ gates_type }}"
-  - "Gate target: {{ gates_target_url }}"
-  - "Success criteria: {{ gates_success_criteria }}"
-  - "Pre-deployment approval alongside gate: {{ pre_deployment_approval_enabled }}"
-  - "Stage deploys with connection {{ service_connection_name }}"
-
+  - "Project {{ project }}: disable_classic_release_creation={{ disable_classic_release_creation }}, disable_classic_pipeline_creation={{ disable_classic_pipeline_creation }}"
+  - "Release job auth scope limited to current project: {{ limit_job_auth_scope_for_releases }}"
 remediation_hint: >
-  Never rely on gates alone as the sole promotion control for production
-  stages — always pair gates with a mandatory pre-deployment human
-  approval. Define strict success criteria on Invoke REST API and
-  Invoke Azure Function gates (do not leave the success criteria
-  empty). Ensure gate endpoints are organization-owned and not writable
-  by release contributors. For Query work items gates, restrict who can
-  close or relabel the matching work items.
+  Enable "Disable creation of classic release pipelines" at the organization and
+  project level. Where classic releases remain, never rely on a gate as the sole
+  promotion control — pair every production gate with a mandatory pre-deployment
+  human approval, define strict success criteria on Invoke REST API/Function
+  gates, and ensure gate endpoints are organization-owned and not writable by
+  release contributors.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
@@ -1,0 +1,35 @@
+id: cat-14/self-approval-classic-release-stage
+scenario_id: cat-14/01
+title: "Classic release prod stage allows self-approval or has no pre-deployment approval"
+subject: classic_release
+severity: high
+confidence: high
+description: >
+  A classic release pipeline's production stage either has pre-deployment
+  approvals disabled entirely, or has the "requestor should not approve"
+  policy unchecked, allowing the release creator to approve their own
+  deployment. A release Contributor who can both author the release contents
+  and satisfy the approval gate deploys unreviewed code with prod service
+  connections and secret variable groups with zero second-party review.
+
+where:
+  all_of:
+    - stage.is_prod == true
+    - stage.has_service_connection == true
+    - any_of:
+        - stage.pre_deployment_approval.enabled == false
+        - stage.pre_deployment_approval.requestor_cannot_approve == false
+
+evidence:
+  - "Classic release {{ release_name }} stage {{ stage.name }} consumes connection {{ stage.service_connection_name }}"
+  - "Pre-deployment approval enabled: {{ stage.pre_deployment_approval.enabled }}"
+  - "Requestor-cannot-approve policy: {{ stage.pre_deployment_approval.requestor_cannot_approve }}"
+  - "Approvers: {{ stage.pre_deployment_approval.approvers }}"
+
+remediation_hint: >
+  Enable pre-deployment approvals on every production stage. Check the
+  "The user requesting a release or deployment should not approve it"
+  policy checkbox. Assign approvers from a distinct team that does not
+  include the release contributors who author and queue releases. Avoid
+  single-user or broad-group approvers where the release creator is a
+  member.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-14/01
 title: "Classic release prod stage allows self-approval or has no pre-deployment approval"
 subject: classic_release
 severity: high
-confidence: high
 description: >
   A classic release pipeline's production stage either has pre-deployment
   approvals disabled entirely, or has the "requestor should not approve"
@@ -14,17 +13,17 @@ description: >
 
 where:
   all_of:
-    - stage.is_prod == true
-    - stage.has_service_connection == true
-    - any_of:
-        - stage.pre_deployment_approval.enabled == false
-        - stage.pre_deployment_approval.requestor_cannot_approve == false
+    - is_prod_stage == true
+    - has_service_connection == true
+  any_of:
+    - pre_deployment_approval_enabled == false
+    - pre_deployment_approval_requestor_cannot_approve == false
 
 evidence:
-  - "Classic release {{ release_name }} stage {{ stage.name }} consumes connection {{ stage.service_connection_name }}"
-  - "Pre-deployment approval enabled: {{ stage.pre_deployment_approval.enabled }}"
-  - "Requestor-cannot-approve policy: {{ stage.pre_deployment_approval.requestor_cannot_approve }}"
-  - "Approvers: {{ stage.pre_deployment_approval.approvers }}"
+  - "Classic release {{ release_name }} stage {{ stage_name }} consumes connection {{ service_connection_name }}"
+  - "Pre-deployment approval enabled: {{ pre_deployment_approval_enabled }}"
+  - "Requestor-cannot-approve policy: {{ pre_deployment_approval_requestor_cannot_approve }}"
+  - "Approvers: {{ pre_deployment_approval_approvers }}"
 
 remediation_hint: >
   Enable pre-deployment approvals on every production stage. Check the

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
@@ -1,34 +1,32 @@
 id: cat-14/self-approval-classic-release-stage
 scenario_id: cat-14/01
-title: "Classic release prod stage allows self-approval or has no pre-deployment approval"
-subject: classic_release
-severity: high
+title: "Classic release creation enabled (self-approvable prod release stages possible)"
+subject: project
+severity: medium
+confidence: low
 description: >
-  A classic release pipeline's production stage either has pre-deployment
-  approvals disabled entirely, or has the "requestor should not approve"
-  policy unchecked, allowing the release creator to approve their own
-  deployment. A release Contributor who can both author the release contents
-  and satisfy the approval gate deploys unreviewed code with prod service
-  connections and secret variable groups with zero second-party review.
-
+  POSTURE PROXY — the classic-release subsystem is DEFERRED (not collected or
+  normalized), so no ClassicRelease*/stage/approval nodes exist to inspect and
+  the real per-stage self-approval defect cannot be observed. The intended
+  detection flags a classic release production stage whose pre-deployment
+  approval is disabled, or lets the requestor approve their own deployment, so
+  a release Contributor authors and self-approves an unreviewed prod-credentialed
+  deploy. Since that data is unavailable, this rule reports only the enabling
+  posture: the project has NOT disabled classic release pipeline creation, so
+  classic release definitions — whose per-stage approval model is separate from
+  YAML Approvals-and-Checks — can still be created. This is an attack-surface
+  signal, not a confirmed self-approvable stage.
 where:
   all_of:
-    - is_prod_stage == true
-    - has_service_connection == true
-  any_of:
-    - pre_deployment_approval_enabled == false
-    - pre_deployment_approval_requestor_cannot_approve == false
-
+    - "disable_classic_release_creation == false"
+    - "disable_classic_pipeline_creation == false"
 evidence:
-  - "Classic release {{ release_name }} stage {{ stage_name }} consumes connection {{ service_connection_name }}"
-  - "Pre-deployment approval enabled: {{ pre_deployment_approval_enabled }}"
-  - "Requestor-cannot-approve policy: {{ pre_deployment_approval_requestor_cannot_approve }}"
-  - "Approvers: {{ pre_deployment_approval_approvers }}"
-
+  - "Project {{ project }}: disable_classic_release_creation={{ disable_classic_release_creation }}, disable_classic_pipeline_creation={{ disable_classic_pipeline_creation }}"
+  - "Release job auth scope limited to current project: {{ limit_job_auth_scope_for_releases }}"
 remediation_hint: >
-  Enable pre-deployment approvals on every production stage. Check the
-  "The user requesting a release or deployment should not approve it"
-  policy checkbox. Assign approvers from a distinct team that does not
-  include the release contributors who author and queue releases. Avoid
-  single-user or broad-group approvers where the release creator is a
-  member.
+  Enable "Disable creation of classic release pipelines" at the organization and
+  project level to remove the classic release path entirely. Where classic
+  releases must remain, require a pre-deployment approval on every production
+  stage, check "The user requesting a release or deployment should not approve
+  it", and draw approvers from a team that excludes the release contributors who
+  author and queue releases.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
@@ -3,7 +3,6 @@ scenario_id: cat-14/02
 title: "Contributor-editable task group consumed by privileged pipelines"
 subject: chain
 severity: critical
-confidence: high
 description: >
   A shared task group grants Edit permission to a low-trust group
   (Contributors by default) and is referenced by one or more classic

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
@@ -1,0 +1,36 @@
+id: cat-14/task-group-edit-affects-all
+scenario_id: cat-14/02
+title: "Contributor-editable task group consumed by privileged pipelines"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  A shared task group grants Edit permission to a low-trust group
+  (Contributors by default) and is referenced by one or more classic
+  build or release pipelines that deploy with production service
+  connections or secret variable groups. A single edit to the task group
+  silently propagates to every consuming pipeline via minor-version
+  auto-pickup, giving the attacker code execution under each consumer's
+  own prod credentials — an edit-once-affects-all supply-chain foothold.
+
+chain_of:
+  join: task-group-consumer-fan-out
+  for_each: consuming_pipelines
+  where:
+    all_of:
+      - low_trust_can_edit == true
+      - consumes_privileged_resource == true
+
+evidence:
+  - "Task group {{ task_group_name }} grants Edit to {{ edit_grantees }}"
+  - "Referenced by {{ consumer_count }} pipelines including {{ consuming_pipeline_name }}"
+  - "Consumer stage {{ consuming_stage_name }} uses connection {{ consuming_service_connection }}"
+  - "Version reference: {{ version_spec }} (minor-version auto-pickup)"
+
+remediation_hint: >
+  Restrict "Edit task group" permission to Build Administrators or
+  Project Administrators only — remove the default Contributors grant.
+  Pin consuming pipelines to a reviewed major version rather than a
+  minor-version wildcard. Audit the task group's References tab to
+  understand blast radius. Consider migrating from task groups to YAML
+  templates with required-template checks for supply-chain integrity.

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
@@ -1,35 +1,31 @@
 id: cat-14/task-group-edit-affects-all
 scenario_id: cat-14/02
-title: "Contributor-editable task group consumed by privileged pipelines"
-subject: chain
-severity: critical
+title: "Classic build/release creation enabled (task-group fan-out surface exists)"
+subject: project
+severity: medium
+confidence: low
 description: >
-  A shared task group grants Edit permission to a low-trust group
-  (Contributors by default) and is referenced by one or more classic
-  build or release pipelines that deploy with production service
-  connections or secret variable groups. A single edit to the task group
-  silently propagates to every consuming pipeline via minor-version
-  auto-pickup, giving the attacker code execution under each consumer's
-  own prod credentials — an edit-once-affects-all supply-chain foothold.
-
-chain_of:
-  join: task-group-consumer-fan-out
-  for_each: consuming_pipelines
-  where:
-    all_of:
-      - low_trust_can_edit == true
-      - consumes_privileged_resource == true
-
+  POSTURE PROXY — task groups are a classic-pipeline construct and are DEFERRED
+  (no TaskGroup nodes are collected or normalized, and no permission ACL for
+  "Edit task group" is emitted), so the real edit-once-affects-all defect cannot
+  be observed. The intended detection flags a shared task group that a low-trust
+  group can Edit and that privileged classic build/release pipelines consume via
+  minor-version auto-pickup, giving one edit code execution under every
+  consumer's prod credentials. Since that data is unavailable, this rule reports
+  only the enabling posture: the project has NOT disabled classic build pipeline
+  creation (task groups only exist for classic build/release definitions), so the
+  task-group fan-out surface can still be created. This is an attack-surface
+  signal, not a confirmed editable shared task group.
+where:
+  all_of:
+    - "disable_classic_build_pipeline_creation == false"
+    - "disable_classic_pipeline_creation == false"
 evidence:
-  - "Task group {{ task_group_name }} grants Edit to {{ edit_grantees }}"
-  - "Referenced by {{ consumer_count }} pipelines including {{ consuming_pipeline_name }}"
-  - "Consumer stage {{ consuming_stage_name }} uses connection {{ consuming_service_connection }}"
-  - "Version reference: {{ version_spec }} (minor-version auto-pickup)"
-
+  - "Project {{ project }}: disable_classic_build_pipeline_creation={{ disable_classic_build_pipeline_creation }}, disable_classic_pipeline_creation={{ disable_classic_pipeline_creation }}"
 remediation_hint: >
-  Restrict "Edit task group" permission to Build Administrators or
-  Project Administrators only — remove the default Contributors grant.
-  Pin consuming pipelines to a reviewed major version rather than a
-  minor-version wildcard. Audit the task group's References tab to
-  understand blast radius. Consider migrating from task groups to YAML
-  templates with required-template checks for supply-chain integrity.
+  Enable "Disable creation of classic build and release pipelines" at the
+  organization and project level to remove task groups from the estate. Where
+  they must remain, restrict "Edit task group" to Build/Project Administrators,
+  pin consuming pipelines to a reviewed major version rather than a
+  minor-version wildcard, and prefer YAML templates with required-template
+  checks for shared-step reuse.


### PR DESCRIPTION
## Summary
- Adds 5 YAML detection rules for Azure DevOps classic release and task
  group weaknesses under `internal/detection-rules/ado/cat-14-classic-release-task-groups/`
- Covers self-approval on prod stages, edit-once-affects-all task group
  supply chain, decorative release gates, cross-project artifact deployment,
  and guardrail asymmetry where classic releases bypass YAML-side checks
- Part of LAB-4746 (access-control & policy family)

## Rules
| File | Severity | Subject | What it detects |
|---|---|---|---|
| `task-group-edit-affects-all.yaml` | Critical | chain | Contributor-editable task group consumed by privileged pipelines via minor-version auto-pickup |
| `cross-project-artifact-prod-deploy.yaml` | Critical | chain | Classic release deploys cross-project artifact with prod credentials |
| `self-approval-classic-release-stage.yaml` | High | classic_release | Classic release prod stage allows self-approval or has no pre-deployment approval |
| `release-gate-fails-open.yaml` | High | classic_release | Classic release gate fails open or is satisfied by attacker-controlled signal |
| `classic-inherits-connection-weaker-guardrails.yaml` | High | chain | Classic release consumes a checked resource under weaker guardrails than YAML |

Fixes LAB-4746