### PR TITLE
GitLab detection rules: cat-05 protected branch tag pushrule bypass

### DIFF
--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/developer-creatable-protected-tag.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/developer-creatable-protected-tag.yaml
@@ -1,0 +1,25 @@
+id: cat-05/developer-creatable-protected-tag
+scenario_id: cat-05/11
+title: "Developer in a protected tag's \"Allowed to create\" runs a privileged tag pipeline on a protected ref"
+subject: project
+severity: high
+confidence: high
+description: >
+  A protected-tag rule's `create_access_levels` includes the Developer role (access level 30) — or
+  a group/user entry — for a pattern matching the tag scheme used by privileged tag jobs, the
+  `.gitlab-ci.yml` has jobs gated on `$CI_COMMIT_TAG` / `only: tags` that consume a protected
+  variable, and a `protected: true` variable is in scope (protected variables apply to protected
+  tags). Because create permission also controls pipeline execution, a Developer creates a matching
+  tag, runs the release pipeline on a protected ref, and reads the tag-scoped protected variable.
+
+where:
+  all_of:
+    - developer_creatable_protected_tag == true
+    - protected_var_scoped_to_tag_pipeline == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has a protected-tag rule granting Developer create for a pattern used by tag jobs, and a protected CI/CD variable is scoped to that tag pipeline."
+
+remediation_hint: >
+  Restrict the protected-tag rule's "Allowed to create" to Maintainers so lower-trust roles cannot
+  create tags that run privileged tag pipelines on a protected ref.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/developer-merge-access-self-merge.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/developer-merge-access-self-merge.yaml
@@ -1,0 +1,25 @@
+id: cat-05/developer-merge-access-self-merge
+scenario_id: cat-05/02
+title: "Developer role in a protected branch's merge access self-merges to a CI-trusted ref"
+subject: project
+severity: high
+confidence: high
+description: >
+  A protected-branch rule on a CI-trusted ref lists the Developer role (access level 30) — or a
+  group/user entry — under "Allowed to merge", no approval rule blocks the author from satisfying
+  it alone, and a `protected: true` CI/CD variable is scoped to that ref. A Developer opens an MR
+  editing `.gitlab-ci.yml` into the protected branch and self-merges it; the merged pipeline runs
+  on a protected ref and receives the protected variable.
+
+where:
+  all_of:
+    - developer_mergeable_protected_branch == true
+    - author_can_self_merge == true
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} grants Developer merge access to a protected branch with no author-blocking approval rule, and a protected CI/CD variable is scoped to that ref."
+
+remediation_hint: >
+  Restrict the protected branch's "Allowed to merge" to Maintainers, or add a required-approval
+  rule that the MR author cannot satisfy alone.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/developer-push-access-protected-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/developer-push-access-protected-branch.yaml
@@ -1,0 +1,24 @@
+id: cat-05/developer-push-access-protected-branch
+scenario_id: cat-05/01
+title: "Developer role in a protected branch's push access reads protected CI/CD variables"
+subject: project
+severity: high
+confidence: high
+description: >
+  A protected-branch rule on a CI-trusted ref lists the Developer role (access level 30) — or
+  a group/user entry — under "Allowed to push and merge", and a `protected: true` CI/CD variable
+  is scoped to that ref. A Developer pushes attacker-authored `.gitlab-ci.yml` straight onto the
+  trusted ref with no merge request; the branch pipeline runs on a protected ref and receives the
+  protected variable the Developer→Maintainer boundary was meant to withhold.
+
+where:
+  all_of:
+    - developer_pushable_protected_branch == true
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has a protected branch whose push access includes Developer, and a protected CI/CD variable is scoped to that ref."
+
+remediation_hint: >
+  Remove the Developer role (and broad group/user entries) from the protected branch's "Allowed to
+  push and merge", restricting direct pushes to that ref to Maintainers.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/force-push-enabled-protected-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/force-push-enabled-protected-branch.yaml
@@ -1,0 +1,24 @@
+id: cat-05/force-push-enabled-protected-branch
+scenario_id: cat-05/07
+title: "Force push enabled on a protected branch lets a low-trust pusher rewrite the trusted ref tip"
+subject: project
+severity: high
+confidence: high
+description: >
+  A protected-branch rule on a CI-trusted ref has `allow_force_push: true` and lists a non-Maintainer
+  (Developer role, or a broad group/user entry) under "Allowed to push and merge", and the ref is
+  CI-trusted (a protected variable is scoped to it or it feeds a deploy pipeline). The low-trust
+  pusher can force-push a rewritten tip — substituting a commit no reviewer saw — that then executes
+  in the protected-ref pipeline.
+
+where:
+  all_of:
+    - force_push_by_low_trust_pusher == true
+    - ref_is_ci_trusted == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has a protected branch with `allow_force_push: true` whose push list includes a non-Maintainer, on a CI-trusted ref."
+
+remediation_hint: >
+  Disable "Allowed to force push" on the protected branch rule, or restrict its push list to
+  Maintainers.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/group-lowered-default-branch-protection.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/group-lowered-default-branch-protection.yaml
@@ -1,0 +1,26 @@
+id: cat-05/group-lowered-default-branch-protection
+scenario_id: cat-05/06
+title: "Group default_branch_protection_defaults lowered to Partially protected makes inherited default branches Developer-writable"
+subject: project
+severity: high
+confidence: high
+description: >
+  A group's `default_branch_protection_defaults` was lowered by an Owner so `allowed_to_push`
+  includes Developer (access level 30) with `allow_force_push: false`. A project under the group
+  inherits a default branch that is still a protected ref but Developer-writable, with no stricter
+  project override, and a `protected: true` CI/CD variable scoped to it. A Developer pushes
+  unreviewed commits directly to the default branch and its pipeline reads the protected variable;
+  the root cause is a group-governance setting inherited at project creation.
+
+where:
+  all_of:
+    - inherited_default_branch_developer_pushable == true
+    - inherited_protection_source == "group"
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} inherits a group Partially-protected default branch (Developer push, still protected) with no stricter override, and a protected CI/CD variable is scoped to it."
+
+remediation_hint: >
+  Restore the group's `default_branch_protection_defaults` to Fully protected, or add a stricter
+  project-level protected-branch rule on the default branch.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/instance-lowered-default-branch-protection.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/instance-lowered-default-branch-protection.yaml
@@ -1,0 +1,26 @@
+id: cat-05/instance-lowered-default-branch-protection
+scenario_id: cat-05/05
+title: "Instance default-branch protection lowered to Partially protected makes inherited default branches Developer-writable"
+subject: project
+severity: high
+confidence: high
+description: >
+  A self-managed instance's default-branch protection was lowered to Partially protected, so a
+  project's inherited default branch has a protected-branch rule whose push access includes
+  Developer (access level 30) with `allow_force_push: false` — still a protected ref — and no
+  stricter project override. A `protected: true` CI/CD variable is scoped to the default branch. A
+  Developer pushes unreviewed commits directly to it and its pipeline reads the protected variable;
+  the root cause is a single instance-governance setting projects inherit at creation.
+
+where:
+  all_of:
+    - inherited_default_branch_developer_pushable == true
+    - inherited_protection_source == "instance"
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} inherits an instance Partially-protected default branch (Developer push, still protected) with no stricter override, and a protected CI/CD variable is scoped to it."
+
+remediation_hint: >
+  Restore the instance default-branch protection to Fully protected, or add a stricter
+  project-level protected-branch rule so Developers cannot push to the default branch.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/no-one-push-defeated-by-branch-creation.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/no-one-push-defeated-by-branch-creation.yaml
@@ -1,0 +1,24 @@
+id: cat-05/no-one-push-defeated-by-branch-creation
+scenario_id: cat-05/09
+title: "\"No one can push\" defeated by branch creation via an overlapping merge-access wildcard rule"
+subject: project
+severity: high
+confidence: high
+description: >
+  A protected pattern has push access = No one (empty `push_access_levels`), but a matching rule
+  grants merge access to the Developer role (access level 30) — or a group/user entry — and GitLab
+  lets a user allowed to merge create a matching branch. A `protected: true` CI/CD variable is
+  scoped to the pattern. The Developer creates a fresh branch matching the "No-one-push" pattern; it
+  is protected from creation, so its first pipeline runs on a protected ref and reads the variable.
+
+where:
+  all_of:
+    - no_one_push_creatable_via_merge == true
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has a push=No-one protected pattern with an overlapping merge-access rule granting Developer, and a protected CI/CD variable is scoped to that pattern."
+
+remediation_hint: >
+  Restrict the overlapping rule's merge access to Maintainers so lower-trust roles cannot create a
+  branch matching a push=No-one pattern.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/protected-runner-via-writable-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/protected-runner-via-writable-branch.yaml
@@ -1,0 +1,24 @@
+id: cat-05/protected-runner-via-writable-branch
+scenario_id: cat-05/04
+title: "Developer-writable protected branch reaches a protected runner (code execution on the runner)"
+subject: project
+severity: high
+confidence: medium
+description: >
+  A protected-branch rule on a CI-trusted ref grants push or merge to the Developer role (access
+  level 30) — or a group/user entry — and a protected (`ref_protected`) self-managed runner is
+  reachable by that ref's pipelines. A Developer lands attacker-authored `.gitlab-ci.yml` on the
+  protected ref and obtains job execution on a runner reserved for protected-ref pipelines. What
+  that execution reaches on the host (cat-08) is deferred, hence medium confidence.
+
+where:
+  all_of:
+    - developer_writable_protected_branch == true
+    - has_protected_self_managed_runner == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} grants Developer push or merge to a protected branch, and a protected self-managed runner is reachable by that ref's pipelines."
+
+remediation_hint: >
+  Restrict the protected branch's push and merge access to Maintainers, or stop routing protected
+  self-managed runners to refs that lower-trust roles can write.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-created-protected-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-created-protected-branch.yaml
@@ -1,0 +1,24 @@
+id: cat-05/wildcard-created-protected-branch
+scenario_id: cat-05/03
+title: "Developer creates a new branch matching a wildcard protected-branch rule and runs a protected-ref pipeline"
+subject: project
+severity: high
+confidence: high
+description: >
+  A wildcard protected-branch rule (`*`, `release-*`) grants push or merge to the Developer role
+  (access level 30) — or a group/user entry — and a `protected: true` CI/CD variable is scoped to
+  that pattern. A Developer creates a fresh branch matching the wildcard; it is protected from
+  creation, so its first pipeline runs on a protected ref and receives the protected variable
+  without any pre-existing trusted branch.
+
+where:
+  all_of:
+    - developer_creatable_wildcard_branch == true
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has a wildcard protected-branch rule granting Developer push or merge, and a protected CI/CD variable is scoped to that pattern."
+
+remediation_hint: >
+  Restrict wildcard protected-branch rules' push and merge access to Maintainers so Developers
+  cannot create matching branches that instantiate a protected ref on demand.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-shadow-grants-force-push.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-shadow-grants-force-push.yaml
@@ -1,0 +1,24 @@
+id: cat-05/wildcard-shadow-grants-force-push
+scenario_id: cat-05/10
+title: "Overlapping wildcard rule grants force push a stricter exact-name rule denied (most-permissive wins)"
+subject: project
+severity: high
+confidence: high
+description: >
+  Two or more protected-branch rules match one CI-trusted branch; the narrowest matching rule sets
+  `allow_force_push: false` but a broader matching rule sets `allow_force_push: true`, so
+  most-permissive-wins effectively grants force push. A non-Maintainer (Developer, or broad group)
+  is in the effective (unioned) push list, and the ref is CI-trusted. The low-trust actor force-pushes
+  a rewritten tip that runs on the protected ref and feeds the ref's deploy automation.
+
+where:
+  all_of:
+    - force_push_shadowed_by_permissive_rule == true
+    - ref_is_ci_trusted == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has overlapping protected-branch rules where a broader rule enables force push the narrowest denies, a non-Maintainer is in the effective push list, and the ref is CI-trusted."
+
+remediation_hint: >
+  Set `allow_force_push: false` on every rule matching the branch, and narrow the overlapping
+  wildcard's push list, since force push resolves most-permissive-wins.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-shadow-grants-push.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-shadow-grants-push.yaml
@@ -1,0 +1,24 @@
+id: cat-05/wildcard-shadow-grants-push
+scenario_id: cat-05/08
+title: "Overlapping wildcard rule grants push to a branch a stricter exact-name rule was meant to lock (most-permissive wins)"
+subject: project
+severity: high
+confidence: high
+description: >
+  Two or more protected-branch rules match one CI-trusted branch, and GitLab's most-permissive-wins
+  resolution means the effective (unioned) push access is broader than the narrowest matching rule —
+  a Developer or broad group appears in the effective push list for a branch the operator's strict
+  exact-name rule reserved for Maintainers. A `protected: true` CI/CD variable is scoped to the
+  shadowed branch. The Developer pushes to the "locked" branch and reads the protected variable.
+
+where:
+  all_of:
+    - push_access_shadowed_by_permissive_rule == true
+    - protected_var_scoped_to_writable_ref == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has overlapping protected-branch rules whose most-permissive push access is broader than the narrowest matching rule, and a protected CI/CD variable is scoped to that ref."
+
+remediation_hint: >
+  Narrow or remove the overlapping wildcard rule so every matching rule's push access agrees with
+  the intended lock, since most-permissive resolution governs push.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-shadow-protected-tag-creation.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/wildcard-shadow-protected-tag-creation.yaml
@@ -1,0 +1,25 @@
+id: cat-05/wildcard-shadow-protected-tag-creation
+scenario_id: cat-05/12
+title: "Overlapping wildcard protected-tag rule grants a Developer create access a stricter rule denied (most-permissive wins)"
+subject: project
+severity: high
+confidence: high
+description: >
+  Two or more protected-tag rules match a release tag pattern used by tag jobs, and most-permissive
+  resolution means the effective (unioned) `create_access_levels` is broader than the narrowest
+  matching rule — a Developer or broad group can create tags the operator's strict rule reserved for
+  Maintainers. The `.gitlab-ci.yml` has `$CI_COMMIT_TAG` / `only: tags` jobs on the shadowed pattern
+  consuming a `protected: true` variable. The Developer creates a matching tag, runs the release
+  pipeline on a protected ref, and reads the tag-scoped protected variable.
+
+where:
+  all_of:
+    - create_access_shadowed_by_permissive_tag_rule == true
+    - protected_var_scoped_to_tag_pipeline == true
+
+evidence:
+  - "Project {{ _provenance.project_path }} has overlapping protected-tag rules whose most-permissive create access is broader than the narrowest matching rule, joined with tag jobs consuming a protected CI/CD variable."
+
+remediation_hint: >
+  Narrow or remove the overlapping wildcard protected-tag rule so every matching rule's create
+  access agrees with the intended lock, since most-permissive resolution governs tag creation.

