### PR TITLE
GitLab detection rules: cat-09 artifact cache registry poisoning

### DIFF
--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-cachekeyfiles-collision.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-cachekeyfiles-collision.yaml
@@ -1,0 +1,33 @@
+id: cat-09/cache-poisoning-cachekeyfiles-collision
+scenario_id: cat-09/05
+title: "Cache poisoning across the protected boundary via cache:key:files collision"
+subject: chain
+severity: high
+confidence: low
+description: >
+  With protected/unprotected cache separation disabled, a `cache:key:files` key (a hash of listed
+  files such as lockfiles) lets a Developer deterministically collide into a protected pipeline's
+  bucket: they set the hashed file contents on their unprotected branch to match what the protected
+  pipeline hashes, writing poisoned content into the exact content-addressed bucket the protected
+  consumer pulls onto executable paths. Confidence is low because whether the distributed cache
+  backend persists and serves the object across the boundary is deferred host state.
+
+chain_of:
+  join: cache-keyspace
+  where:
+    all_of:
+      - producer.cache_separation_enabled == false
+      - producer.runs_on_untrusted_ref == true
+      - producer.cache_key_files_attacker_writable == true
+      - producer.cache_policy_writes == true
+      - producer.cache_paths_executable == true
+      - consumer.protected_ref_gate == "strong"
+      - consumer.cache_key_files_attacker_writable == true
+      - consumer.cache_paths_executable == true
+
+evidence:
+  - "With cache separation disabled, unprotected-branch writer {{ producer._provenance.project_path }} controls the files a cache:key:files hashes and collides into the protected consumer's bucket over executable cached paths."
+
+remediation_hint: >
+  Re-enable "Use separate caches for protected branches", or ensure `cache:key:files` inputs are
+  not writable by lower-trust actors on refs that share a namespace with protected pipelines.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-cachekeyfiles-collision.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-cachekeyfiles-collision.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: cache-keyspace
+  for_each: prefix_overlaps
   where:
     all_of:
       - producer.cache_separation_enabled == false

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-static-key-separation-disabled.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-static-key-separation-disabled.yaml
@@ -1,0 +1,33 @@
+id: cat-09/cache-poisoning-static-key-separation-disabled
+scenario_id: cat-09/04
+title: "Cache poisoning across the protected boundary via a static key with separation disabled"
+subject: chain
+severity: high
+confidence: low
+description: >
+  Protected/unprotected cache separation is disabled (`ci_separated_caches: false`), collapsing
+  both classes into one namespace. A Developer-writable unprotected-branch job writes a static
+  `cache:key` with `policy: pull-push`, and a protected-ref consumer pulls the same key onto
+  executable/loaded paths — extracted before scripts run — giving the low-trust pusher code
+  execution in the protected context. Confidence is low because whether the runner's distributed
+  cache backend persists and serves the object across the boundary is deferred host state.
+
+chain_of:
+  join: cache-keyspace
+  where:
+    all_of:
+      - producer.cache_separation_enabled == false
+      - producer.runs_on_untrusted_ref == true
+      - producer.cache_key_static_cross_boundary == true
+      - producer.cache_policy_writes == true
+      - producer.cache_paths_executable == true
+      - consumer.protected_ref_gate == "strong"
+      - consumer.cache_key_static_cross_boundary == true
+      - consumer.cache_paths_executable == true
+
+evidence:
+  - "With cache separation disabled, unprotected-branch writer {{ producer._provenance.project_path }} shares a static cache key with a protected-ref consumer that extracts executable cached paths."
+
+remediation_hint: >
+  Re-enable "Use separate caches for protected branches" (`ci_separated_caches: true`), or scope
+  the cache key by protection class / ref so unprotected and protected pipelines never collide.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-static-key-separation-disabled.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cache-poisoning-static-key-separation-disabled.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: cache-keyspace
+  for_each: prefix_overlaps
   where:
     all_of:
       - producer.cache_separation_enabled == false

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/container-registry-mutable-tag-no-protection-rule.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/container-registry-mutable-tag-no-protection-rule.yaml
@@ -1,0 +1,28 @@
+id: cat-09/container-registry-mutable-tag-no-protection-rule
+scenario_id: cat-09/09
+title: "Container-registry mutable-tag poisoning with no protected-tag rule"
+subject: job
+severity: high
+confidence: medium
+description: >
+  A protected-ref deploy job pulls a registry image by a mutable tag (`latest`, `staging`, an
+  environment name) rather than an immutable `@sha256:` digest, while no protected container tag
+  rule covers that tag pattern. Because Developer+ can push/overwrite tags by default, a low-trust
+  actor overwrites the image behind the tag between build and deploy and the trusted pipeline runs
+  it with production credentials. Confidence is medium because whether the tag was actually
+  overwritten / current registry contents is deferred runtime state.
+
+where:
+  all_of:
+    - image_from_registry_mutable_tag == true
+    - image_pinned_digest == false
+    - registry_tag_protection_covers_consumed_tag == false
+    - registry_push_reachable_by_developer == true
+    - protected_ref_gate == "strong"
+
+evidence:
+  - "Protected-ref deploy job pulls image {{ image_ref }} by a mutable tag with no covering protected-tag rule; Developer+ can overwrite the tag before deploy."
+
+remediation_hint: >
+  Pin the deployed image by `@sha256:` digest, or create a protected container tag rule covering
+  the consumed tag with a minimum push/delete role of Maintainer+.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cross-pipeline-artifact-untrusted-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cross-pipeline-artifact-untrusted-branch.yaml
@@ -1,0 +1,27 @@
+id: cat-09/cross-pipeline-artifact-untrusted-branch
+scenario_id: cat-09/07
+title: "Upstream-pipeline artifact from an untrusted branch consumed via needs:pipeline:job"
+subject: job
+severity: high
+confidence: high
+description: >
+  A protected-ref consumer job pulls an artifact from another same-project pipeline via
+  `needs:pipeline:job:` (with `artifacts: true`). Because the referenced upstream pipeline is not
+  constrained to protected refs, a Developer's unprotected-branch pipeline can be the source, so
+  its artifact is attacker-controlled. The consumer extracts/executes those bytes with no integrity
+  step, giving the low-trust branch pusher code execution in the protected context.
+
+where:
+  all_of:
+    - consumes_cross_pipeline_artifact == true
+    - upstream_pipeline_untrusted_ref_reachable == true
+    - executes_fetched_artifact == true
+    - artifact_integrity_checked == false
+    - protected_ref_gate == "strong"
+
+evidence:
+  - "Protected-ref job consumes an artifact via needs:pipeline:job from an upstream pipeline reachable on an untrusted branch and executes it with no integrity check."
+
+remediation_hint: >
+  Constrain the referenced upstream pipeline to protected refs, and verify a checksum/signature
+  before extracting or executing any cross-pipeline artifact.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cross-project-artifact-executed-no-integrity-check.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cross-project-artifact-executed-no-integrity-check.yaml
@@ -1,0 +1,32 @@
+id: cat-09/cross-project-artifact-executed-no-integrity-check
+scenario_id: cat-09/06
+title: "Cross-project artifact pulled from a mutable source ref and executed without integrity check"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A consumer job pulls an artifact via `needs:project:…:artifacts:true` from a lower-trust project
+  at a mutable branch ref a Developer can push, then extracts/executes the fetched bytes with no
+  checksum/signature/pinned-digest step, while running in a higher-trust context the source-project
+  Developer holds no membership in. GitLab resolves the source by ref, so attacker-controlled bytes
+  are ingested and run with the consumer's credentials. Reachability is via the consumer being on
+  the source's job-token inbound allowlist (private source).
+
+chain_of:
+  join: cross-project-artifact
+  where:
+    all_of:
+      - consumer.cross_project_needs != []
+      - consumer.artifact_source_ref_mutable == true
+      - consumer.executes_fetched_artifact == true
+      - consumer.artifact_integrity_checked == false
+      - consumer.runs_on_protected_ref == true
+      - producer.source_ref_developer_pushable == true
+      - producer.on_consumer_job_token_allowlist == true
+
+evidence:
+  - "Consumer {{ consumer._provenance.project_path }} pulls an artifact from lower-trust producer {{ producer._provenance.project_path }} at a mutable Developer-pushable ref and executes it with no integrity check."
+
+remediation_hint: >
+  Pin cross-project `needs:` to an immutable tag/SHA, verify a checksum or signature before
+  executing the fetched artifact, and do not rely on `artifacts:access` to gate job-token fetches.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cross-project-artifact-executed-no-integrity-check.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/cross-project-artifact-executed-no-integrity-check.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: cross-project-artifact
+  for_each: edges
   where:
     all_of:
       - consumer.cross_project_needs != []

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-cross-project-needs.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-cross-project-needs.yaml
@@ -1,0 +1,34 @@
+id: cat-09/dotenv-injection-cross-project-needs
+scenario_id: cat-09/01
+title: "dotenv variable injection from a lower-trust upstream project via needs:project"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A consumer job pulls a dotenv report cross-project via `needs:project:…:artifacts:true` from a
+  lower-trust upstream whose producer job emits attacker-influenceable `KEY=value` content on a
+  Developer-writable ref. The consumer does not narrow inheritance and uses an inherited variable
+  in an execution sink (`image:`, script, deploy target), while running in a higher-trust context
+  the upstream Developer holds no membership in. The dotenv values override the consumer's
+  job/global `variables:`, so the injection crosses the project boundary.
+
+chain_of:
+  join: dotenv-flow
+  where:
+    all_of:
+      - producer.produces_dotenv == true
+      - producer.dotenv_content_attacker_influenced == true
+      - producer.runs_on_untrusted_ref == true
+      - consumer.consumes_dotenv == true
+      - consumer.cross_project_needs != []
+      - consumer.dotenv_inheritance_unnarrowed == true
+      - consumer.inherited_var_in_exec_sink == true
+      - consumer.runs_on_protected_ref == true
+
+evidence:
+  - "Consumer {{ consumer._provenance.project_path }} pulls dotenv cross-project via needs:project from lower-trust producer {{ producer._provenance.project_path }} (on untrusted ref) and uses an inherited value in an execution sink without narrowing inheritance."
+
+remediation_hint: >
+  Narrow the consumer with `dependencies: []` or `inherit: {variables: false}`, validate inherited
+  names/values, and pin execution-sensitive values as protected variables rather than trusting
+  cross-project dotenv.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-cross-project-needs.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-cross-project-needs.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: dotenv-flow
+  for_each: edges
   where:
     all_of:
       - producer.produces_dotenv == true

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-untrusted-input-same-project.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-untrusted-input-same-project.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: dotenv-flow
+  for_each: edges
   where:
     all_of:
       - producer.produces_dotenv == true

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-untrusted-input-same-project.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-injection-untrusted-input-same-project.yaml
@@ -1,0 +1,32 @@
+id: cat-09/dotenv-injection-untrusted-input-same-project
+scenario_id: cat-09/02
+title: "dotenv variable injection where a trusted-ref producer's exported content is derived from untrusted input"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A same-project producer job on a trusted ref builds its `artifacts:reports:dotenv` content from
+  untrusted input fetched at runtime from a lower-trust source (an artifact/ref/submodule a
+  Developer can write without a review gate). A later-stage consumer inherits the dotenv with
+  default inheritance and uses the inherited value in an execution sink while running in a
+  higher-trust context. The producer runs on a trusted ref, so its attacker-derived bytes are
+  treated as trusted and injected into the consumer.
+
+chain_of:
+  join: dotenv-flow
+  where:
+    all_of:
+      - producer.produces_dotenv == true
+      - producer.runs_on_protected_ref == true
+      - producer.dotenv_content_from_untrusted_source == true
+      - consumer.consumes_dotenv == true
+      - consumer.dotenv_inheritance_unnarrowed == true
+      - consumer.inherited_var_in_exec_sink == true
+      - consumer.runs_on_protected_ref == true
+
+evidence:
+  - "Trusted-ref producer {{ producer._provenance.project_path }} derives its dotenv content from an untrusted lower-trust source; consumer inherits it and uses the value in an execution sink without narrowing inheritance."
+
+remediation_hint: >
+  Build dotenv content only from trusted in-repo steps behind a review gate, or narrow the
+  consumer with `dependencies: []` / `inherit: {variables: false}` and validate inherited values.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-precedence-clobber-declared-default.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-precedence-clobber-declared-default.yaml
@@ -1,0 +1,32 @@
+id: cat-09/dotenv-precedence-clobber-declared-default
+scenario_id: cat-09/03
+title: "dotenv override of a consumer's job/global variable the author believed fixed"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A consumer job declares a security-relevant variable at job/global `variables:` scope and uses
+  it in an execution sink, believing the hard-coded default cannot change. A reachable, lower-trust
+  producer emits a dotenv `KEY=value` whose key collides with that declared name; because dotenv
+  outranks job/global `variables:`, the ingested value silently overrides the author's default,
+  redirecting the consumer's `image:`/deploy target/command. The finding is the name collision plus
+  a trust gradient the producer's controller cannot otherwise cross.
+
+chain_of:
+  join: dotenv-flow
+  where:
+    all_of:
+      - producer.produces_dotenv == true
+      - producer.dotenv_content_attacker_influenced == true
+      - consumer.consumes_dotenv == true
+      - consumer.dotenv_inheritance_unnarrowed == true
+      - consumer.dotenv_key_collides_declared_var == true
+      - consumer.colliding_var_in_exec_sink == true
+      - consumer.runs_on_protected_ref == true
+
+evidence:
+  - "Producer {{ producer._provenance.project_path }} emits a dotenv key that collides with a job/global variable the consumer {{ consumer._provenance.project_path }} declares and uses in an execution sink; dotenv precedence overrides the declared default."
+
+remediation_hint: >
+  Pin security-relevant defaults as protected project/group/instance variables (which outrank
+  dotenv) rather than declaring them at job/global scope, and narrow dotenv inheritance.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-precedence-clobber-declared-default.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/dotenv-precedence-clobber-declared-default.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: dotenv-flow
+  for_each: edges
   where:
     all_of:
       - producer.produces_dotenv == true

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/package-registry-mutable-version-no-protection-rule.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/package-registry-mutable-version-no-protection-rule.yaml
@@ -1,0 +1,29 @@
+id: cat-09/package-registry-mutable-version-no-protection-rule
+scenario_id: cat-09/10
+title: "Package-registry mutable-version poisoning with no package protection rule"
+subject: job
+severity: high
+confidence: medium
+description: >
+  A protected-ref job installs a package from the GitLab package registry at a mutable range (a
+  floating/`latest`/`*`/caret/tilde version, unpinned) with no exact-version + checksum
+  verification, while no package protection rule limits that name to Maintainer+. Because Developer+
+  can publish/overwrite versions by default, a low-trust actor publishes a poisoned version whose
+  install-time hooks run in the trusted context. Confidence is medium because whether the registry
+  holds a poisoned version / an install hook fires is deferred runtime state.
+
+where:
+  all_of:
+    - installs_gitlab_registry_package == true
+    - package_version_mutable_range == true
+    - package_version_checksum_verified == false
+    - package_protection_covers_consumed_name == false
+    - package_publish_reachable_by_developer == true
+    - protected_ref_gate == "strong"
+
+evidence:
+  - "Protected-ref job installs a GitLab package-registry package at a mutable range with no pinned version+checksum and no covering package protection rule; Developer+ can overwrite the name."
+
+remediation_hint: >
+  Pin an exact package version and verify its checksum, or create a package protection rule
+  limiting the consumed name/pattern to a minimum push role of Maintainer+.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/public-internal-artifact-bare-job-token.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/public-internal-artifact-bare-job-token.yaml
@@ -1,0 +1,28 @@
+id: cat-09/public-internal-artifact-bare-job-token
+scenario_id: cat-09/08
+title: "Public/internal-project artifact fetched by bare job token, allowlist never applies"
+subject: job
+severity: high
+confidence: high
+description: >
+  A protected-ref consumer job fetches an artifact from a public/internal source project — via a
+  bare `CI_JOB_TOKEN` job-artifacts API call or `needs:project:…:artifacts:true` — at a mutable ref
+  a source-project Developer can push, then extracts/executes it with no integrity step. Because the
+  job-token inbound allowlist gates only private resources, public/internal artifacts are fetchable
+  with any job token and no allowlist entry, so the control teams rely on never applies to this path.
+
+where:
+  all_of:
+    - fetches_cross_project_artifact == true
+    - artifact_source_visibility in {public, internal}
+    - artifact_source_ref_mutable == true
+    - executes_fetched_artifact == true
+    - artifact_integrity_checked == false
+    - protected_ref_gate == "strong"
+
+evidence:
+  - "Protected-ref job fetches an artifact from a {{ artifact_source_visibility }} source project at a mutable ref with a bare job token (allowlist never applies) and executes it with no integrity check."
+
+remediation_hint: >
+  Verify a checksum/signature and pin to an immutable tag/SHA before executing a fetched artifact,
+  and do not treat the job-token allowlist as protection for public/internal source artifacts.

