### PR TITLE
GitLab detection rules: cat-01 poisoned pipeline execution

### DIFF
--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/environment-deploy-untrusted-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/environment-deploy-untrusted-ref.yaml
@@ -1,0 +1,23 @@
+id: cat-01/environment-deploy-untrusted-ref
+scenario_id: cat-01/11
+title: "Environment-scoped variables reach an attacker-nameable ref via a glob-gated deployment job"
+subject: job
+severity: high
+confidence: high
+description: >
+  A deployment job binds an `environment:` and an unprotected variable scoped to that environment
+  reaches it, yet the job's `rules:` gate on a broad glob rather than ref protection — so a
+  low-trust actor who creates a matching ref obtains the environment-scoped secret.
+
+where:
+  all_of:
+    - deploys_environment == true
+    - env_scoped_secret_reachable == true
+    - runs_on_untrusted_ref == true
+
+evidence:
+  - "Deployment job for environment `{{ environment_name }}` exposes an unprotected environment-scoped variable on an attacker-nameable ref."
+
+remediation_hint: >
+  Gate deployment jobs on a protected ref or a protected environment, and mark environment-scoped
+  secrets `protected`.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/fork-mr-pipeline-parent-job-token.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/fork-mr-pipeline-parent-job-token.yaml
@@ -1,0 +1,29 @@
+id: cat-01/fork-mr-pipeline-parent-job-token
+scenario_id: cat-01/03
+title: "Fork MR pipeline in the parent obtains a parent-scoped CI_JOB_TOKEN reaching allowlisted projects"
+subject: project
+severity: high
+confidence: high
+description: >
+  Fork MR pipelines may run in the parent, and the parent's inbound `CI_JOB_TOKEN` scope is
+  broad — disabled, or an allowlist reaching beyond its own trust boundary. A fork MR pipeline
+  wields a parent-scoped job token against every project that trusts the parent.
+
+where:
+  all_of:
+    - fork_pipelines_run_in_parent == true
+    - any_of:
+        - visibility == "public"
+        - visibility == "internal"
+        - forking_enabled == true
+    - any_of:
+        - inbound_job_token_scope_enabled == false
+        - job_token_allowlist.mode == "open"
+        - job_token_allowlist.mode == "group_scoped"
+
+evidence:
+  - "Fork MR pipelines run in the parent and inbound job-token scope is broad (enabled {{ inbound_job_token_scope_enabled }}, allowlist mode {{ job_token_allowlist.mode }}); a fork MR gets a parent-scoped CI_JOB_TOKEN reaching allowlisted projects."
+
+remediation_hint: >
+  Disable fork-pipeline-in-parent; enable inbound job-token scope and narrow the allowlist to
+  the minimum set of genuinely trusted projects.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/fork-mr-pipeline-parent-self-managed-runner.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/fork-mr-pipeline-parent-self-managed-runner.yaml
@@ -1,0 +1,26 @@
+id: cat-01/fork-mr-pipeline-parent-self-managed-runner
+scenario_id: cat-01/02
+title: "Fork MR pipeline in the parent project lands on a self-managed parent runner"
+subject: project
+severity: high
+confidence: medium
+description: >
+  Fork merge-request pipelines may run in the parent, and the parent has a self-managed
+  runner reachable by its pipelines. An unaudited fork MR pipeline executes attacker-controlled
+  config on the parent's own runner host (loot beyond the pipeline is the deferred host state).
+
+where:
+  all_of:
+    - fork_pipelines_run_in_parent == true
+    - has_self_managed_runner == true
+    - any_of:
+        - visibility == "public"
+        - visibility == "internal"
+        - forking_enabled == true
+
+evidence:
+  - "Fork MR pipelines run in the parent and the parent exposes a self-managed runner; an unaudited fork MR pipeline executes on the parent's runner host."
+
+remediation_hint: >
+  Disable fork-pipeline-in-parent, restrict self-managed runners to protected refs, and prefer
+  ephemeral runners so a poisoned job cannot persist on the host.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/fork-mr-pipeline-parent-variables.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/fork-mr-pipeline-parent-variables.yaml
@@ -1,0 +1,29 @@
+id: cat-01/fork-mr-pipeline-parent-variables
+scenario_id: cat-01/01
+title: "Fork MR pipeline in the parent project exposes parent CI/CD variables and job token"
+subject: project
+severity: critical
+confidence: high
+description: >
+  Fork merge-request pipelines may run in the parent project
+  (`ci_allow_fork_pipelines_to_run_in_parent_project`), and the project accepts MRs from
+  untrusted forks. A maintainer running an unaudited fork MR pipeline executes the fork
+  branch's `.gitlab-ci.yml` in the parent with the parent's project/group CI/CD variables
+  and a parent-scoped `CI_JOB_TOKEN` in scope — before any review or merge.
+
+where:
+  all_of:
+    - fork_pipelines_run_in_parent == true
+    - cicd_variables != []
+    - has_reachable_runner == true
+    - any_of:
+        - visibility == "public"
+        - visibility == "internal"
+        - forking_enabled == true
+
+evidence:
+  - "Fork MR pipelines run in the parent, the project accepts fork MRs (visibility {{ visibility }}, forking {{ forking_enabled }}), and parent CI/CD variables plus runners are in scope."
+
+remediation_hint: >
+  Disable `ci_allow_fork_pipelines_to_run_in_parent_project`, or require an explicit review
+  gate before running a fork MR pipeline, and mark sensitive variables `protected`.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/merged-results-pipeline-protected-resources.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/merged-results-pipeline-protected-resources.yaml
@@ -1,0 +1,26 @@
+id: cat-01/merged-results-pipeline-protected-resources
+scenario_id: cat-01/09
+title: "Merged-results / merge-train pipeline exposes protected variables/runners to a Developer's pre-merge code"
+subject: job
+severity: high
+confidence: high
+description: >
+  With `protect_merge_request_pipelines` disabled and merged-results / merge-train pipelines
+  enabled, a Developer's pre-merge code runs against the merged-results commit with the project's
+  protected variables or a protected runner in scope.
+
+where:
+  all_of:
+    - runs_on_merged_result == true
+    - mr_pipelines_unprotected == true
+    - developer_controls_mr_branches == true
+    - any_of:
+        - reads_protected_variable == true
+        - targets_protected_runner == true
+
+evidence:
+  - "Merged-results pipeline runs a Developer's pre-merge code with protected resources in scope while MR-pipeline protection is off."
+
+remediation_hint: >
+  Keep `protect_merge_request_pipelines` enabled; restrict who can open MRs that build against
+  protected refs.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/mr-pipeline-protected-resources-loose-scheme.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/mr-pipeline-protected-resources-loose-scheme.yaml
@@ -1,0 +1,26 @@
+id: cat-01/mr-pipeline-protected-resources-loose-scheme
+scenario_id: cat-01/08
+title: "MR pipeline grants protected variables/runners to a Developer via a loose protected-branch scheme"
+subject: job
+severity: high
+confidence: high
+description: >
+  With `protect_merge_request_pipelines` disabled and a protected-branch scheme loose enough
+  that a Developer controls both the MR source and target, a `merge_request_event` job receives
+  the project's protected variables or a protected runner from a Developer's pre-review code.
+
+where:
+  all_of:
+    - triggers ∋ {merge_request_event}
+    - mr_pipelines_unprotected == true
+    - developer_controls_mr_branches == true
+    - any_of:
+        - reads_protected_variable == true
+        - targets_protected_runner == true
+
+evidence:
+  - "merge_request_event job receives protected resources (protected variable {{ reads_protected_variable }}, protected runner {{ targets_protected_runner }}) because MR-pipeline protection is off and a Developer controls both MR branches."
+
+remediation_hint: >
+  Keep `protect_merge_request_pipelines` enabled and tighten protected-branch push/merge access
+  so a Developer cannot control both MR endpoints.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/oidc-id-tokens-untrusted-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/oidc-id-tokens-untrusted-ref.yaml
@@ -1,0 +1,23 @@
+id: cat-01/oidc-id-tokens-untrusted-ref
+scenario_id: cat-01/10
+title: "OIDC id_tokens job fires on an attacker-nameable ref (glob gate, not ref protection)"
+subject: job
+severity: high
+confidence: low
+description: >
+  A job that mints an OIDC `id_tokens:` is reachable on an attacker-nameable ref because its
+  `rules:` gate on a broad glob rather than a protected-ref check. A low-trust actor mints the
+  token; exploitability hinges on the deferred cloud/Vault trust policy behind it.
+
+where:
+  all_of:
+    - mints_id_token == true
+    - runs_on_untrusted_ref == true
+    - protected_ref_gate != "strong"
+
+evidence:
+  - "id_tokens job is reachable on an attacker-nameable ref (ref gate {{ protected_ref_gate }}); a low-trust actor can mint the OIDC token."
+
+remediation_hint: >
+  Gate id_tokens jobs on a protected-ref check ($CI_COMMIT_REF_PROTECTED) or a protected
+  environment, and bind the cloud trust policy to the ref or environment claim.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-commit-message.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-commit-message.yaml
@@ -1,0 +1,27 @@
+id: cat-01/shell-injection-commit-message
+scenario_id: cat-01/06
+title: "Shell injection from a commit message interpolated unquoted into a job script"
+subject: job
+severity: high
+confidence: high
+description: >
+  A job interpolates `$CI_COMMIT_MESSAGE` / `$CI_COMMIT_TITLE` / `$CI_COMMIT_DESCRIPTION`
+  unquoted into its script and is reachable by a lower-trust pusher's commit, with secrets or a
+  self-managed runner in scope.
+
+where:
+  all_of:
+    - script_uses_untrusted_input == true
+    - attacker_input_fields ∋ {commit_message}
+    - runs_on_untrusted_ref == true
+    - any_of:
+        - reads_cicd_variable == true
+        - mints_id_token == true
+        - targets_self_managed_runner == true
+
+evidence:
+  - "Job interpolates an unquoted commit message ({{ attacker_input_fields }}) and is reachable by a lower-trust pusher's commit with secrets or a self-managed runner in scope."
+
+remediation_hint: >
+  Do not interpolate commit messages into a shell; use quoted variables. Restrict secret-bearing
+  jobs to protected refs.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-component-input.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-component-input.yaml
@@ -1,0 +1,26 @@
+id: cat-01/shell-injection-component-input
+scenario_id: cat-01/07
+title: "Shell injection from an unconstrained CI component/template input"
+subject: job
+severity: high
+confidence: high
+description: >
+  A job interpolates an unconstrained `$[[ inputs.<name> ]]` — the matching `spec:inputs`
+  declares no `regex`, no `options`, and no constraining type — into its script, and the input
+  is settable by a lower-trust caller, with secrets or a self-managed runner in scope.
+
+where:
+  all_of:
+    - script_uses_untrusted_input == true
+    - attacker_input_fields ∋ {component_input}
+    - any_of:
+        - reads_cicd_variable == true
+        - mints_id_token == true
+        - targets_self_managed_runner == true
+
+evidence:
+  - "Component/template job interpolates an unconstrained input ($[[ inputs.* ]]) into a shell with secrets or a self-managed runner in scope."
+
+remediation_hint: >
+  Constrain component inputs with `spec:inputs` `regex` / `options` / a typed value, and never
+  interpolate a raw input into a shell.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-mr-metadata.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-mr-metadata.yaml
@@ -1,0 +1,28 @@
+id: cat-01/shell-injection-mr-metadata
+scenario_id: cat-01/04
+title: "Shell injection from merge-request metadata interpolated unquoted into a job script"
+subject: job
+severity: high
+confidence: high
+description: >
+  A job interpolates attacker-supplied MR metadata (`$CI_MERGE_REQUEST_TITLE` /
+  `_DESCRIPTION` / `_LABELS` / `_SOURCE_BRANCH_NAME`) unquoted into its script and runs on
+  `merge_request_event`, so an MR author reaches it before review — with secrets or a
+  self-managed runner in scope.
+
+where:
+  all_of:
+    - script_uses_untrusted_input == true
+    - attacker_input_fields ∋ {mr_metadata}
+    - triggers ∋ {merge_request_event}
+    - any_of:
+        - reads_cicd_variable == true
+        - mints_id_token == true
+        - targets_self_managed_runner == true
+
+evidence:
+  - "Job interpolates unquoted MR metadata ({{ attacker_input_fields }}) on merge_request_event with secrets or a self-managed runner in scope."
+
+remediation_hint: >
+  Never interpolate MR metadata into a shell; bind it to a quoted environment variable and
+  validate it. Gate secret-bearing jobs on protected refs.

