### PR TITLE
GitLab detection rules: cat-14 integrations webhooks mirroring

### DIFF
--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/group-webhook-url-recapture.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/group-webhook-url-recapture.yaml
@@ -1,0 +1,29 @@
+id: cat-14/group-webhook-url-recapture
+scenario_id: cat-14/04
+title: "Group webhook credential recaptured by a group Owner re-pointing the delivery URL"
+subject: integration
+severity: high
+confidence: medium
+description: >
+  A group webhook — firing across every project in the group — carries write-only credential
+  material (a secret token in `X-Gitlab-Token` and/or masked custom headers) yet its delivery
+  `url` is editable by a group Owner who is not the operator that set the credential. That Owner
+  re-points the group webhook at a listener they control, fires a qualifying event from any
+  project in the group, and captures the credential in plaintext.
+
+where:
+  all_of:
+    - kind == "webhook"
+    - url_mutable == true
+    - firable_event_trigger == true
+    - editor_below_credential_trust == true
+    - any_of:
+        - token_present == true
+        - custom_headers != []
+
+evidence:
+  - "Group webhook carries write-only credential material (token {{ token_present }}, headers {{ custom_headers }}) with a mutable URL and a firable event trigger, editable by an Owner other than the credential-setter."
+
+remediation_hint: >
+  Prefer an HMAC signing token over a reusable secret, and restrict who can edit group-webhook
+  destinations to the operator that owns the downstream credential.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/integration-credential-url-recapture.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/integration-credential-url-recapture.yaml
@@ -1,0 +1,27 @@
+id: cat-14/integration-credential-url-recapture
+scenario_id: cat-14/12
+title: "Integration credential recaptured by a Maintainer re-pointing the integration's server URL"
+subject: integration
+severity: high
+confidence: low
+description: >
+  An active integration (e.g. Jenkins, Harbor, Datadog) stores a write-only downstream credential
+  (`password` / `api_key` / `token`) alongside an editable server/target `url`. A Maintainer never
+  entitled to read that credential can re-point the URL at a listener they control and force a
+  delivery via "Test settings" or a qualifying event, capturing the stored credential in plaintext
+  and using it directly against the downstream system.
+
+where:
+  all_of:
+    - kind == "integration"
+    - token_present == true
+    - url_mutable == true
+    - firable_event_trigger == true
+    - editor_below_credential_trust == true
+
+evidence:
+  - "Active integration stores a write-only credential ({{ token_present }}) with an editable server URL, editable by a role below the credential's trust level."
+
+remediation_hint: >
+  Restrict who can edit an integration's destination URL to the operator that owns the downstream
+  credential, and rotate credentials a re-pointable integration could have exposed.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-dotenv-secret-published-public.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-dotenv-secret-published-public.yaml
@@ -1,0 +1,26 @@
+id: cat-14/pages-job-dotenv-secret-published-public
+scenario_id: cat-14/10
+title: "Public Pages job inherits a dotenv-exported secret that lands in the published bundle"
+subject: job
+severity: high
+confidence: low
+description: >
+  The public Pages producer job (`pages:`, `artifacts:paths` including `public`) inherits a dotenv
+  artifact from an upstream `needs:` producer, on a project whose Pages is served public. Because
+  dotenv-inherited variables arrive unmasked downstream, a secret exported into that report is in
+  scope for a build that inlines env into the bundle or writes it under `public/` — and is then
+  served on the open internet.
+
+where:
+  all_of:
+    - publishes_pages == true
+    - artifact_paths ∋ {public}
+    - consumes_dotenv == true
+    - pages_public == true
+
+evidence:
+  - "Public Pages producer job inherits a dotenv artifact from a `needs:` producer and publishes `public/` (pages public {{ pages_public }})."
+
+remediation_hint: >
+  Do not let the public Pages producer inherit dotenv artifacts; pass build metadata to a private
+  deploy job instead and keep secrets out of the Pages job's environment.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-masked-variable-inlined-public.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-masked-variable-inlined-public.yaml
@@ -1,0 +1,26 @@
+id: cat-14/pages-job-masked-variable-inlined-public
+scenario_id: cat-14/08
+title: "Public Pages job inlines a masked/protected CI/CD variable into the published bundle"
+subject: job
+severity: high
+confidence: low
+description: >
+  A single job both publishes the public Pages artifact (`pages:`, `artifacts:paths` including
+  `public`) and explicitly references a protected or masked CI/CD variable, on a project whose
+  Pages is served public. A front-end build routinely inlines such env references into the emitted
+  bundle — and masking only redacts logs, not the artifact — so the secret can be served on the
+  open internet to anonymous users.
+
+where:
+  all_of:
+    - publishes_pages == true
+    - artifact_paths ∋ {public}
+    - pages_references_secret_variable == true
+    - pages_public == true
+
+evidence:
+  - "Public Pages producer job references a protected/masked CI/CD variable and publishes `public/` (pages public {{ pages_public }})."
+
+remediation_hint: >
+  Separate secret-consuming build/deploy jobs from the public Pages producer, and never reference
+  protected/masked variables in a job that publishes `public/`.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-secure-file-published-public.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-secure-file-published-public.yaml
@@ -1,0 +1,26 @@
+id: cat-14/pages-job-secure-file-published-public
+scenario_id: cat-14/09
+title: "Public Pages job downloads a secure file that lands in the published bundle"
+subject: job
+severity: high
+confidence: low
+description: >
+  A single job both publishes the public Pages artifact (`pages:`, `artifacts:paths` including
+  `public`) and downloads a project secure file (via `download-secure-files` / a `.secure_files/`
+  path), on a project whose Pages is served public. The signing material sits in the workspace
+  alongside the publish directory, so a broad copy or overlapping publish path sweeps it into
+  `public/` and serves it on the open internet.
+
+where:
+  all_of:
+    - publishes_pages == true
+    - artifact_paths ∋ {public}
+    - downloads_secure_file == true
+    - pages_public == true
+
+evidence:
+  - "Public Pages producer job downloads a project secure file and publishes `public/` (pages public {{ pages_public }})."
+
+remediation_hint: >
+  Keep secure-file downloads out of the Pages producer job, and publish only a dedicated
+  build-output directory rather than the workspace that holds the secure file.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-whole-workspace-published-public.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pages-job-whole-workspace-published-public.yaml
@@ -1,0 +1,25 @@
+id: cat-14/pages-job-whole-workspace-published-public
+scenario_id: cat-14/11
+title: "Public Pages job publishes the whole workspace, sweeping secret files into the public site"
+subject: job
+severity: high
+confidence: medium
+description: >
+  The public Pages producer job (`pages:`) publishes a broad `artifacts:paths` — the whole
+  workspace (`.`), the repository root, or a directory that is not a dedicated build-output dir —
+  on a project whose Pages is served public. The published tree then includes whatever is checked
+  out (`.env`, `config/` credentials, downloaded secure files, `.git`), all served to the internet
+  regardless of what the build intended.
+
+where:
+  all_of:
+    - publishes_pages == true
+    - artifact_paths_broad == true
+    - pages_public == true
+
+evidence:
+  - "Public Pages producer job publishes a workspace-wide artifact path ({{ artifact_paths }}) with Pages served public ({{ pages_public }})."
+
+remediation_hint: >
+  Publish only a dedicated, build-generated site output directory from the Pages job — never the
+  whole workspace or repository root.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pull-mirror-all-branches-unprotected-variable-read.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pull-mirror-all-branches-unprotected-variable-read.yaml
@@ -1,0 +1,27 @@
+id: cat-14/pull-mirror-all-branches-unprotected-variable-read
+scenario_id: cat-14/07
+title: "Pull-mirror auto-pipeline on all branches reads unprotected variables from any mirrored ref"
+subject: integration
+severity: high
+confidence: high
+description: >
+  A pull mirror from an external upstream auto-runs a pipeline on every sync
+  (`mirror_trigger_builds`) and mirrors all branches (`only_mirror_protected_branches` off), so
+  any upstream branch can trigger a pipeline. Even off a protected ref that pipeline sees the
+  project's unprotected (and masked) CI/CD variables — masking only redacts logs — so an external
+  upstream committer gains code execution on an arbitrary ref and reads those secrets.
+
+where:
+  all_of:
+    - kind == "pull_mirror"
+    - mirror.trigger_pipelines == true
+    - mirror.upstream_untrusted_host == true
+    - mirror.all_branches == true
+    - mirror.reaches_unprotected_variable == true
+
+evidence:
+  - "Pull mirror from external upstream `{{ url }}` auto-triggers pipelines on all mirrored branches with an unprotected CI/CD variable in scope."
+
+remediation_hint: >
+  Restrict mirroring to protected branches (`only_mirror_protected_branches`), disable
+  `mirror_trigger_builds` for external upstreams, and mark sensitive variables `protected`.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pull-mirror-protected-branch-secret-read.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pull-mirror-protected-branch-secret-read.yaml
@@ -1,0 +1,27 @@
+id: cat-14/pull-mirror-protected-branch-secret-read
+scenario_id: cat-14/05
+title: "Pull-mirror auto-pipeline runs an external upstream's CI config and reads protected variables"
+subject: integration
+severity: critical
+confidence: high
+description: >
+  A pull mirror from an external upstream auto-runs a pipeline on every sync
+  (`mirror_trigger_builds`), executing the upstream's `.gitlab-ci.yml` with the mirror-setup
+  user's credentials. Because the mirrored default branch is protected, that pipeline runs in a
+  trusted context — so an external upstream committer with no GitLab membership gains code
+  execution and can read the project's protected CI/CD variables, with no merge or review.
+
+where:
+  all_of:
+    - kind == "pull_mirror"
+    - mirror.trigger_pipelines == true
+    - mirror.upstream_untrusted_host == true
+    - mirror.protected_default_branch == true
+    - mirror.reaches_protected_variable == true
+
+evidence:
+  - "Pull mirror from external upstream `{{ url }}` auto-triggers pipelines on a protected default branch with a protected CI/CD variable in scope."
+
+remediation_hint: >
+  Disable `mirror_trigger_builds` for externally-sourced mirrors, or restrict mirroring to a
+  trusted first-party upstream and keep sensitive variables out of the auto-pipeline's scope.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pull-mirror-write-back-job-token.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/pull-mirror-write-back-job-token.yaml
@@ -1,0 +1,26 @@
+id: cat-14/pull-mirror-write-back-job-token
+scenario_id: cat-14/06
+title: "Pull-mirror auto-pipeline writes back into the repository via job-token push"
+subject: integration
+severity: critical
+confidence: high
+description: >
+  A pull mirror from an external upstream auto-runs a pipeline on every sync
+  (`mirror_trigger_builds`), and the project also permits the CI job token to push to the
+  repository (`ci_push_repository_for_job_token_allowed`). An external upstream committer who
+  controls the mirrored `.gitlab-ci.yml` can therefore authenticate with `CI_JOB_TOKEN` and
+  push attacker-authored commits back into the project — persisting code with no merge or review.
+
+where:
+  all_of:
+    - kind == "pull_mirror"
+    - mirror.trigger_pipelines == true
+    - mirror.upstream_untrusted_host == true
+    - mirror.job_token_push_allowed == true
+
+evidence:
+  - "Pull mirror from external upstream `{{ url }}` auto-triggers pipelines and the project permits job-token repository push, letting the upstream's CI config write commits back."
+
+remediation_hint: >
+  Disable `ci_push_repository_for_job_token_allowed`, or disable `mirror_trigger_builds` for
+  externally-sourced mirrors so an upstream's CI config cannot obtain repository write.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/webhook-custom-header-url-recapture.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/webhook-custom-header-url-recapture.yaml
@@ -1,0 +1,27 @@
+id: cat-14/webhook-custom-header-url-recapture
+scenario_id: cat-14/02
+title: "Webhook custom-header credential recaptured by a Maintainer re-pointing the delivery URL"
+subject: integration
+severity: high
+confidence: medium
+description: >
+  A project webhook carries a credential-bearing custom header (e.g. `Authorization: Bearer …`
+  or `X-Api-Key`) whose value is write-only — the API returns only the header key — yet its
+  delivery `url` is editable by a Maintainer never entitled to read that value. The Maintainer
+  re-points the webhook at a listener they control, fires a qualifying event, and captures the
+  downstream API credential in plaintext.
+
+where:
+  all_of:
+    - kind == "webhook"
+    - custom_headers != []
+    - url_mutable == true
+    - firable_event_trigger == true
+    - editor_below_credential_trust == true
+
+evidence:
+  - "Webhook carries a write-only custom header ({{ custom_headers }}) with a mutable URL and a firable event trigger, editable by a role below the credential's trust level."
+
+remediation_hint: >
+  Do not ship reusable downstream credentials through a webhook custom header, and restrict who
+  can edit a webhook's delivery URL to the operator that owns the credential.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/webhook-secret-token-url-recapture.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/webhook-secret-token-url-recapture.yaml
@@ -1,0 +1,28 @@
+id: cat-14/webhook-secret-token-url-recapture
+scenario_id: cat-14/01
+title: "Webhook secret token recaptured by a Maintainer re-pointing the delivery URL"
+subject: integration
+severity: high
+confidence: medium
+description: >
+  A project webhook carries a write-only secret token (delivered verbatim in `X-Gitlab-Token`)
+  yet its delivery `url` is editable by a Maintainer who was never entitled to read the token.
+  Because the receiver relies on that replayable shared secret rather than a per-request HMAC
+  signature, the Maintainer can re-point the webhook at a listener they control, fire a
+  qualifying event, and capture the token in plaintext to forge GitLab-signed deliveries.
+
+where:
+  all_of:
+    - kind == "webhook"
+    - token_present == true
+    - webhook_signing_token_present != true
+    - url_mutable == true
+    - firable_event_trigger == true
+    - editor_below_credential_trust == true
+
+evidence:
+  - "Webhook with a write-only secret token (signing token {{ webhook_signing_token_present }}) has a mutable URL and a firable event trigger, editable by a role below the token's trust level."
+
+remediation_hint: >
+  Prefer an HMAC signing token over a replayable secret token, and restrict who can edit a
+  webhook's delivery URL to the operator that owns the receiver's credential.

