### PR TITLE
Add ADO detection rules for cat-03: secret isolation and variable group exposure

### DIFF
--- a/internal/detection-rules/ado/cat-03-secret-isolation/keyvault-linked-group-broad-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/keyvault-linked-group-broad-access.yaml
@@ -1,40 +1,37 @@
 id: cat-03/keyvault-linked-group-broad-access
 scenario_id: cat-03/03
-title: "KV-linked variable group fronts service connection with vault-wide Get/List"
-subject: chain
+title: "Key Vault-linked variable group is open to every pipeline"
+subject: variable_group
 severity: high
 confidence: medium
 description: >
-  A Key Vault-linked variable group is backed by a service connection whose
-  Azure RBAC assignment grants Get and List on the entire vault rather than
-  on specific secrets. Any pipeline authorized to consume the variable group
-  inherits the ability to enumerate and read every secret in the vault,
-  including secrets not surfaced as variables in the group. The finding
-  confidence is medium because the exploitable breadth depends on the
-  Azure RBAC scope (Tier-B), which is asserted via the service connection's
-  configured scope rather than live cloud enumeration.
+  A Key Vault-linked variable group (is_linked_to_keyvault) has "Grant access
+  to all pipelines" enabled. A KV-linked group maps only selected secret names;
+  the values are fetched live at runtime by the backing Azure Resource Manager
+  service connection, whose identity typically holds vault-scoped Get/List. When
+  the group is open to every pipeline, any pipeline in the project can borrow
+  that identity and — via an AzureCLI/Key Vault task on the same connection —
+  enumerate and read every secret in the vault, not just the mapped names. The
+  mapped-secret list is a UI convenience, not a boundary. Confidence is medium
+  because the exploitable breadth ultimately depends on the connection's Azure
+  RBAC scope, which is not collectable from ADO alone.
 
-chain_of:
-  join: group_uses_service_connection
-  for_each: kv_chain
-  where:
-    all_of:
-      - group.is_keyvault_linked == true
-      - group.service_connection.scope_is_broad == true
-      - pipeline.authorized_for_group == true
+where:
+  all_of:
+    - "is_linked_to_keyvault == true"
+    - "pipeline_permissions.all_pipelines == true"
 
 evidence:
-  - "Variable group: {{ kv_chain.group.name }}"
-  - "Service connection: {{ kv_chain.group.service_connection.name }}"
-  - "Key Vault: {{ kv_chain.group.service_connection.vault_name }}"
-  - "RBAC scope level: {{ kv_chain.group.service_connection.rbac_scope }}"
-  - "Authorized pipeline: {{ kv_chain.pipeline.name }}"
+  - "Key Vault-linked variable group: {{ project }} › {{ name }}"
+  - "Backing Key Vault: {{ keyvault_name }}"
+  - "Mapped secrets: {{ secret_variable_names }}"
+  - "Open access (all pipelines authorized): {{ pipeline_permissions.all_pipelines }}"
 
 remediation_hint: >
