### PR TITLE
GitLab detection rules: cat-07 protected environment deploy bypass

### DIFF
--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/bot-service-account-approver.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/bot-service-account-approver.yaml
@@ -1,0 +1,27 @@
+id: cat-07/bot-service-account-approver
+scenario_id: cat-07/02
+title: "Deployment approval satisfiable by an automatable bot/service-account approver"
+subject: environment
+severity: high
+confidence: low
+description: >
+  A protected environment's deployment-approval rule names a non-human principal — a service
+  account or a group/project access-token bot user — as an eligible approver, and only one
+  approval is required. Because the bot is a distinct identity from the deployer, an approval
+  submitted with the bot's token is not caught by the triggerer-self-approval block, so a
+  deployer who can drive that token closes the gate programmatically with no independent review.
+  Confidence is low because whether the deployer can actually obtain and use the bot's token is
+  a value-level fact the collector cannot confirm.
+
+where:
+  all_of:
+    - protected == true
+    - deploy_approvals_required == 1
+    - approval_rule_bot_approver == true
+
+evidence:
+  - "Protected environment `{{ name }}` names a bot/service-account approver as an eligible sole sign-off ({{ deploy_approvals_required }} approval required), an automatable second party."
+
+remediation_hint: >
+  Remove service-account / access-token bot users from the environment's approval rules and
+  require independent human approvers, or raise the required approval count above the automatable set.

--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/dynamic-environment-name-scope-selection.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/dynamic-environment-name-scope-selection.yaml
@@ -1,0 +1,27 @@
+id: cat-07/dynamic-environment-name-scope-selection
+scenario_id: cat-07/06
+title: "Runtime-chosen environment name lets a Developer select which scope injects"
+subject: job
+severity: high
+confidence: high
+description: >
+  A deploy/build job builds its `environment:name:` from a variable interpolation
+  (`$TARGET_ENV`, `review/$CI_COMMIT_REF_SLUG`, …) whose input a Developer controls. Because
+  environment scope decides which scoped variable is injected for a given name, and the name is
+  attacker-influenced, the Developer selects which scoped credential they receive by choosing the
+  name at run time. No exact-match Protected Environments entry can cover a run-time-computed name,
+  so exact-match protection cannot gate it either.
+
+where:
+  all_of:
+    - deploys_environment == true
+    - environment_name_interpolated == true
+    - env_scoped_secret_reachable == true
+    - runs_on_untrusted_ref == true
+
+evidence:
+  - "Job binds a run-time-interpolated environment name `{{ environment_name }}` and can reach an environment-scoped credential from an attacker-nameable ref, letting a Developer select which scoped secret is injected."
+
+remediation_hint: >
+  Fix the environment name to a static, protected value (or restrict the interpolation input to a
+  protected variable), and mark scoped credentials `protected`.

--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/environment-scoped-variable-unprotected.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/environment-scoped-variable-unprotected.yaml
@@ -1,0 +1,25 @@
+id: cat-07/environment-scoped-variable-unprotected
+scenario_id: cat-07/05
+title: "Environment-scoped CI/CD variable trusted as a boundary but left unprotected"
+subject: job
+severity: high
+confidence: high
+description: >
+  A high-value CI/CD variable is scoped to a specific environment (`environment_scope != "*"`)
+  but left `protected == false` — the operator relied on environment scope, which only selects
+  which environment name receives the variable, as the boundary. A Developer who can push an
+  unprotected branch declares the matching `environment:name:` in a job and GitLab injects the
+  scoped variable, because scope, not protection, was the only gate. Scope was never authorization.
+
+where:
+  all_of:
+    - deploys_environment == true
+    - env_scoped_secret_reachable == true
+    - runs_on_untrusted_ref == true
+
+evidence:
+  - "Job binding environment `{{ environment_name }}` reads an environment-scoped but unprotected variable from an attacker-nameable ref, exposing the scoped credential to a lower-trust actor."
+
+remediation_hint: >
+  Mark environment-scoped credentials `protected` so they are only injected on protected refs, and
+  do not rely on environment scope as an actor/ref authorization boundary.

--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/group-deployment-tier-mismatch.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/group-deployment-tier-mismatch.yaml
@@ -1,0 +1,27 @@
+id: cat-07/group-deployment-tier-mismatch
+scenario_id: cat-07/07
+title: "Group-tier environment protection escaped via deployment_tier mismatch"
+subject: environment
+severity: high
+confidence: high
+description: >
+  A top-level group protects a specific deployment tier (e.g. `production`) so descendant
+  projects' matching environments inherit its deploy-access and approval rules. But tier
+  membership is derived from the job's self-declared `environment:deployment_tier:` (or guessed
+  from the name, defaulting to `other`). A Developer points a job at the real production target
+  while declaring a tier outside the protected set — or omitting it — so the environment falls
+  outside the group's tier-scoped protection with no covering project-level entry, yet still hits
+  production infrastructure.
+
+where:
+  all_of:
+    - protected == false
+    - group_tier_protection_escaped == true
+    - carries_deploy_context == true
+
+evidence:
+  - "Environment `{{ name }}` declares tier `{{ tier }}`, outside the group-protected tier set, and carries production deploy context with no covering project-level protection — escaping the group's tier-scoped gate."
+
+remediation_hint: >
+  Add a project-level Protected Environments entry for the real production environment, or enforce
+  that production deploy jobs declare the group-protected `deployment_tier`.

