### PR TITLE
GitLab detection rules: cat-12 group instance settings

### DIFF
--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/auto-devops-deploy-kubernetes-agent.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/auto-devops-deploy-kubernetes-agent.yaml
@@ -1,0 +1,29 @@
+id: cat-12/auto-devops-deploy-kubernetes-agent
+scenario_id: cat-12/14
+title: "Auto DevOps deploy stage authenticates to a cluster, running config-less-project code beside a live kubeconfig"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  A GitLab Agent for Kubernetes `ci_access` grant authorizes the scope an Auto DevOps run executes
+  under, and a config-less project with a reachable runner sits in that scope. The Auto DevOps
+  deploy stage then receives a cluster kubeconfig via the agent, so a code-only pusher's source runs
+  in the same org-owned pipeline that materializes cluster credentials. The cluster's service-
+  account RBAC behind the grant is deferred, hence medium confidence.
+  NOTE: joins the agent-ci-access chain (produced by correlate during normalize).
+
+chain_of:
+  join: agent-ci-access
+  where:
+    all_of:
+      - agent.ci_access_targets != []
+      - project.auto_devops_enabled == true
+      - project.has_cicd_config == false
+      - project.has_reachable_runner == true
+
+evidence:
+  - "Agent `{{ agent._provenance.project_path }}` grants ci_access to the Auto DevOps scope of config-less project `{{ project._provenance.project_path }}`, whose pipeline runs pushed code beside a cluster kubeconfig."
+
+remediation_hint: >
+  Restrict the agent `ci_access` grant to trusted projects, or disable the Auto DevOps default so
+  config-less projects cannot auto-run a deploy stage holding cluster credentials.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/auto-devops-deploy-kubernetes-agent.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/auto-devops-deploy-kubernetes-agent.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: agent-ci-access
+  for_each: grants
   where:
     all_of:
       - agent.ci_access_targets != []

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/group-auto-devops-inherited-deploy-vars.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/group-auto-devops-inherited-deploy-vars.yaml
@@ -1,0 +1,26 @@
+id: cat-12/group-auto-devops-inherited-deploy-vars
+scenario_id: cat-12/13
+title: "Group-scoped Auto DevOps with inherited deploy variables runs org-credentialed pipelines on config-less projects"
+subject: project
+severity: high
+confidence: medium
+description: >
+  A group defaults its descendant projects to Auto DevOps and carries inherited deploy variables
+  (`KUBE_*` / `AUTO_DEVOPS_*` or a group-wired registry). A config-less descendant project with a
+  reachable runner then auto-runs the Auto DevOps template with those group credentials in scope,
+  so a code-only pusher's source executes inside a group-privileged pipeline. Whether the inherited
+  credentials reach a production-powerful target is deferred, hence medium confidence.
+
+where:
+  all_of:
+    - auto_devops_enabled == true
+    - has_cicd_config == false
+    - has_reachable_runner == true
+    - group_inherited_deploy_vars == true
+
+evidence:
+  - "Config-less project {{ _provenance.project_path }} inherits group Auto DevOps plus group deploy variables and a reachable runner, running pushed code in a group-privileged pipeline."
+
+remediation_hint: >
+  Disable the group Auto DevOps default or scope the inherited deploy variables to trusted
+  projects, so config-less descendants do not auto-run with group credentials.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/group-shared-runners-inherited-subgroups.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/group-shared-runners-inherited-subgroups.yaml
@@ -1,0 +1,29 @@
+id: cat-12/group-shared-runners-inherited-subgroups
+scenario_id: cat-12/07
+title: "Group runners inherited to all subgroups let any self-service subgroup project run code on the group's shared compute"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  A group-scoped runner is inherited recursively by every descendant project and accepts untagged,
+  non-protected jobs, while the group permits non-Owner subgroup/project creation. Any user who can
+  create a project under the group lands an untagged job on the group's shared runner without
+  membership in an existing project. The runner's host isolation is the deferred half, hence
+  medium confidence.
+  NOTE: joins the group runner to its owning group's creation-governance posture.
+
+chain_of:
+  join: group-runner-reachability
+  where:
+    all_of:
+      - runner.runner_type == "group_type"
+      - runner.run_untagged == true
+      - runner.ref_protected != true
+      - group.group_open_project_creation == true
+
+evidence:
+  - "Group runner `{{ runner._provenance.scope }}` accepts untagged non-protected jobs and is inherited to descendants of `{{ group._provenance.group_path }}` that any user can self-create under a permissive project-creation policy."
+
+remediation_hint: >
+  Require tags / `ref_protected` on the group runner, or raise `project_creation_role` /
+  `subgroup_creation_level` so untrusted users cannot self-create projects onto it.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/group-shared-runners-inherited-subgroups.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/group-shared-runners-inherited-subgroups.yaml
@@ -14,6 +14,7 @@ description: >
 
 chain_of:
   join: group-runner-reachability