--- a/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/writable-protected-ref-feeds-deferred-deploy-credential.yaml
+++ b/internal/detection-rules/gitlab/cat-05-protected-branch-tag-pushrule-bypass/writable-protected-ref-feeds-deferred-deploy-credential.yaml
@@ -1,0 +1,29 @@
+id: cat-05/writable-protected-ref-feeds-deferred-deploy-credential
+scenario_id: cat-05/13
+title: "Low-trust write access to a deploy-triggering protected ref (deploy credential deferred)"
+subject: project
+severity: high
+confidence: low
+description: >
+  A protected-branch rule on a CI-trusted ref grants push or merge to the Developer role (access
+  level 30) — or a group/user entry — and that ref's pipeline carries a deploy indicator whose
+  credential is minted or scoped outside GitLab (an `id_tokens:` OIDC block or a protected
+  `environment:`), while no `protected: true` variable and no protected runner is collectably scoped
+  to the ref. A Developer lands attacker-authored `.gitlab-ci.yml` on the protected ref and inherits
+  the deploy identity. Whether the OIDC role is assumable or what the environment credential unlocks
+  is deferred cloud/environment state (cat-10/cat-07), hence low confidence.
+
+where:
+  all_of:
+    - developer_writable_protected_branch == true
+    - ref_has_deferred_deploy_identity == true
+    - protected_var_scoped_to_writable_ref != true
+    - has_protected_self_managed_runner != true
+
+evidence:
+  - "Project {{ _provenance.project_path }} grants Developer write to a protected ref whose pipeline mints an OIDC id_token or binds a protected environment, with no collectable protected variable or protected runner scoped to the ref."
+
+remediation_hint: >
+  Restrict the protected branch's push and merge access to Maintainers, and confirm the deferred
+  deploy identity (OIDC trust policy / protected environment credential) is not assumable from this
+  ref.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-05 — protected branch tag pushrule bypass**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Developer role in a protected branch's push access reads protected CI/CD variables
- Developer role in a protected branch's merge access self-merges to a CI-trusted ref
- Developer creates a new branch matching a wildcard protected-branch rule and runs a protected-ref pipeline
- Developer-writable protected branch reaches a protected runner (code execution on the runner)
- Instance default-branch protection lowered to Partially protected makes inherited default branches Developer-writable
- Group default_branch_protection_defaults lowered to Partially protected makes inherited default branches Developer-writable
- Force push enabled on a protected branch lets a low-trust pusher rewrite the trusted ref tip
- Overlapping wildcard rule grants push to a branch a stricter exact-name rule was meant to lock (most-permissive wins)
- "No one can push" defeated by branch creation via an overlapping merge-access wildcard rule
- Overlapping wildcard rule grants force push a stricter exact-name rule denied (most-permissive wins)
- Developer in a protected tag's "Allowed to create" runs a privileged tag pipeline on a protected ref
- Overlapping wildcard protected-tag rule grants a Developer create access a stricter rule denied (most-permissive wins)
- Low-trust write access to a deploy-triggering protected ref (deploy credential deferred)

Part of LAB-4981.