--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/protected-environment-name-mismatch.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/protected-environment-name-mismatch.yaml
@@ -1,0 +1,25 @@
+id: cat-07/protected-environment-name-mismatch
+scenario_id: cat-07/04
+title: "Protected Environments entry does not match the name the deploy job declares"
+subject: environment
+severity: high
+confidence: high
+description: >
+  Project-level Protected Environments match environment names exactly — no wildcard or prefix
+  matching. A deploy job declares a name that is a near-neighbor of a protected name (case-only
+  difference, a `/<suffix>`, or a common alias such as `prod`↔`production`) but has no exact-match
+  protected entry, so it runs entirely outside the protection. A Developer who cannot deploy to
+  the protected name simply declares the near-miss name and reaches the same real infrastructure.
+
+where:
+  all_of:
+    - protected == false
+    - near_miss_protected_name == true
+    - carries_deploy_context == true
+
+evidence:
+  - "Environment `{{ name }}` is a near-neighbor of a protected environment name yet has no exact-match Protected Environments entry, leaving its deploy target unprotected."
+
+remediation_hint: >
+  Add the exact declared environment name to Protected Environments (or normalize deploy jobs to
+  the protected name) so the near-miss variant cannot escape deploy-access restriction.

--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/triggerer-self-approve.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/triggerer-self-approve.yaml
@@ -1,0 +1,25 @@
+id: cat-07/triggerer-self-approve
+scenario_id: cat-07/01
+title: 'Deployment approval defeated by "Allow pipeline triggerer to approve"'
+subject: environment
+severity: high
+confidence: high
+description: >
+  A protected environment with a deployment-approval gate has the per-environment toggle
+  "Allow pipeline triggerer to approve deployment" turned on, so the person who starts the
+  deploy pipeline can approve their own pending deployment. When the required approval count
+  is satisfiable by that single self-approval, the two-person control collapses to a rubber
+  stamp and one actor ships to the protected environment with its scoped credentials.
+
+where:
+  all_of:
+    - protected == true
+    - allow_pipeline_trigger_approve_deployment == true
+    - deploy_approvals_required >= 1
+
+evidence:
+  - "Protected environment `{{ name }}` allows the pipeline triggerer to approve its own deployment while requiring only {{ deploy_approvals_required }} approval, defeating independent sign-off."
+
+remediation_hint: >
+  Disable "Allow pipeline triggerer to approve deployment" on the protected environment so the
+  deployer cannot satisfy the approval gate they triggered.

--- a/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/unprotected-sensitive-environment.yaml
+++ b/internal/detection-rules/gitlab/cat-07-protected-environment-deploy-bypass/unprotected-sensitive-environment.yaml
@@ -1,0 +1,25 @@
+id: cat-07/unprotected-sensitive-environment
+scenario_id: cat-07/03
+title: "Sensitive environment carrying deploy context is not in Protected Environments"
+subject: environment
+severity: high
+confidence: high
+description: >
+  An environment that carries real deploy context — an environment-scoped deploy credential, an
+  id_tokens/OIDC deploy identity, or a production/staging deployment tier — is absent from
+  Protected Environments, so no deploy-access restriction applies. Because the environment a job
+  targets is self-declared in `.gitlab-ci.yml`, any Developer can author a job that names it and
+  deploy, inheriting the bound deploy context and crossing the deployer boundary the operator
+  believed Protected Environments enforced.
+
+where:
+  all_of:
+    - protected == false
+    - carries_deploy_context == true
+
+evidence:
+  - "Environment `{{ name }}` (tier `{{ tier }}`) carries deploy context but is absent from Protected Environments, so any Developer can deploy to it."
+
+remediation_hint: >
+  Add the sensitive environment to Protected Environments and restrict its deploy-access levels to
+  the intended production-deployer set.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-07 — protected environment deploy bypass**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Deployment approval defeated by "Allow pipeline triggerer to approve"
- Deployment approval satisfiable by an automatable bot/service-account approver
- Sensitive environment carrying deploy context is not in Protected Environments
- Protected Environments entry does not match the name the deploy job declares
- Environment-scoped CI/CD variable trusted as a boundary but left unprotected
- Runtime-chosen environment name lets a Developer select which scope injects
- Group-tier environment protection escaped via deployment_tier mismatch

Closes LAB-4981.