+  for_each: reachable_runners
   where:
     all_of:
       - runner.runner_type == "group_type"

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/instance-auto-devops-config-less-project-deploy-creds.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/instance-auto-devops-config-less-project-deploy-creds.yaml
@@ -1,0 +1,26 @@
+id: cat-12/instance-auto-devops-config-less-project-deploy-creds
+scenario_id: cat-12/12
+title: "Instance-wide Auto DevOps runs an org-credentialed pipeline on any CI-config-less project"
+subject: project
+severity: high
+confidence: medium
+description: >
+  Auto DevOps is defaulted ON instance-wide, so a project with no `.gitlab-ci.yml` and a reachable
+  shared runner auto-runs GitLab's Auto DevOps template — wired to instance/group deploy, cluster,
+  and registry credentials. A low-trust actor who only pushes code (or creates a bare project) thus
+  gets it executed inside a privileged org-authored pipeline they never wrote. Whether the wired
+  deploy target is production-powerful is deferred, hence medium confidence.
+
+where:
+  all_of:
+    - auto_devops_enabled == true
+    - has_cicd_config == false
+    - has_reachable_runner == true
+    - auto_devops_deploy_creds_wired == true
+
+evidence:
+  - "Config-less project {{ _provenance.project_path }} inherits instance Auto DevOps with a reachable runner and wired deploy credentials, running pushed code in an org-privileged pipeline."
+
+remediation_hint: >
+  Disable the instance Auto DevOps default (or per-project), or require every project to author its
+  own reviewed `.gitlab-ci.yml` before deploy credentials are in scope.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/internal-project-debug-trace-authenticated-variable-dump.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/internal-project-debug-trace-authenticated-variable-dump.yaml
@@ -1,0 +1,24 @@
+id: cat-12/internal-project-debug-trace-authenticated-variable-dump
+scenario_id: cat-12/02
+title: "Internal project with CI debug tracing exposes every CI variable to any authenticated instance user"
+subject: project
+severity: high
+confidence: high
+description: >
+  An internal project leaves `public_pipelines` enabled — the default — so every authenticated
+  non-external instance user can read job traces, and a truthy `CI_DEBUG_TRACE` forces the Runner
+  to log every non-masked variable (including protected-but-unmasked ones) and any runtime-derived
+  secret into that internally readable trace.
+
+where:
+  all_of:
+    - visibility == "internal"
+    - public_pipelines == true
+    - ci_debug_trace_enabled == true
+
+evidence:
+  - "Internal project {{ _provenance.project_path }} has public_pipelines {{ public_pipelines }} and CI_DEBUG_TRACE enabled, dumping every non-masked variable into a trace readable by any authenticated instance user."
+
+remediation_hint: >
+  Remove `CI_DEBUG_TRACE`, or restrict pipeline visibility (`public_pipelines: false` / "Only
+  project members") so job traces are not readable by non-members.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/open-self-registration-no-admin-approval.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/open-self-registration-no-admin-approval.yaml
@@ -1,0 +1,26 @@
+id: cat-12/open-self-registration-no-admin-approval
+scenario_id: cat-12/16
+title: "Open self-registration with no admin approval admits untrusted users onto a self-managed instance"
+subject: instance
+severity: high
+confidence: medium
+description: >
+  A self-managed instance leaves `signup_enabled` on and `require_admin_approval_after_user_signup`
+  off while hosting internal/private organisational content, so any anonymous party who reaches the
+  sign-up form mints an active account with no invitation or review. That account reads every
+  internal-visibility project and can self-provision projects onto shared runners. The exploit value
+  is realised only in composition with those findings, hence medium confidence. Not applicable to
+  GitLab.com.
+
+where:
+  all_of:
+    - signup_enabled == true
+    - require_admin_approval_after_signup == false
+    - closed_audience_instance == true
+
+evidence:
+  - "Self-managed instance has open sign-up (signup_enabled {{ signup_enabled }}) with no admin approval on a closed-audience instance, admitting untrusted accounts with no review."
+
+remediation_hint: >
+  Disable open sign-up or enable "Require admin approval for new sign-ups" on a private-audience
+  instance, and restrict sign-up to organisation email domains.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/private-project-public-pipelines-guest-log-read.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/private-project-public-pipelines-guest-log-read.yaml
@@ -1,0 +1,24 @@
+id: cat-12/private-project-public-pipelines-guest-log-read
+scenario_id: cat-12/03
+title: "Private project with public pipelines lets a Guest read job logs and artifacts"
+subject: project
+severity: medium
+confidence: high
+description: >
+  A private project leaves `public_pipelines` enabled — the default — while holding at least one
+  Guest member. On a private project that setting grants Guests read of job logs, the artifacts
+  browser, and the CI/CD menu, a Reporter-equivalent CI read the Guest role is designed to
+  withhold. Disabling `public_pipelines` restricts that surface to Reporter+.
+
+where:
+  all_of:
+    - visibility == "private"
+    - public_pipelines == true
+    - members ∋ {access_level == 10}
+
+evidence:
+  - "Private project {{ _provenance.project_path }} has public_pipelines {{ public_pipelines }} with a Guest member, granting Guests read of job logs and artifacts."
+
+remediation_hint: >
+  Disable `public_pipelines` on the private project so pipeline output is restricted to Reporter+
+  members rather than exposed to Guests.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/private-project-public-pipelines-guest-log-read.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/private-project-public-pipelines-guest-log-read.yaml
@@ -14,7 +14,7 @@ where:
   all_of:
     - visibility == "private"
     - public_pipelines == true
-    - members ∋ {access_level == 10}
+    - has_guest_member == true
 
 evidence:
   - "Private project {{ _provenance.project_path }} has public_pipelines {{ public_pipelines }} with a Guest member, granting Guests read of job logs and artifacts."

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/public-project-debug-trace-anonymous-variable-dump.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/public-project-debug-trace-anonymous-variable-dump.yaml
@@ -1,0 +1,24 @@
+id: cat-12/public-project-debug-trace-anonymous-variable-dump
+scenario_id: cat-12/01
+title: "Public project with CI debug tracing publishes every CI variable to anonymous readers"
+subject: project
+severity: high
+confidence: high
+description: >
+  A public project leaves `Project-based pipeline visibility` (`public_pipelines`) enabled — the
+  default — so anonymous internet users can read job traces, and a truthy `CI_DEBUG_TRACE` forces
+  the Runner to log every non-masked variable (including protected-but-unmasked ones) and any
+  runtime-derived secret into that world-readable trace.
+
+where:
+  all_of:
+    - visibility == "public"
+    - public_pipelines == true
+    - ci_debug_trace_enabled == true
+
+evidence:
+  - "Public project {{ _provenance.project_path }} has public_pipelines {{ public_pipelines }} and CI_DEBUG_TRACE enabled, dumping every non-masked variable into an anonymously readable job trace."
+
+remediation_hint: >
+  Remove `CI_DEBUG_TRACE`, or restrict pipeline visibility (`public_pipelines: false` / "Only
+  project members") so job traces are not readable by non-members.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/public-project-default-public-artifacts-credential-file.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/public-project-default-public-artifacts-credential-file.yaml
@@ -1,0 +1,25 @@
+id: cat-12/public-project-default-public-artifacts-credential-file
+scenario_id: cat-12/04
+title: "Job artifacts left default-public serve credential-bearing files to non-members"
+subject: job
+severity: high
+confidence: low
+description: >
+  A job on a non-member-readable project (public or internal, with `public_pipelines` enabled)
+  defines `artifacts:paths` without restricting access — no `artifacts:public: false` and no
+  `artifacts:access` — so the archive stays at the default-public visibility and is downloadable
+  by non-members. Whether a saved artifact actually contains a credential is deferred content
+  state, hence low confidence.
+
+where:
+  all_of:
+    - artifact_paths != []
+    - artifacts_access_unrestricted == true
+    - non_member_readable_pipelines == true
+
+evidence:
+  - "Job {{ _provenance.config_file }} publishes artifacts `{{ artifact_paths }}` with no access restriction on a non-member-readable project, downloadable by non-members."
+
+remediation_hint: >
+  Set `artifacts:public: false` or `artifacts:access: developer|maintainer|none` on jobs that
+  save sensitive files, or restrict pipeline visibility.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/report-artifact-dotenv-exposure.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/report-artifact-dotenv-exposure.yaml
@@ -1,0 +1,25 @@
+id: cat-12/report-artifact-dotenv-exposure
+scenario_id: cat-12/05
+title: "Report artifacts (dotenv / security reports) left default-public expose exported variables and inventory to non-members"
+subject: job
+severity: medium
+confidence: low
+description: >
+  A job on a non-member-readable project (public or internal, with `public_pipelines` enabled)
+  produces an `artifacts:reports:*` output — notably `dotenv`, which carries exported CI
+  variables — without `artifacts:public: false` or an `artifacts:access` restriction, leaving the
+  report archive default-public and downloadable by non-members. Whether the report actually
+  carries a sensitive variable is deferred content state, hence low confidence.
+
+where:
+  all_of:
+    - produces_dotenv == true
+    - artifacts_access_unrestricted == true
+    - non_member_readable_pipelines == true
+
+evidence:
+  - "Job {{ _provenance.config_file }} emits an unrestricted dotenv report on a non-member-readable project, exposing exported variables to non-members."
+
+remediation_hint: >
+  Set `artifacts:public: false` or `artifacts:access: developer|maintainer|none` on report-
+  producing jobs, or restrict pipeline visibility.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/saml-scim-default-custom-cicd-role.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/saml-scim-default-custom-cicd-role.yaml
@@ -1,0 +1,24 @@
+id: cat-12/saml-scim-default-custom-cicd-role
+scenario_id: cat-12/11
+title: "SAML/SCIM default membership role is a custom role carrying a CI/CD-admin ability"
+subject: group
+severity: high
+confidence: high
+description: >
+  A group has SAML SSO and/or SCIM provisioning active and its `default_membership_role`
+  references a custom member role whose enabled abilities include a CI/CD-administrative permission
+  (`admin_cicd_variables`, `manage_project_access_tokens`, runner management, etc.) on a low base
+  role. Every provisioned identity silently gains the layered Maintainer-class ability while a
+  role-number check sees only a low base, so the danger is invisible to naive review.
+
+where:
+  all_of:
+    - saml_provisioning_active == true
+    - default_role_custom_cicd_ability == true
+
+evidence:
+  - "Group {{ _provenance.group_path }} provisions via SAML/SCIM with a custom default role carrying a CI/CD-admin ability, granting it to every provisioned identity despite a low base role."
+
+remediation_hint: >
+  Set the group's provisioning default to a stock low-trust role, or strip CI/CD-administrative
+  abilities from any custom role used as the provisioning default.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/saml-scim-default-membership-role-developer.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/saml-scim-default-membership-role-developer.yaml
@@ -1,0 +1,23 @@
+id: cat-12/saml-scim-default-membership-role-developer
+scenario_id: cat-12/09
+title: "SAML/SCIM default membership role of Developer auto-grants CI execution to every provisioned identity"
+subject: group
+severity: high
+confidence: high
+description: >
+  A group has SAML SSO and/or SCIM provisioning active and its `default_membership_role` is set to
+  Developer instead of the Guest default. Every identity the IdP provisions therefore silently
+  gains Developer-class CI capability — pipeline execution, non-protected-branch push, project-
+  runner creation — with no invite or per-user review.
+
+where:
+  all_of:
+    - saml_provisioning_active == true
+    - default_membership_role == "developer"
+
+evidence:
+  - "Group {{ _provenance.group_path }} provisions via SAML/SCIM with default_membership_role `{{ default_membership_role }}`, auto-granting Developer CI capability to every provisioned identity."
+
+remediation_hint: >
+  Lower the group's `default_membership_role` to Guest and elevate individual users deliberately,
+  so IdP provisioning does not confer un-reviewed CI/CD write access.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/saml-scim-default-membership-role-maintainer.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/saml-scim-default-membership-role-maintainer.yaml
@@ -1,0 +1,25 @@
+id: cat-12/saml-scim-default-membership-role-maintainer
+scenario_id: cat-12/10
+title: "SAML/SCIM default membership role of Maintainer/Owner auto-grants CI/CD administration to every provisioned identity"
+subject: group
+severity: high
+confidence: high
+description: >
+  A group has SAML SSO and/or SCIM provisioning active and its `default_membership_role` is set at
+  or above Maintainer. Every identity the IdP provisions therefore silently gains CI/CD-
+  administrative control — managing protected variables, protected refs, tokens, and runners —
+  with no invite or per-user review.
+
+where:
+  all_of:
+    - saml_provisioning_active == true
+    - any_of:
+        - default_membership_role == "maintainer"
+        - default_membership_role == "owner"
+
+evidence:
+  - "Group {{ _provenance.group_path }} provisions via SAML/SCIM with default_membership_role `{{ default_membership_role }}`, auto-granting CI/CD administration to every provisioned identity."
+
+remediation_hint: >
+  Lower the group's `default_membership_role` to Guest and elevate individual users deliberately,
+  so IdP provisioning does not confer un-reviewed CI/CD administrative control.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/shared-instance-runners-open-project-creation.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/shared-instance-runners-open-project-creation.yaml
@@ -13,6 +13,7 @@ description: >
 
 chain_of:
   join: runner-reachability
+  for_each: reachable_runners
   where:
     all_of:
       - runner.runner_type == "instance_type"

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/shared-instance-runners-open-project-creation.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/shared-instance-runners-open-project-creation.yaml
@@ -1,0 +1,29 @@
+id: cat-12/shared-instance-runners-open-project-creation
+scenario_id: cat-12/06
+title: "Instance runners reachable by open project creation let any account run code on shared compute"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  An instance/shared runner accepts untagged, non-protected jobs while instance runners are
+  available to newly-created projects and project creation is open to any authenticated user. Any
+  account can then create a project, push an untagged job, and land it on the shared fleet with no
+  prior relationship. The runner's host isolation is the deferred half, hence medium confidence.
+  NOTE: joins the runner-reachability chain (runner posture x instance open-creation posture).
+
+chain_of:
+  join: runner-reachability
+  where:
+    all_of:
+      - runner.runner_type == "instance_type"
+      - runner.is_shared == true
+      - runner.run_untagged == true
+      - runner.ref_protected != true
+      - instance.open_project_creation == true
+
+evidence:
+  - "Shared instance runner `{{ runner._provenance.scope }}` accepts untagged non-protected jobs, and open project creation lets any account reach it on shared compute."
+
+remediation_hint: >
+  Restrict instance runners from new projects, require tags / `ref_protected` on shared runners,
+  or lock down project creation so untrusted accounts cannot self-provision onto the fleet.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/unlocked-project-runner-bridged-across-trust.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/unlocked-project-runner-bridged-across-trust.yaml
@@ -1,0 +1,25 @@
+id: cat-12/unlocked-project-runner-bridged-across-trust
+scenario_id: cat-12/08
+title: "Unlocked project runner enabled across projects of differing trust shares a host across the boundary"
+subject: runner
+severity: high
+confidence: medium
+description: >
+  A project runner with `locked == false` (the non-default deviation) is enabled on two or more
+  projects of differing trust, so a lower-trust project's jobs share a non-ephemeral host with a
+  higher-trust workload. On a non-ephemeral executor the lower-trust Maintainer can read residual
+  build dirs, caches, and checkouts left by the higher-trust project. Whether the executor is
+  non-ephemeral is the deferred half, hence medium confidence.
+
+where:
+  all_of:
+    - runner_type == "project_type"
+    - locked == false
+    - bridges_trust_boundary == true
+
+evidence:
+  - "Unlocked project runner is enabled on {{ projects }}, bridging projects of differing trust on a shared host."
+
+remediation_hint: >
+  Lock the project runner to its project (`locked: true`), or dedicate separate runners to
+  projects of differing trust so higher-trust workloads never share a host.

--- a/internal/detection-rules/gitlab/cat-12-group-instance-settings/webhook-integration-local-network-egress-ssrf.yaml
+++ b/internal/detection-rules/gitlab/cat-12-group-instance-settings/webhook-integration-local-network-egress-ssrf.yaml
@@ -1,0 +1,25 @@
+id: cat-12/webhook-integration-local-network-egress-ssrf
+scenario_id: cat-12/15
+title: "Instance allows webhook/integration requests to the local network, giving Maintainers an SSRF primitive"
+subject: instance
+severity: high
+confidence: medium
+description: >
+  The instance enables `allow_local_requests_from_webhooks` while leaving the local-address
+  allowlist empty or broad, so any project Maintainer's routine ability to set a webhook or
+  integration URL becomes a server-side request-forgery primitive: the GitLab server issues
+  attacker-directed requests to loopback, RFC1918 internal services, and cloud metadata endpoints.
+  Whether a valuable internal service or metadata endpoint is actually reachable is deferred, hence
+  medium confidence.
+
+where:
+  all_of:
+    - allow_local_requests_from_webhooks == true
+    - outbound_local_requests_allowlist_effective != true
+
+evidence:
+  - "Instance permits local-network egress from webhooks/integrations (allow_local_requests_from_webhooks {{ allow_local_requests_from_webhooks }}) with no confining allowlist, giving any Maintainer an SSRF primitive."
+
+remediation_hint: >
+  Disable "Allow requests to the local network from webhooks and integrations", or set a tight
+  local-address allowlist confining which internal hosts hooks may reach.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-12 — group instance settings**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Public project with CI debug tracing publishes every CI variable to anonymous readers
- Internal project with CI debug tracing exposes every CI variable to any authenticated instance user
- Private project with public pipelines lets a Guest read job logs and artifacts
- Job artifacts left default-public serve credential-bearing files to non-members
- Report artifacts (dotenv / security reports) left default-public expose exported variables and inventory to non-members
- Instance runners reachable by open project creation let any account run code on shared compute
- Group runners inherited to all subgroups let any self-service subgroup project run code on the group's shared compute
- Unlocked project runner enabled across projects of differing trust shares a host across the boundary
- SAML/SCIM default membership role of Developer auto-grants CI execution to every provisioned identity
- SAML/SCIM default membership role of Maintainer/Owner auto-grants CI/CD administration to every provisioned identity
- SAML/SCIM default membership role is a custom role carrying a CI/CD-admin ability
- Instance-wide Auto DevOps runs an org-credentialed pipeline on any CI-config-less project
- Group-scoped Auto DevOps with inherited deploy variables runs org-credentialed pipelines on config-less projects
- Auto DevOps deploy stage authenticates to a cluster, running config-less-project code beside a live kubeconfig
- Instance allows webhook/integration requests to the local network, giving Maintainers an SSRF primitive
- Open self-registration with no admin approval admits untrusted users onto a self-managed instance

Part of LAB-4984.
