### PR TITLE
GitLab detection rules: cat-06 merge request approval bypass

### DIFF
--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-broad-bypass.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-broad-bypass.yaml
@@ -1,0 +1,24 @@
+id: cat-06/approval-policy-broad-bypass
+scenario_id: cat-06/12
+title: "MR approval policy exempts a broadly-held actor via bypass_settings"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  An enabled approval policy with a `require_approval` action carries a `bypass_settings` block that
+  exempts a broadly-held or lower-trust actor — the Developer role, a large group, a shared token or
+  service account, or a permissive branch pattern like `*`. The policy appears to require security
+  approval for everyone but waives it for a large population, so an exempted Developer merges
+  policy-violating code to the protected target branch.
+
+where:
+  all_of:
+    - approval_policy.enabled == true
+    - approval_policy.bypass_actor_broad == true
+
+evidence:
+  - "An enabled approval policy exempts a broadly-held actor via bypass_settings ({{ approval_policy.bypass_actor_broad }}), so lower-trust authors skip the required security approval on the protected branch."
+
+remediation_hint: >
+  Narrow `bypass_settings` to a single break-glass identity, and remove role/group/branch-pattern
+  exemptions that cover a broad population.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-fail-open.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-fail-open.yaml
@@ -1,0 +1,25 @@
+id: cat-06/approval-policy-fail-open
+scenario_id: cat-06/09
+title: "MR approval policy fails open (fallback_behavior: fail_open) when its named scanner never runs"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  An enabled Ultimate approval policy has a `scan_finding` rule naming a scanner, a `require_approval`
+  action, and `fallback_behavior == "fail_open"` (a deliberate change from the safe `fail_closed`
+  default). The named scanner has no job/include in the target project's resolved pipeline, so the
+  rule can never evaluate and fail-open waives the required approval on every MR to the protected
+  branch — a silent no-op gate that still shows "active".
+
+where:
+  all_of:
+    - approval_policy.enabled == true
+    - approval_policy.fallback_behavior == "fail_open"
+    - approval_policy.named_scanner_absent == true
+
+evidence:
+  - "An enabled approval policy fails open ({{ approval_policy.fallback_behavior }}) and its named scanner is absent from the resolved pipeline ({{ approval_policy.named_scanner_absent }}), so the unevaluable rule waives the required approval."
+
+remediation_hint: >
+  Set `fallback_behavior: fail_closed` so an unevaluable rule blocks the merge, and wire the named
+  scanner into the target project's pipeline.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-misscoped-target.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-misscoped-target.yaml
@@ -1,0 +1,27 @@
+id: cat-06/approval-policy-misscoped-target
+scenario_id: cat-06/11
+title: "MR approval policy does not bind the reachable branch (misscoped / unprotected target)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  An approval policy relied on as the security gate does not actually bind a CI-trusted target branch:
+  the branch is not in the protected-branches list (policies enforce only on protected branches), or
+  `policy_scope` excludes the project, or the policy is disabled. The dashboard shows the policy, but
+  the branch an author targets is unbound, so a Developer merges to a trusted ref with no required
+  security approval.
+
+where:
+  all_of:
+    - approval_policy.binds_trusted_target == false
+    - any_of:
+        - approval_policy.enabled == false
+        - approval_policy.scope_excludes_target == true
+        - target_branch_ci_trusted_unprotected == true
+
+evidence:
+  - "An approval policy does not bind a CI-trusted target branch ({{ approval_policy.binds_trusted_target }}) via unprotected target, excluded scope, or being disabled, so merges there require no security approval."
+
+remediation_hint: >
+  Add every CI-trusted branch to the protected-branches list and ensure the policy's `policy_scope`
+  and `branches:` cover it, with the policy enabled.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-warn-mode.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approval-policy-warn-mode.yaml
@@ -1,0 +1,23 @@
+id: cat-06/approval-policy-warn-mode
+scenario_id: cat-06/10
+title: "MR approval policy in warn mode — violations are dismissable, not blocking"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  An enabled Ultimate approval policy relied on as the security gate runs in
+  `enforcement_type == "warn"`: a violation surfaces as a dismissable warning rather than a required
+  approval, so an author clicks "dismiss with a reason" and merges policy-violating code to the
+  protected target branch. The policy shows "active" on dashboards but is fundamentally advisory.
+
+where:
+  all_of:
+    - approval_policy.enabled == true
+    - approval_policy.enforcement_type == "warn"
+
+evidence:
+  - "An enabled approval policy runs in {{ approval_policy.enforcement_type }} mode, so its `require_approval` action is a self-dismissable warning rather than a blocking gate on the protected branch."
+
+remediation_hint: >
+  Switch the policy to the blocking enforcement mode so `require_approval` violations add a required
+  approval instead of a dismissable warning.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approvals-persist-across-push.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/approvals-persist-across-push.yaml
@@ -1,0 +1,23 @@
+id: cat-06/approvals-persist-across-push
+scenario_id: cat-06/04
+title: "Approvals persist across post-approval commits (\"Keep approvals\" — reset-on-push disabled)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  Reset-on-push is set to "Keep approvals" (`reset_approvals_on_push == false`, an operator change
+  from the secure default) while a required approval rule gates a protected target branch. A benign
+  diff is approved, then unreviewed commits are appended to the still-open MR and ride the persisting
+  approvals into the trusted branch — merging code no reviewer saw behind a green "Approved" badge.
+
+where:
+  all_of:
+    - reset_approvals_on_push == false
+    - approvals_required >= 1
+
+evidence:
+  - "Approvals are kept across post-approval commits ({{ reset_approvals_on_push }}) on a gate requiring {{ approvals_required }} approval(s) for a protected branch, so appended commits merge unreviewed."
+
+remediation_hint: >
+  Set "When commits are added" to remove all approvals on push (`reset_approvals_on_push = true`) so
+  every approval binds to the exact reviewed diff.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/author-self-approval.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/author-self-approval.yaml
@@ -1,0 +1,24 @@
+id: cat-06/author-self-approval
+scenario_id: cat-06/01
+title: "MR author approves their own merge request (\"Prevent approval by author\" disabled)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  "Prevent approval by merge request author" is off (`author_approval_allowed == true`, a deliberate
+  change from the secure default), a required approval rule gates a protected target branch, and the
+  author sits inside a broad eligible-approver set — so the author clears their own single-approval
+  gate and merges unreviewed code (including a malicious `.gitlab-ci.yml`) to the trusted ref.
+
+where:
+  all_of:
+    - author_approval_allowed == true
+    - approvals_required >= 1
+    - approver_set_broad == true
+
+evidence:
+  - "Author self-approval is permitted ({{ author_approval_allowed }}) and a broad-approver rule requiring {{ approvals_required }} approval(s) gates a protected branch, so the author clears their own gate."
+
+remediation_hint: >
+  Re-enable "Prevent approval by merge request author" (`merge_requests_author_approval = false`) and
+  scope the approval rule's eligible approvers to a set that excludes likely authors.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/codeowners-advisory-not-required.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/codeowners-advisory-not-required.yaml
@@ -1,0 +1,23 @@
+id: cat-06/codeowners-advisory-not-required
+scenario_id: cat-06/07
+title: "CODEOWNERS names owners for trust-relevant paths but code-owner approval is not required"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  CODEOWNERS assigns owners to trust-relevant paths (`.gitlab-ci.yml`, deploy paths, `/CODEOWNERS`) —
+  evidence the org relies on them to gate changes — but "Require approval from Code Owners" is off on
+  the protected target branch (`code_owner_approval_required == false`), so the assignment is purely
+  advisory. An author changes an owned trust-relevant path and merges with no owner sign-off.
+
+where:
+  all_of:
+    - codeowners.covers_cicd_config == true
+    - code_owner_approval_required == false
+
+evidence:
+  - "CODEOWNERS owns trust-relevant paths ({{ codeowners.covers_cicd_config }}) but code-owner approval is not required ({{ code_owner_approval_required }}) on the protected branch, so owner assignments never block a merge."
+
+remediation_hint: >
+  Enable "Require approval from Code Owners" (`code_owner_approval_required = true`) on the protected
+  target branch so declared owners actually gate changes to their paths.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/codeowners-optional-section.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/codeowners-optional-section.yaml
@@ -1,0 +1,24 @@
+id: cat-06/codeowners-optional-section
+scenario_id: cat-06/08
+title: "Trust-relevant paths owned only under an Optional CODEOWNERS section (never blocks a merge)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  CODEOWNERS declares owners for trust-relevant paths only under an Optional (`^`-prefixed) section,
+  whose code-owner approvals are never required even when "Require approval from Code Owners" is
+  enabled on the protected branch. The paths appear owned and enforcement may even be on, yet no owner
+  approval is ever demanded — so an author merges changes to `.gitlab-ci.yml` or deploy configs
+  unreviewed by the declared owner.
+
+where:
+  all_of:
+    - codeowners.covers_cicd_config == true
+    - trust_relevant_path_optional_only == true
+
+evidence:
+  - "Trust-relevant paths are owned only under an Optional (^) CODEOWNERS section ({{ trust_relevant_path_optional_only }}), so their owner approval is structurally never required even with enforcement on."
+
+remediation_hint: >
+  Move trust-relevant path ownership out of the Optional (`^`-prefixed) section into a required
+  CODEOWNERS section so owner approval is actually demanded.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/codeowners-self-editable.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/codeowners-self-editable.yaml
@@ -1,0 +1,26 @@
+id: cat-06/codeowners-self-editable
+scenario_id: cat-06/15
+title: "CODEOWNERS ownership is removable within the same MR (`/CODEOWNERS` not self-owned)"
+subject: merge_request
+severity: high
+confidence: low
+description: >
+  CODEOWNERS owns trust-relevant paths under a required section and code-owner approval is enforced
+  on the protected branch (`code_owner_approval_required == true`), yet CODEOWNERS does not require an
+  owner's approval to change CODEOWNERS itself (`codeowners.self_owned_required == false`). An author
+  can rewrite the owner list in the same MR that changes an owned path, dropping the owner gate. The
+  immediacy of exploitation depends on the deferred platform behavior of which CODEOWNERS revision an
+  MR is evaluated against, so confidence is low.
+
+where:
+  all_of:
+    - codeowners.covers_cicd_config == true
+    - code_owner_approval_required == true
+    - codeowners.self_owned_required == false
+
+evidence:
+  - "CODEOWNERS gates trust-relevant paths with enforcement on ({{ code_owner_approval_required }}) but does not require owner approval to edit CODEOWNERS itself ({{ codeowners.self_owned_required }}), so an author can rewrite the owner list in the same MR."
+
+remediation_hint: >
+  Add a required (non-Optional) CODEOWNERS entry owning its own path (`/CODEOWNERS @owners`) so
+  changes to the reviewer-defining file demand owner approval.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/committer-self-approval.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/committer-self-approval.yaml
@@ -1,0 +1,25 @@
+id: cat-06/committer-self-approval
+scenario_id: cat-06/02
+title: "MR committer approves an MR they added commits to (\"Prevent approvals by users who add commits\" off)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  "Prevent approvals by users who add commits" is at its permissive default
+  (`committer_approval_disabled == false`), a required approval rule gates a protected target branch,
+  and a committer sits inside a broad eligible-approver set — so a committing identity (a second
+  account, a bot, or a colluding co-Developer) clears the single-approval gate with no party
+  independent of the change. Absent commit-identity push rules make the control further evadable.
+
+where:
+  all_of:
+    - committer_approval_disabled == false
+    - approvals_required >= 1
+    - approver_set_broad == true
+
+evidence:
+  - "Committer approval is permitted ({{ committer_approval_disabled }}) on a broad-approver rule requiring {{ approvals_required }} approval(s) for a protected branch; push rules: {{ push_rules }}."
+
+remediation_hint: >
+  Enable "Prevent approvals by users who add commits" and enforce `commit_committer_check` plus
+  `reject_unsigned_commits` so committers cannot approve under unverified identities.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/external-status-check-not-enforced.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/external-status-check-not-enforced.yaml
@@ -1,0 +1,24 @@
+id: cat-06/external-status-check-not-enforced
+scenario_id: cat-06/14
+title: "External status check configured but not enforced (\"Status checks must succeed\" off)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  One or more external status checks are configured (evidence the org relies on them as a merge gate)
+  while "Status checks must succeed" is off (`only_merge_if_status_checks_pass == false`). A
+  `pending` or `failed` check is therefore advisory and never blocks — so a Developer merges past a
+  non-`passed` external gate onto the protected, CI-trusted branch.
+
+where:
+  all_of:
+    - external_status_checks != []
+    - only_merge_if_status_checks_pass == false
+
+evidence:
+  - "{{ external_status_checks }} external status check(s) are configured but enforcement is off ({{ only_merge_if_status_checks_pass }}), so a pending/failed check does not block a merge to the protected branch."
+
+remediation_hint: >
+  Enable "Status checks must succeed"
+  (`only_allow_merge_if_all_status_checks_passed = true`) so configured checks block until they
+  report `passed`.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/in-mr-approval-rule-override.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/in-mr-approval-rule-override.yaml
@@ -1,0 +1,24 @@
+id: cat-06/in-mr-approval-rule-override
+scenario_id: cat-06/06
+title: "MR author edits the approval rule from inside their own MR (rule overriding not prevented)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  "Prevent editing approval rules in merge requests" is at its permissive default
+  (`author_controls_approver_count == true`) while a required project approval rule is the effective
+  gate for a protected target branch. The author lowers the required count or swaps the approvers on
+  their own MR, so the review gate they are subject to no longer forces an independent party.
+
+where:
+  all_of:
+    - author_controls_approver_count == true
+    - approvals_required >= 1
+
+evidence:
+  - "Authors may edit approval rules in their own MR ({{ author_controls_approver_count }}) on a gate requiring {{ approvals_required }} approval(s) for a protected branch, so the author rewrites the requirement they are subject to."
+
+remediation_hint: >
+  Enable "Prevent editing approval rules in merge requests"
+  (`disable_overriding_approvers_per_merge_request = true`), or enforce the rule via an Ultimate
+  approval policy that locks it.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/multi-approval-author-controlled.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/multi-approval-author-controlled.yaml
@@ -1,0 +1,28 @@
+id: cat-06/multi-approval-author-controlled
+scenario_id: cat-06/03
+title: "Multi-approval gate cleared entirely by author-controlled identities (no independent reviewer)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  A `approvals_required >= 2` gate looks stronger but is defeated because independence controls are
+  permissive (author or committer approval allowed), the approver set is broad, and the count of
+  distinct independent eligible approvers — those who are neither the author nor a committer — is
+  smaller than the required count. Author-controlled identities supply the full count, so no party
+  independent of the change reviews the code before it merges to a protected branch.
+
+where:
+  all_of:
+    - approvals_required >= 2
+    - approver_set_broad == true
+    - independent_approver_count < approvals_required
+    - any_of:
+        - author_approval_allowed == true
+        - committer_approval_disabled == false
+
+evidence:
+  - "A gate requiring {{ approvals_required }} approvals has only {{ independent_approver_count }} independent eligible approver(s) with author/committer approval permitted, so author-controlled identities clear it."
+
+remediation_hint: >
+  Scope the approval rule to an eligible-approver set with more distinct independent members than the
+  required count, and enable both author- and committer-approval prevention.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/pipeline-must-succeed-skipped-bypass.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/pipeline-must-succeed-skipped-bypass.yaml
@@ -1,0 +1,25 @@
+id: cat-06/pipeline-must-succeed-skipped-bypass
+scenario_id: cat-06/13
+title: "\"Pipelines must succeed\" bypassed by a skipped/empty pipeline (skipped counts as success)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  "Pipelines must succeed" is relied on as the merge gate (`only_merge_if_pipeline_succeeds == true`)
+  while "Skipped pipelines are considered successful" is also on
+  (`allow_merge_on_skipped_pipeline == true`), and the required security/test jobs are gated behind
+  author-controllable `rules:`/`workflow:` so an MR can yield no jobs. An empty/skipped pipeline
+  satisfies the gate with zero CI having run, and unvetted code merges to the protected branch.
+
+where:
+  all_of:
+    - only_merge_if_pipeline_succeeds == true
+    - allow_merge_on_skipped_pipeline == true
+    - required_jobs_evadable == true
+
+evidence:
+  - "\"Pipelines must succeed\" ({{ only_merge_if_pipeline_succeeds }}) is satisfied by a skipped pipeline ({{ allow_merge_on_skipped_pipeline }}) while required jobs are author-evadable ({{ required_jobs_evadable }}), so a no-op pipeline merges unvetted code."
+
+remediation_hint: >
+  Disable "Skipped pipelines are considered successful" (`allow_merge_on_skipped_pipeline = false`)
+  so a skipped/empty pipeline does not satisfy the must-succeed gate.