-  Narrow the service connection's Azure RBAC assignment from vault scope to
-  individual secret-level permissions, granting Get only on the specific
-  secrets the variable group surfaces. If multiple secrets are needed, prefer
-  an explicit allowlist over vault-wide Get/List. Add a Branch control check
-  on the variable group and restrict pipeline authorization to the minimum
-  required set. Review the vault for additional secrets that should not be
-  reachable from CI pipelines.
+  Disable Open access on the variable group and authorize only the specific
+  pipelines that need the mapped secrets. Narrow the backing service
+  connection's Azure RBAC assignment from vault scope to individual
+  secret-level permissions, granting Get only on the specific secrets the group
+  surfaces. Add a Branch control check so the group is only consumable from
+  protected branches. Review the vault for additional secrets that should not
+  be reachable from CI pipelines.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/keyvault-linked-group-broad-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/keyvault-linked-group-broad-access.yaml
@@ -1,0 +1,40 @@
+id: cat-03/keyvault-linked-group-broad-access
+scenario_id: cat-03/03
+title: "KV-linked variable group fronts service connection with vault-wide Get/List"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  A Key Vault-linked variable group is backed by a service connection whose
+  Azure RBAC assignment grants Get and List on the entire vault rather than
+  on specific secrets. Any pipeline authorized to consume the variable group
+  inherits the ability to enumerate and read every secret in the vault,
+  including secrets not surfaced as variables in the group. The finding
+  confidence is medium because the exploitable breadth depends on the
+  Azure RBAC scope (Tier-B), which is asserted via the service connection's
+  configured scope rather than live cloud enumeration.
+
+chain_of:
+  join: group_uses_service_connection
+  for_each: kv_chain
+  where:
+    all_of:
+      - group.is_keyvault_linked == true
+      - group.service_connection.scope_is_broad == true
+      - pipeline.authorized_for_group == true
+
+evidence:
+  - "Variable group: {{ kv_chain.group.name }}"
+  - "Service connection: {{ kv_chain.group.service_connection.name }}"
+  - "Key Vault: {{ kv_chain.group.service_connection.vault_name }}"
+  - "RBAC scope level: {{ kv_chain.group.service_connection.rbac_scope }}"
+  - "Authorized pipeline: {{ kv_chain.pipeline.name }}"
+
+remediation_hint: >
+  Narrow the service connection's Azure RBAC assignment from vault scope to
+  individual secret-level permissions, granting Get only on the specific
+  secrets the variable group surfaces. If multiple secrets are needed, prefer
+  an explicit allowlist over vault-wide Get/List. Add a Branch control check
+  on the variable group and restrict pipeline authorization to the minimum
+  required set. Review the vault for additional secrets that should not be
+  reachable from CI pipelines.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/multistage-ungated-stage-reads-secret.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/multistage-ungated-stage-reads-secret.yaml
@@ -1,0 +1,40 @@
+id: cat-03/multistage-ungated-stage-reads-secret
+scenario_id: cat-03/06
+title: "Multistage pipeline: ungated early stage reads secret meant for gated deploy stage"
+subject: chain
+severity: medium
+description: >
+  A pipeline-scoped variable group containing secrets is referenced in an
+  early stage that has no approval or check gate. A later stage in the same
+  pipeline carries environment checks (reviewers, business-hours gates, etc.),
+  creating the appearance of secret protection. Because the variable group is
+  scoped to the entire pipeline rather than to the gated stage, any run that
+  reaches the early stage — including runs triggered from feature branches or
+  queued manually — can exfiltrate secrets before the gated stage is ever
+  evaluated. The protection is decorative: the gate guards deployment, not
+  secret access.
+
+chain_of:
+  join: stage_references_group
+  for_each: multistage_pair
+  where:
+    all_of:
+      - group.scope == "pipeline"
+      - stage.has_checks == false
+      - stage.references_secret_group == true
+      - pipeline.has_gated_stage == true
+
+evidence:
+  - "Pipeline: {{ multistage_pair.pipeline.name }}"
+  - "Ungated stage that reads secrets: {{ multistage_pair.stage.name }}"
+  - "Gated stage (checks present): {{ multistage_pair.pipeline.gated_stage_name }}"
+  - "Variable group: {{ multistage_pair.group.name }}"
+
+remediation_hint: >
+  Move secret variables out of the pipeline-scoped variable group and into
+  stage-scoped variable groups that are linked only to the gated deploy stage.
+  Alternatively, add a Branch control or manual approval check directly on the
+  variable group so that secret injection is blocked regardless of which stage
+  runs first. If stage-scoped groups are not feasible, add an environment check
+  on the early stage itself to gate secret access at the point of use rather
+  than at deployment.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/multistage-ungated-stage-reads-secret.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/multistage-ungated-stage-reads-secret.yaml
@@ -1,40 +1,35 @@
 id: cat-03/multistage-ungated-stage-reads-secret
 scenario_id: cat-03/06
-title: "Multistage pipeline: ungated early stage reads secret meant for gated deploy stage"
-subject: chain
+title: "Multistage pipeline: named stage reads a pipeline-scoped secret with no gate"
+subject: reads
 severity: medium
+confidence: high
 description: >
