### PR TITLE
GitLab detection rules: cat-08 runner exposure abuse

### DIFF
--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/any-user-open-creation-shared-runner.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/any-user-open-creation-shared-runner.yaml
@@ -1,0 +1,25 @@
+id: cat-08/any-user-open-creation-shared-runner
+scenario_id: cat-08/02
+title: "Open project/group creation plus instance runners on lets any authenticated user reach the shared runner pool"
+subject: instance
+severity: high
+confidence: low
+description: >
+  The instance leaves project creation open to any authenticated user and enables instance runners
+  for new projects by default, so any account with zero project membership can create a throwaway
+  project and land its first job on a self-managed shared runner pool that also services higher-trust
+  projects. Host isolation / ephemerality is the deferred half, so this is confidence low.
+
+where:
+  all_of:
+    - project_creation_unrestricted == true
+    - can_create_group == true
+    - shared_runners_enabled == true
+    - self_managed_shared_runner_serves_higher_trust == true
+
+evidence:
+  - "Instance allows open project/group creation with shared_runners_enabled={{ shared_runners_enabled }}, so any authenticated account self-provisions onto a self-managed shared runner serving higher-trust work."
+
+remediation_hint: >
+  Restrict project/group creation to trusted roles, disable instance runners for new projects by
+  default, and keep higher-trust work on dedicated protected-ref ephemeral runners.

--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/group-runner-inherited-low-trust-subgroup.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/group-runner-inherited-low-trust-subgroup.yaml
@@ -1,0 +1,26 @@
+id: cat-08/group-runner-inherited-low-trust-subgroup
+scenario_id: cat-08/03
+title: "Group runner recursively inherited into a low-trust subgroup project"
+subject: runner
+severity: high
+confidence: low
+description: >
+  A self-managed group runner is inherited recursively by every descendant project, so a low-trust
+  subgroup project silently gains entitlement alongside the group's higher-trust projects. A Developer
+  in the low-trust subgroup project lands a feature-branch job on the group-runner host that also runs
+  trusted jobs. Host isolation / ephemerality is the deferred half, so this is confidence low.
+
+where:
+  all_of:
+    - runner_type == "group_type"
+    - self_managed == true
+    - ref_protected != true
+    - run_untagged == true
+    - spans_trust_boundary == true
+
+evidence:
+  - "Self-managed group runner {{ runner_type }} (ref_protected={{ ref_protected }}, run_untagged={{ run_untagged }}) is inherited by both a low-trust subgroup project and higher-trust descendant projects ({{ projects }})."
+
+remediation_hint: >
+  Restrict the group runner to protected refs, register dedicated runners for trusted projects, and
+  avoid registering broadly-inherited group runners for a handful of trusted deploy projects.

--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/non-ephemeral-runner-state-reuse.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/non-ephemeral-runner-state-reuse.yaml
@@ -1,0 +1,24 @@
+id: cat-08/non-ephemeral-runner-state-reuse
+scenario_id: cat-08/05
+title: "Non-ephemeral runner reuses on-disk state across a trust boundary"
+subject: job
+severity: high
+confidence: low
+description: >
+  A job uses a reuse-dependent checkout strategy (`GIT_STRATEGY` fetch/none, or a persisted
+  cache/submodule path) and runs on a self-managed shared runner that also services higher-trust
+  jobs and is not protected-ref restricted. An earlier attacker job can plant on-disk state
+  (`.git/hooks`, poisoned vendored deps, cache) that a later higher-trust job on the same host
+  executes. Host filesystem reuse / ephemerality is the deferred half, so this is confidence low.
+
+where:
+  all_of:
+    - reuses_ondisk_checkout == true
+    - runs_on_cross_trust_shared_runner == true
+
+evidence:
+  - "Job reuses on-disk checkout state (GIT_STRATEGY fetch/none or persisted cache/submodules) on a self-managed shared runner that also runs higher-trust jobs, so planted state crosses the trust boundary."
+
+remediation_hint: >
+  Force a clean clone into a wiped directory (avoid GIT_STRATEGY fetch/none on shared runners) and
+  run cross-trust workloads on ephemeral per-job executors so on-disk state cannot persist.

--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/reusable-registration-token-rogue-runner.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/reusable-registration-token-rogue-runner.yaml
@@ -1,0 +1,27 @@
+id: cat-08/reusable-registration-token-rogue-runner
+scenario_id: cat-08/07
+title: "Legacy runner registration-token flow re-enabled lets a rogue runner steal jobs"
+subject: instance
+severity: high
+confidence: medium
+description: >
+  The legacy reusable runner registration-token flow is re-enabled against the 17.0 default-disable
+  and delegated to project/group members, on a scope that services protected/deploy pipelines. A
+  delegated member (or anyone holding a leaked reusable token) stands up a rogue runner that
+  authenticates to that scope and races the trusted runner for its jobs, capturing their variables and
+  artifacts. Token leak and race outcome are deferred, so this is confidence medium.
+
+where:
+  all_of:
+    - runner_registration_token_allowed == true
+    - any_of:
+        - valid_runner_registrars ∋ {project}
+        - valid_runner_registrars ∋ {group}
+    - reusable_token_scope_serves_secrets == true
+
+evidence:
+  - "Instance has runner_registration_token_allowed={{ runner_registration_token_allowed }} with valid_runner_registrars={{ valid_runner_registrars }}, delegating reusable-token registration on a scope that carries protected variables/deploy credentials."
+
+remediation_hint: >
+  Disable allow_runner_registration_token (keep the 17.0 default) and use per-runner authentication
+  tokens, so a reusable token cannot register additional rogue runners in a trusted scope.