--- a/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/selective-code-owner-reset.yaml
+++ b/internal/detection-rules/gitlab/cat-06-merge-request-approval-bypass/selective-code-owner-reset.yaml
@@ -1,0 +1,26 @@
+id: cat-06/selective-code-owner-reset
+scenario_id: cat-06/05
+title: "Only Code-Owner approvals reset on push, regular approvals persist (selective_code_owner_removals)"
+subject: merge_request
+severity: high
+confidence: high
+description: >
+  Selective code-owner removal is on (`selective_code_owner_removal == true`, accepted only with
+  `reset_approvals_on_push == false`), a required regular-approval rule gates a protected target
+  branch, and CODEOWNERS leaves trust-relevant paths uncovered. A post-approval commit that touches
+  only non-owned paths triggers no code-owner reset, so the persisting regular approvals carry
+  unreviewed code onto the trusted branch.
+
+where:
+  all_of:
+    - selective_code_owner_removal == true
+    - reset_approvals_on_push == false
+    - approvals_required >= 1
+    - codeowners.covers_cicd_config == false
+
+evidence:
+  - "Selective code-owner reset ({{ selective_code_owner_removal }}) keeps regular approvals while CODEOWNERS leaves trust-relevant paths ({{ codeowners.covers_cicd_config }}) uncovered, so a post-approval commit on those paths merges unreviewed."
+
+remediation_hint: >
+  Disable selective code-owner removal (full reset on push) or extend CODEOWNERS to own every
+  trust-relevant path so no non-owned lane exists for a post-approval payload.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-06 — merge request approval bypass**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- MR author approves their own merge request ("Prevent approval by author" disabled)
- MR committer approves an MR they added commits to ("Prevent approvals by users who add commits" off)
- Multi-approval gate cleared entirely by author-controlled identities (no independent reviewer)
- Approvals persist across post-approval commits ("Keep approvals" — reset-on-push disabled)
- Only Code-Owner approvals reset on push, regular approvals persist (selective_code_owner_removals)
- MR author edits the approval rule from inside their own MR (rule overriding not prevented)
- CODEOWNERS names owners for trust-relevant paths but code-owner approval is not required
- Trust-relevant paths owned only under an Optional CODEOWNERS section (never blocks a merge)
- MR approval policy fails open (fallback_behavior: fail_open) when its named scanner never runs
- MR approval policy in warn mode — violations are dismissable, not blocking
- MR approval policy does not bind the reachable branch (misscoped / unprotected target)
- MR approval policy exempts a broadly-held actor via bypass_settings
- "Pipelines must succeed" bypassed by a skipped/empty pipeline (skipped counts as success)
- External status check configured but not enforced ("Status checks must succeed" off)
- CODEOWNERS ownership is removable within the same MR (`/CODEOWNERS` not self-owned)

Part of LAB-4981.