-  A pipeline-scoped variable group containing secrets is referenced in an
-  early stage that has no approval or check gate. A later stage in the same
-  pipeline carries environment checks (reviewers, business-hours gates, etc.),
-  creating the appearance of secret protection. Because the variable group is
-  scoped to the entire pipeline rather than to the gated stage, any run that
-  reaches the early stage — including runs triggered from feature branches or
-  queued manually — can exfiltrate secrets before the gated stage is ever
-  evaluated. The protection is decorative: the gate guards deployment, not
-  secret access.
+  A secret is referenced at pipeline scope (via_level == "pipeline") but is
+  resolved inside an explicitly named stage that carries no check
+  (gate_state == "absent"). Approvals and checks on a variable group are
+  evaluated per stage, before that stage starts, so they only protect the
+  secret in the specific stage that consumes the resource. When the group is
+  scoped to the whole pipeline rather than to the gated deploy stage, any
+  earlier ungated stage — a Build/Test stage that runs before any approval —
+  resolves the secret for free, defeating the gate meant to guard it. The
+  approval is on the stage; the secret is on the pipeline.
 
-chain_of:
-  join: stage_references_group
-  for_each: multistage_pair
-  where:
-    all_of:
-      - group.scope == "pipeline"
-      - stage.has_checks == false
-      - stage.references_secret_group == true
-      - pipeline.has_gated_stage == true
+where:
+  all_of:
+    - "via_level == 'pipeline'"
+    - "gate_state == 'absent'"
+    - "stage != '__default'"
 
 evidence:
-  - "Pipeline: {{ multistage_pair.pipeline.name }}"
-  - "Ungated stage that reads secrets: {{ multistage_pair.stage.name }}"
-  - "Gated stage (checks present): {{ multistage_pair.pipeline.gated_stage_name }}"
-  - "Variable group: {{ multistage_pair.group.name }}"
+  - "Pipeline {{ pipeline_id }} in {{ project }}, stage {{ stage }} reads {{ secret_name }}"
+  - "Secret scope level: {{ via_level }} (available to every stage)"
+  - "Gate on the consuming stage: {{ gate_state }}"
 
 remediation_hint: >
-  Move secret variables out of the pipeline-scoped variable group and into
-  stage-scoped variable groups that are linked only to the gated deploy stage.
-  Alternatively, add a Branch control or manual approval check directly on the
-  variable group so that secret injection is blocked regardless of which stage
-  runs first. If stage-scoped groups are not feasible, add an environment check
-  on the early stage itself to gate secret access at the point of use rather
-  than at deployment.
+  Move the secret out of the pipeline-scoped variable group and into a
+  stage-scoped variables block linked only to the gated deploy stage.
+  Alternatively add a Branch control or manual approval check directly on the
+  variable group so secret injection is blocked regardless of which stage runs
+  first. If stage-scoped groups are not feasible, add an environment check on
+  the early stage itself to gate secret access at the point of use.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/no-branch-control-feature-branch-secret.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/no-branch-control-feature-branch-secret.yaml
@@ -1,36 +1,34 @@
-id: cat-03/no-branch-control-feature-branch-secret
+id: cat-03/secret-reachable-no-gate
 scenario_id: cat-03/02
-title: "Authorized pipeline with no Branch control lets feature branch read prod secrets"
-subject: chain
+title: "Pipeline reads a variable-group secret with no branch/approval gate"
+subject: reads
 severity: high
+confidence: high
 description: >
-  A pipeline is explicitly authorized to consume a secret-bearing variable
-  group, but the group has no Branch control check. The pipeline also accepts
-  triggers from non-protected branches (feature, PR head, or manually queued
-  runs on arbitrary refs). An attacker who can push to or open a PR from any
-  non-protected branch can trigger the authorized pipeline and exfiltrate
-  production secrets, bypassing the intent of the explicit authorization.
+  A pipeline resolves a secret from a variable group with no check standing
+  between it and the secret — gate_state is "absent" and gate_strength is
+  "none". Pipeline permissions authorize a pipeline, not a branch: once a
+  pipeline is authorized for a secret-bearing group it can consume those
+  secrets from any branch it runs on, including an attacker-controlled feature
+  branch whose YAML the attacker fully edits. Without a Branch control (or
+  manual approval) check on the resource, branch isolation does not exist, and
+  a Contributor who can push a branch and trigger the pipeline reads the secret.
 
