### PR TITLE
GitLab detection rules: cat-02 unsafe includes supply chain

### DIFF
--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/bare-ref-include-shadowed-by-tag.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/bare-ref-include-shadowed-by-tag.yaml
@@ -1,0 +1,22 @@
+id: cat-02/bare-ref-include-shadowed-by-tag
+scenario_id: cat-02/09
+title: "Bare ref in an include or trigger is shadowed by a lower-trust same-named tag"
+subject: job
+severity: high
+confidence: medium
+description: >
+  An `include:`/`trigger:` `ref:` is a bare name (neither `refs/heads|tags/...` nor a 40-hex SHA)
+  that matches a protected branch but not a protected tag in the referenced project, whose members
+  include Developers — so a Developer creates a same-named tag that GitLab's ambiguous-ref
+  resolution may select over the branch.
+
+where:
+  all_of:
+    - include_bare_ref_shadowable == true
+
+evidence:
+  - "A bare include/trigger ref matches a protected branch but not a protected tag in a referenced project with Developer members, allowing a shadowing tag."
+
+remediation_hint: >
+  Use a fully-qualified ref (`refs/heads/<branch>`) or a 40-hex SHA, or protect the tag namespace
+  on the referenced project.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/branch-name-controlled-include.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/branch-name-controlled-include.yaml
@@ -1,0 +1,25 @@
+id: cat-02/branch-name-controlled-include
+scenario_id: cat-02/05
+title: "Branch-name-controlled include steers the pipeline to attacker-chosen config"
+subject: job
+severity: high
+confidence: high
+description: >
+  An `include:` `ref`/`file`/`remote` string interpolates a user-controllable predefined variable
+  (`CI_COMMIT_REF_NAME`, `CI_COMMIT_TAG`, `CI_PROJECT_PATH`, …), so a lower-trust actor who names a
+  ref selects the config that runs — with variables or a usable job token in scope.
+
+where:
+  all_of:
+    - include_ref_interpolated == true
+    - any_of:
+        - triggers ∋ {merge_request_event}
+        - reads_cicd_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "Pipeline builds an include path from a user-controllable variable, letting an attacker-named ref select the config."
+
+remediation_hint: >
+  Never interpolate user-controllable variables into an `include:` path; pin includes to fixed
+  refs/files.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/catalog-component-mutable-version.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/catalog-component-mutable-version.yaml
@@ -1,0 +1,24 @@
+id: cat-02/catalog-component-mutable-version
+scenario_id: cat-02/04
+title: "CI/CD Catalog component at a mutable version ships attacker code into consumer pipelines"
+subject: job
+severity: high
+confidence: medium
+description: >
+  The pipeline pulls an `include:component` at a mutable `@version` (`~latest`, a branch, a
+  partial semver, or a movable tag) from a third-party publisher outside the consumer's trust
+  boundary — so a new component release runs in the consumer's secret/token context.
+
+where:
+  all_of:
+    - mutable_component_version == true
+    - any_of:
+        - reads_protected_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "Pipeline includes a third-party catalog component at a mutable @version, with protected variables or a broad job token in scope."
+
+remediation_hint: >
+  Pin components to a 40-hex commit SHA, and prefer components from your own group or a vetted
+  publisher.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/cicd-step-function-cross-trust-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/cicd-step-function-cross-trust-ref.yaml
@@ -1,0 +1,23 @@
+id: cat-02/cicd-step-function-cross-trust-ref
+scenario_id: cat-02/08
+title: "CI/CD Step / Function referenced from a git ref a less-trusted party can write"
+subject: job
+severity: high
+confidence: high
+description: >
+  A `run:` step references a remote `step`/`func` at a mutable version, a lower-trust-writable
+  ref, or a third-party host — so that party's code executes in the consuming job with protected
+  variables or a broad job token in scope.
+
+where:
+  all_of:
+    - remote_step_untrusted_ref == true
+    - any_of:
+        - reads_protected_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "A `run:` step/func resolves to a remote git ref a lower-trust party can write, with protected variables or a broad job token in scope."
+
+remediation_hint: >
+  Pin remote steps/functions to a 40-hex commit SHA from a trusted repo, or use a local step.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/dynamic-child-pipeline-cross-project-artifact.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/dynamic-child-pipeline-cross-project-artifact.yaml
@@ -1,0 +1,24 @@
+id: cat-02/dynamic-child-pipeline-cross-project-artifact
+scenario_id: cat-02/06
+title: "Dynamic child pipeline built from a cross-project artifact from a lower-trust project"
+subject: job
+severity: high
+confidence: high
+description: >
+  A `trigger: include:` builds a child pipeline from an artifact produced by a generator job that
+  pulls a cross-project artifact from a lower-trust project/ref — so that project's content
+  becomes the child pipeline definition, run with protected variables or a broad job token.
+
+where:
+  all_of:
+    - child_pipeline_from_cross_project_artifact == true
+    - any_of:
+        - reads_protected_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "Child pipeline is generated from a cross-project artifact pulled from a lower-trust project, with protected variables or a broad job token in scope."
+
+remediation_hint: >
+  Generate child pipelines only from artifacts produced within your trust boundary on a protected
+  ref, and pin cross-project `needs:` to trusted refs.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/pipeline-execution-policy-writable-project.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/pipeline-execution-policy-writable-project.yaml
@@ -1,0 +1,21 @@
+id: cat-02/pipeline-execution-policy-writable-project
+scenario_id: cat-02/07
+title: "Pipeline execution policy sourcing CI from a mutable/writable policy project"
+subject: project
+severity: critical
+confidence: high
+description: >
+  A `pipeline_execution_policy` sources its CI content from a policy project at a mutable or
+  lower-trust-writable ref, and the policy is enforced over projects whose secret trust exceeds
+  the write access on that ref — so a lower-trust actor injects CI into the enforced projects.
+
+where:
+  all_of:
+    - pipeline_execution_policy_from_mutable_project == true
+
+evidence:
+  - "A pipeline_execution_policy sources CI content from a mutable / lower-trust-writable policy project, enforced over higher-trust projects."
+
+remediation_hint: >
+  Pin the policy's `content:` include to a 40-hex SHA on a protected ref, and restrict write
+  access on the policy project to the enforced projects' trust tier.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/project-include-mutable-cross-trust-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/project-include-mutable-cross-trust-ref.yaml
@@ -1,0 +1,25 @@
+id: cat-02/project-include-mutable-cross-trust-ref
+scenario_id: cat-02/03
+title: "include:project at a mutable ref lets a lower-trust template author poison a higher-trust pipeline"
+subject: job
+severity: critical
+confidence: high
+description: >
+  The pipeline pulls config via `include:project` at a mutable ref (branch, `~latest`, absent,
+  or an unprotected tag) from a project in a different trust scope where a lower-trust member can
+  push the tracked ref — so that author's code runs in the consumer's protected/secret context.
+
+where:
+  all_of:
+    - mutable_cross_trust_project_include == true
+    - any_of:
+        - runs_on_protected_ref == true
+        - reads_protected_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "Pipeline includes project CI config at a mutable cross-trust ref a lower-trust author can push, reaching a protected ref / protected variables / broad job token."
+
+remediation_hint: >
+  Pin `include:project` to a 40-hex commit SHA or a protected tag, and only include from projects
+  within your trust boundary.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/remote-include-cleartext-http.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/remote-include-cleartext-http.yaml
@@ -1,0 +1,24 @@
+id: cat-02/remote-include-cleartext-http
+scenario_id: cat-02/02
+title: "Cleartext (http) remote include with no integrity pin allows MITM CI-config injection"
+subject: job
+severity: high
+confidence: low
+description: >
+  The pipeline pulls CI config via an `include:remote:` over `http://` with no `integrity:` pin,
+  so an on-path attacker can rewrite the config in transit. Fires even for a first-party host,
+  since the transport itself is the weakness.
+
+where:
+  all_of:
+    - remote_include_cleartext == true
+    - any_of:
+        - runs_on_protected_ref == true
+        - reads_protected_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "Pipeline includes remote CI config over cleartext http with no `integrity:` pin, reaching a protected ref / protected variables / broad job token."
+
+remediation_hint: >
+  Use `https://` and pin an `integrity:` hash on every remote include.