--- a/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/webhook-url-redirect-ssrf-internal.yaml
+++ b/internal/detection-rules/gitlab/cat-14-integrations-webhooks-mirroring/webhook-url-redirect-ssrf-internal.yaml
@@ -1,0 +1,26 @@
+id: cat-14/webhook-url-redirect-ssrf-internal
+scenario_id: cat-14/03
+title: "Webhook re-pointed to an internal/metadata endpoint via local-network requests allowed (self-managed)"
+subject: integration
+severity: high
+confidence: medium
+description: >
+  The instance permits webhook/integration requests to the local network, so a webhook whose
+  delivery `url` is editable by a Maintainer becomes an SSRF primitive: the Maintainer re-points
+  the URL at an internal service or the `169.254.169.254` metadata endpoint and fires a qualifying
+  event, and GitLab issues the request from its trusted egress — reaching targets the Maintainer
+  cannot route to directly (and delivering any attached credential there).
+
+where:
+  all_of:
+    - kind == "webhook"
+    - allows_local_network == true
+    - url_mutable == true
+    - firable_event_trigger == true
+
+evidence:
+  - "Webhook with a mutable URL and a firable event trigger can reach the local network ({{ allows_local_network }}) and is editable by a role below the instance admin who set the network policy."
+
+remediation_hint: >
+  Keep `allow_local_requests_from_web_hooks_and_services` off (or tightly allowlist internal
+  receivers), and restrict who can edit webhook delivery URLs to a trusted operator.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-14 — integrations webhooks mirroring**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Webhook secret token recaptured by a Maintainer re-pointing the delivery URL
- Webhook custom-header credential recaptured by a Maintainer re-pointing the delivery URL
- Webhook re-pointed to an internal/metadata endpoint via local-network requests allowed (self-managed)
- Group webhook credential recaptured by a group Owner re-pointing the delivery URL
- Pull-mirror auto-pipeline runs an external upstream's CI config and reads protected variables
- Pull-mirror auto-pipeline writes back into the repository via job-token push
- Pull-mirror auto-pipeline on all branches reads unprotected variables from any mirrored ref
- Public Pages job inlines a masked/protected CI/CD variable into the published bundle
- Public Pages job downloads a secure file that lands in the published bundle
- Public Pages job inherits a dotenv-exported secret that lands in the published bundle
- Public Pages job publishes the whole workspace, sweeping secret files into the public site
- Integration credential recaptured by a Maintainer re-pointing the integration's server URL

Closes LAB-4984.