--- a/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-ref-name.yaml
+++ b/internal/detection-rules/gitlab/cat-01-poisoned-pipeline-execution/shell-injection-ref-name.yaml
@@ -1,0 +1,27 @@
+id: cat-01/shell-injection-ref-name
+scenario_id: cat-01/05
+title: "Shell injection from a branch or tag name interpolated unquoted into a job script"
+subject: job
+severity: high
+confidence: high
+description: >
+  A job interpolates `$CI_COMMIT_REF_NAME` / `$CI_COMMIT_BRANCH` / `$CI_COMMIT_TAG` unquoted
+  into its script and is reachable by a lower-trust actor who can create a matching ref, with
+  secrets or a self-managed runner in scope.
+
+where:
+  all_of:
+    - script_uses_untrusted_input == true
+    - attacker_input_fields ∋ {ref_name}
+    - runs_on_untrusted_ref == true
+    - any_of:
+        - reads_cicd_variable == true
+        - mints_id_token == true
+        - targets_self_managed_runner == true
+
+evidence:
+  - "Job interpolates an unquoted ref name ({{ attacker_input_fields }}) and is reachable on an attacker-nameable ref with secrets or a self-managed runner in scope."
+
+remediation_hint: >
+  Do not interpolate ref names into a shell; use quoted variables. Restrict secret-bearing jobs
+  to protected refs.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-01 — poisoned pipeline execution**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Covers:
- Fork merge-request pipelines run in the parent project — exposing parent CI/CD variables, a self-managed parent runner, or a parent-scoped `CI_JOB_TOKEN`.
- Shell injection from untrusted input interpolated unquoted into a job script — MR metadata, branch/tag name, commit message, and unconstrained component/template input.
- MR and merged-results/merge-train pipelines granting protected variables or runners to a Developer via a loose protected-branch scheme.
- OIDC `id_tokens:` and environment-scoped deployment jobs firing on an attacker-nameable ref (glob gate, not ref protection).

Part of LAB-4980.