--- a/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/remote-include-untrusted-host.yaml
+++ b/internal/detection-rules/gitlab/cat-02-unsafe-includes-supply-chain/remote-include-untrusted-host.yaml
@@ -1,0 +1,26 @@
+id: cat-02/remote-include-untrusted-host
+scenario_id: cat-02/01
+title: "Unpinned remote include to an external host executes attacker-served CI config"
+subject: job
+severity: high
+confidence: medium
+description: >
+  The pipeline pulls CI config via `include:remote:` from a host that is not the GitLab
+  instance or a first-party domain, with no `integrity:` pin — so whoever controls that host
+  serves the config into a pipeline that reaches a protected ref, protected variables, or a
+  broad job token.
+
+where:
+  all_of:
+    - remote_include_untrusted_host == true
+    - any_of:
+        - runs_on_protected_ref == true
+        - reads_protected_variable == true
+        - outbound_job_token_broad == true
+
+evidence:
+  - "Pipeline includes remote CI config from an untrusted host with no `integrity:` pin, reaching a protected ref / protected variables / broad job token."
+
+remediation_hint: >
+  Pin the include to a first-party host and an `integrity:` hash, or vendor the config into the
+  project.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-02 — unsafe includes supply chain**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Unpinned remote include to an external host executes attacker-served CI config
- Cleartext (http) remote include with no integrity pin allows MITM CI-config injection
- include:project at a mutable ref lets a lower-trust template author poison a higher-trust pipeline
- CI/CD Catalog component at a mutable version ships attacker code into consumer pipelines
- Branch-name-controlled include steers the pipeline to attacker-chosen config
- Dynamic child pipeline built from a cross-project artifact from a lower-trust project
- Pipeline execution policy sourcing CI from a mutable/writable policy project
- CI/CD Step / Function referenced from a git ref a less-trusted party can write
- Bare ref in an include or trigger is shadowed by a lower-trust same-named tag

Part of LAB-4980.