--- a/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/registry-tag-overwrite-write-registry-deploy-token.yaml
+++ b/internal/detection-rules/gitlab/cat-09-artifact-cache-registry-poisoning/registry-tag-overwrite-write-registry-deploy-token.yaml
@@ -1,0 +1,29 @@
+id: cat-09/registry-tag-overwrite-write-registry-deploy-token
+scenario_id: cat-09/11
+title: "Mutable-tag overwrite performed with a broadly-reachable write_registry deploy token"
+subject: job
+severity: high
+confidence: medium
+description: >
+  A protected-ref deploy job pulls a registry image by a mutable tag with no covering protected
+  container tag rule, and a `write_registry` deploy token (group-level → usable across the group,
+  or the auto-exposed `gitlab-deploy-token` surfaced as `CI_DEPLOY_USER`/`CI_DEPLOY_PASSWORD`) is
+  reachable from a low-trust pipeline. The token is a standalone push credential, so a non-member
+  overwrites the tag the deploy consumes without project registry-push membership. Confidence is
+  medium because whether the tag was overwritten / current registry contents is deferred runtime
+  state.
+
+where:
+  all_of:
+    - image_from_registry_mutable_tag == true
+    - image_pinned_digest == false
+    - registry_tag_protection_covers_consumed_tag == false
+    - write_registry_token_reachable_low_trust == true
+    - protected_ref_gate == "strong"
+
+evidence:
+  - "Protected-ref deploy job pulls {{ image_ref }} by a mutable tag with no covering protected-tag rule, while a write_registry deploy token reachable from a low-trust pipeline can overwrite that tag."
+
+remediation_hint: >
+  Pin the deployed image by digest or add a Maintainer+ protected container tag rule, and stop
+  exposing `write_registry`/`gitlab-deploy-token` credentials to lower-trust branch pipelines.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-09 — artifact cache registry poisoning**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- dotenv variable injection from a lower-trust upstream project via needs:project
- dotenv variable injection where a trusted-ref producer's exported content is derived from untrusted input
- dotenv override of a consumer's job/global variable the author believed fixed
- Cache poisoning across the protected boundary via a static key with separation disabled
- Cache poisoning across the protected boundary via cache:key:files collision
- Cross-project artifact pulled from a mutable source ref and executed without integrity check
- Upstream-pipeline artifact from an untrusted branch consumed via needs:pipeline:job
- Public/internal-project artifact fetched by bare job token, allowlist never applies
- Container-registry mutable-tag poisoning with no protected-tag rule
- Package-registry mutable-version poisoning with no package protection rule
- Mutable-tag overwrite performed with a broadly-reachable write_registry deploy token

Closes LAB-4980.