-chain_of:
-  join: pipeline_authorizes_group
-  for_each: authorized_pair
-  where:
-    all_of:
-      - pipeline.authorized_for_group == true
-      - group.has_branch_control_check == false
-      - group.contains_secrets == true
-      - pipeline.triggers_on_non_protected_branch == true
+where:
+  all_of:
+    - "gate_state == 'absent'"
+    - "gate_strength == 'none'"
 
 evidence:
-  - "Pipeline: {{ authorized_pair.pipeline.name }}"
-  - "Variable group: {{ authorized_pair.group.name }}"
-  - "Branch trigger pattern: {{ authorized_pair.pipeline.trigger_branch_pattern }}"
-  - "Secret variables: {{ authorized_pair.group.secret_variable_names }}"
+  - "Pipeline {{ pipeline_id }} in {{ project }} reads secret {{ secret_name }}"
+  - "Variable group id: {{ variable_group_id }} · scoped at {{ via_level }} level"
+  - "Gate state: {{ gate_state }} ({{ gate_strength }})"
 
 remediation_hint: >
   Add a Branch control check to the variable group, restricting secret
-  injection to runs originating from protected branches (e.g., main, release/*).
-  Restrict the pipeline's CI trigger and manual-run branch filters to
-  protected branches only. Consider splitting prod-credential variable groups
-  from non-prod groups so authorization boundaries align with branch protection
-  boundaries.
+  injection to runs originating from protected branches (e.g. refs/heads/main,
+  refs/heads/releases/*) and requiring the branch to actually have protection.
+  Restrict the pipeline's CI trigger and manual-run branch filters to protected
+  branches only, and split prod-credential groups from non-prod so authorization
+  boundaries align with branch-protection boundaries. Consider a manual approval
+  check on the resource for the highest-value secrets.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/no-branch-control-feature-branch-secret.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/no-branch-control-feature-branch-secret.yaml
@@ -1,0 +1,36 @@
+id: cat-03/no-branch-control-feature-branch-secret
+scenario_id: cat-03/02
+title: "Authorized pipeline with no Branch control lets feature branch read prod secrets"
+subject: chain
+severity: high
+description: >
+  A pipeline is explicitly authorized to consume a secret-bearing variable
+  group, but the group has no Branch control check. The pipeline also accepts
+  triggers from non-protected branches (feature, PR head, or manually queued
+  runs on arbitrary refs). An attacker who can push to or open a PR from any
+  non-protected branch can trigger the authorized pipeline and exfiltrate
+  production secrets, bypassing the intent of the explicit authorization.
+
+chain_of:
+  join: pipeline_authorizes_group
+  for_each: authorized_pair
+  where:
+    all_of:
+      - pipeline.authorized_for_group == true
+      - group.has_branch_control_check == false
+      - group.contains_secrets == true
+      - pipeline.triggers_on_non_protected_branch == true
+
+evidence:
+  - "Pipeline: {{ authorized_pair.pipeline.name }}"
+  - "Variable group: {{ authorized_pair.group.name }}"
+  - "Branch trigger pattern: {{ authorized_pair.pipeline.trigger_branch_pattern }}"
+  - "Secret variables: {{ authorized_pair.group.secret_variable_names }}"
+
+remediation_hint: >
+  Add a Branch control check to the variable group, restricting secret
+  injection to runs originating from protected branches (e.g., main, release/*).
+  Restrict the pipeline's CI trigger and manual-run branch filters to
+  protected branches only. Consider splitting prod-credential variable groups
+  from non-prod groups so authorization boundaries align with branch protection
+  boundaries.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/secure-file-open-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/secure-file-open-access.yaml
@@ -1,31 +1,33 @@
 id: cat-03/secure-file-open-access
 scenario_id: cat-03/05
-title: "Secure File Open access lets any pipeline download signing key or credential file"
+title: "Secure File Open access lets any pipeline download the signing key"
 subject: secure_file
 severity: high
+confidence: high
 description: >
-  A secure file (signing key, keystore, SSH private key, or certificate bundle)
-  is configured with "Grant access to all pipelines" enabled. Any pipeline in
-  the project can download the file using the DownloadSecureFile task without
-  explicit authorization. An attacker with pipeline-create or pipeline-edit
-  permission can retrieve the raw credential material and use it to sign
-  artifacts, impersonate service identities, or pivot to external systems,
-  with no branch or approver gate standing between them and the file.
+  A secure file (code-signing cert, keystore, SSH key, or credential bundle)
+  has "Grant access to all pipelines" (Open access) enabled —
+  pipeline_permissions.all_pipelines is true. Secure files are a protected
+  resource consumed via DownloadSecureFile@1, which decrypts the file to the
+  agent workspace. Open access hands a copy of that file to every pipeline in
+  the project: any Contributor authors a pipeline on a branch they control,
+  downloads the file, and exfiltrates the bytes (masking does not apply to
+  arbitrary binary content). Unlike a string secret, a secure file is often a
+  long-lived, hard-to-rotate cryptographic asset whose theft enables
+  supply-chain forgery.
 
 where:
   all_of:
-    - grant_all_pipelines == true
-    - is_sensitive_asset == true
+    - "pipeline_permissions.all_pipelines == true"
 
 evidence:
-  - "Secure file: {{ secure_file.name }}"
-  - "File type / purpose: {{ secure_file.asset_type }}"
-  - "Pipelines that can download this file (project-wide): {{ secure_file.authorized_pipeline_count }}"
+  - "Secure file: {{ project }} › {{ name }}"
+  - "Open access (all pipelines authorized): {{ pipeline_permissions.all_pipelines }}"
 
 remediation_hint: >
   Disable "Grant access to all pipelines" on the secure file and authorize only
   the specific pipelines that require it. Add a Branch control check so the file
   is only downloadable during runs on protected branches. If the file has been
   accessible to unintended pipelines, treat the credential as compromised and
-  rotate it: generate a new signing key or certificate, revoke the old one, and
-  update all dependent systems before re-uploading.
+  rotate it — generate a new signing key or certificate, revoke the old one, and
+  update dependent systems before re-uploading.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/secure-file-open-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/secure-file-open-access.yaml
@@ -1,0 +1,31 @@
+id: cat-03/secure-file-open-access
+scenario_id: cat-03/05
+title: "Secure File Open access lets any pipeline download signing key or credential file"
+subject: secure_file
+severity: high
+description: >
+  A secure file (signing key, keystore, SSH private key, or certificate bundle)
+  is configured with "Grant access to all pipelines" enabled. Any pipeline in
+  the project can download the file using the DownloadSecureFile task without
+  explicit authorization. An attacker with pipeline-create or pipeline-edit
+  permission can retrieve the raw credential material and use it to sign
+  artifacts, impersonate service identities, or pivot to external systems,
+  with no branch or approver gate standing between them and the file.
+
+where:
+  all_of:
+    - grant_all_pipelines == true
+    - is_sensitive_asset == true
+
+evidence:
+  - "Secure file: {{ secure_file.name }}"
+  - "File type / purpose: {{ secure_file.asset_type }}"
+  - "Pipelines that can download this file (project-wide): {{ secure_file.authorized_pipeline_count }}"
+
+remediation_hint: >
+  Disable "Grant access to all pipelines" on the secure file and authorize only
+  the specific pipelines that require it. Add a Branch control check so the file
+  is only downloadable during runs on protected branches. If the file has been
+  accessible to unintended pipelines, treat the credential as compromised and
+  rotate it: generate a new signing key or certificate, revoke the old one, and
+  update all dependent systems before re-uploading.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/variable-group-open-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/variable-group-open-access.yaml
@@ -1,0 +1,29 @@
+id: cat-03/variable-group-open-access
+scenario_id: cat-03/01
+title: "Variable group Open access exposes secrets to every pipeline"
+subject: variable_group
+severity: high
+description: >
+  A variable group that contains secret variables is configured with
+  "Grant access to all pipelines" enabled. Any pipeline in the project,
+  including those triggered from feature or fork branches, can consume
+  every secret in the group without any explicit authorization. An attacker
+  with pipeline-create or pipeline-edit permission can exfiltrate production
+  credentials simply by referencing the group in a new or modified pipeline.
+
+where:
+  all_of:
+    - grant_all_pipelines == true
+    - contains_secrets == true
+
+evidence:
+  - "Variable group: {{ variable_group.name }}"
+  - "Secret variables: {{ variable_group.secret_variable_names }}"
+  - "Pipelines that can consume this group (project-wide): {{ variable_group.authorized_pipeline_count }}"
+
+remediation_hint: >
+  Disable "Grant access to all pipelines" on the variable group and enumerate
+  only the specific pipelines that legitimately need these secrets under
+  "Pipeline permissions." Add a Branch control check on the variable group
+  so secrets are only injected when the consuming pipeline runs on a protected
+  branch. Rotate any secrets that may have been consumed by unintended pipelines.

--- a/internal/detection-rules/ado/cat-03-secret-isolation/variable-group-open-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/variable-group-open-access.yaml
@@ -3,27 +3,29 @@ scenario_id: cat-03/01
 title: "Variable group Open access exposes secrets to every pipeline"
 subject: variable_group
 severity: high
+confidence: high
 description: >
-  A variable group that contains secret variables is configured with
-  "Grant access to all pipelines" enabled. Any pipeline in the project,
-  including those triggered from feature or fork branches, can consume
-  every secret in the group without any explicit authorization. An attacker
-  with pipeline-create or pipeline-edit permission can exfiltrate production
-  credentials simply by referencing the group in a new or modified pipeline.
+  A variable group that contains secret variables has "Grant access to all
+  pipelines" (Open access) enabled — pipeline_permissions.all_pipelines is true.
+  Pipeline permissions are the only per-pipeline control isolating the secrets,
+  and Open access disables it project-wide: any pipeline in the project,
+  including one authored on an attacker-controlled feature branch, can reference
+  the group and read every secret in it. A Contributor who can create or push a
+  pipeline exfiltrates production credentials with no authorization prompt.
 
 where:
   all_of:
-    - grant_all_pipelines == true
-    - contains_secrets == true
+    - "pipeline_permissions.all_pipelines == true"
+    - "secret_variable_names != []"
 
 evidence:
-  - "Variable group: {{ variable_group.name }}"
-  - "Secret variables: {{ variable_group.secret_variable_names }}"
-  - "Pipelines that can consume this group (project-wide): {{ variable_group.authorized_pipeline_count }}"
+  - "Variable group: {{ project }} › {{ name }}"
+  - "Secret variables: {{ secret_variable_names }}"
+  - "Open access (all pipelines authorized): {{ pipeline_permissions.all_pipelines }}"
 
 remediation_hint: >
   Disable "Grant access to all pipelines" on the variable group and enumerate
   only the specific pipelines that legitimately need these secrets under
-  "Pipeline permissions." Add a Branch control check on the variable group
-  so secrets are only injected when the consuming pipeline runs on a protected
+  Pipeline permissions. Add a Branch control check on the variable group so
+  secrets are only injected when the consuming pipeline runs on a protected
   branch. Rotate any secrets that may have been consumed by unintended pipelines.


### PR DESCRIPTION
## Summary

Adds 5 detection rules for ADO category 03 (secret isolation). These rules detect scenarios where secrets in variable groups and secure files are reachable from untrusted pipeline contexts — open-access grants, missing Branch control checks, over-permissioned Key Vault links, open-access secure files, and pipeline-scoped secrets leaking to ungated stages.

| File | Severity | Subject | What it detects |
|---|---|---|---|
| `variable-group-open-access.yaml` | High | variable_group | Variable group with secrets grants access to all pipelines |
| `no-branch-control-feature-branch-secret.yaml` | High | chain | Authorized pipeline with no Branch control lets feature branches read prod secrets |
| `keyvault-linked-group-broad-access.yaml` | High | chain | KV-linked variable group fronts a service connection with vault-wide Get/List |
| `secure-file-open-access.yaml` | High | secure_file | Secure file (signing key, keystore) grants access to all pipelines |
| `multistage-ungated-stage-reads-secret.yaml` | Medium | chain | Ungated early stage reads pipeline-scoped secret meant for gated deploy stage |

Fixes LAB-4744