--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/shared-instance-runner-low-trust-coresidency.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/shared-instance-runner-low-trust-coresidency.yaml
@@ -1,0 +1,28 @@
+id: cat-08/shared-instance-runner-low-trust-coresidency
+scenario_id: cat-08/01
+title: "Self-managed instance runner shared across a trust boundary gives a low-trust Developer co-residency"
+subject: runner
+severity: high
+confidence: low
+description: >
+  A self-managed instance runner (shared by scope, not restricted to protected refs, picks up
+  untagged jobs) is entitled to both a low-trust project and a higher-trust one. A Developer's
+  feature-branch job in the low-trust project lands on the same host that executes the higher-trust
+  project's jobs — co-residency the attacker never held. Host isolation / ephemerality is the
+  deferred half, so this is confidence low.
+
+where:
+  all_of:
+    - runner_type == "instance_type"
+    - is_shared == true
+    - self_managed == true
+    - ref_protected != true
+    - run_untagged == true
+    - spans_trust_boundary == true
+
+evidence:
+  - "Self-managed instance runner {{ runner_type }} (is_shared={{ is_shared }}, ref_protected={{ ref_protected }}, run_untagged={{ run_untagged }}) services both a low-trust and a higher-trust project ({{ projects }})."
+
+remediation_hint: >
+  Restrict the shared runner to protected refs, isolate higher-trust projects onto dedicated
+  ephemeral runners, and prefer per-job clean VM executors over persistent shared hosts.

--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/unlocked-project-runner-cross-trust.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/unlocked-project-runner-cross-trust.yaml
@@ -1,0 +1,31 @@
+id: cat-08/unlocked-project-runner-cross-trust
+scenario_id: cat-08/06
+title: "Unlocked project runner enabled on a sensitive and a low-trust project"
+subject: runner
+severity: high
+confidence: low
+description: >
+  An unlocked project runner originally attached to a sensitive project has been enabled on a
+  lower-trust project too, so its `projects` list straddles a trust boundary. A Developer in the
+  low-trust project lands a feature-branch job on the same host that serves the sensitive project,
+  reaching its residual state and execution context. Host isolation is the deferred half, so this is
+  confidence low.
+
+where:
+  all_of:
+    - runner_type == "project_type"
+    - locked == false
+    - self_managed == true
+    - ref_protected != true
+    - projects != []
+    - spans_trust_boundary == true
+    - any_of:
+        - run_untagged == true
+        - untrusted_ref_job_matches_tags == true
+
+evidence:
+  - "Unlocked self-managed project runner (locked={{ locked }}, ref_protected={{ ref_protected }}) is enabled on projects spanning a trust boundary ({{ projects }})."
+
+remediation_hint: >
+  Lock the project runner to its original project (locked=true) or dedicate it to one trust level,
+  and never re-enable a sensitive project's runner on a lower-trust project.

--- a/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/unprotected-trusted-runner-untrusted-branch-jobs.yaml
+++ b/internal/detection-rules/gitlab/cat-08-runner-exposure-abuse/unprotected-trusted-runner-untrusted-branch-jobs.yaml
@@ -1,0 +1,29 @@
+id: cat-08/unprotected-trusted-runner-untrusted-branch-jobs
+scenario_id: cat-08/04
+title: "Unprotected trusted/deploy runner executes non-protected-branch jobs"
+subject: runner
+severity: high
+confidence: medium
+description: >
+  A self-managed runner whose Protected flag is off is targeted both by jobs that only run on
+  protected refs (a trusted/deploy runner) and by jobs reachable from arbitrary branches — no
+  protected-ref separation exists on the host. A Developer steers a feature-branch job (by tag or via
+  run_untagged) onto the trusted runner and inherits its deploy context. Only the host credential
+  presence is deferred, so this is confidence medium.
+
+where:
+  all_of:
+    - self_managed == true
+    - ref_protected != true
+    - serves_protected_ref_only_jobs == true
+    - serves_untrusted_ref_jobs == true
+    - any_of:
+        - run_untagged == true
+        - untrusted_ref_job_matches_tags == true
+
+evidence:
+  - "Self-managed runner (ref_protected={{ ref_protected }}, run_untagged={{ run_untagged }}, tags={{ tags }}) is targeted by protected-ref-only jobs yet also picks up non-protected-branch jobs — no protected-ref separation on the trusted host."
+
+remediation_hint: >
+  Set the runner to protected-ref only (access_level=ref_protected) so deploy work is confined to
+  protected branches, and never share a credentialed deploy runner with feature-branch jobs.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-08 — runner exposure abuse**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Self-managed instance runner shared across a trust boundary gives a low-trust Developer co-residency
- Open project/group creation plus instance runners on lets any authenticated user reach the shared runner pool
- Group runner recursively inherited into a low-trust subgroup project
- Unprotected trusted/deploy runner executes non-protected-branch jobs
- Non-ephemeral runner reuses on-disk state across a trust boundary
- Unlocked project runner enabled on a sensitive and a low-trust project
- Legacy runner registration-token flow re-enabled lets a rogue runner steal jobs

Part of LAB-4984.
