### PR TITLE
GitLab detection rules: cat-03 cicd variable secret exposure

### DIFF
--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/env-scoped-not-protected-secret-untrusted-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/env-scoped-not-protected-secret-untrusted-ref.yaml
@@ -1,0 +1,25 @@
+id: cat-03/env-scoped-not-protected-secret-untrusted-ref
+scenario_id: cat-03/07
+title: "Environment-scoped-but-not-protected CI/CD variable is readable from an untrusted ref"
+subject: project
+severity: high
+confidence: high
+description: >
+  A secret-shaped CI/CD variable has `environment_scope != "*"` but `protected == false`, and the
+  project has a Developer-pushable ref not covered by a restrictive protected-branch rule.
+  Environment scope is not a ref boundary: the scope is matched against the `environment:` keyword
+  the pipeline author writes, so a Developer pushes a feature branch, declares the matching
+  environment name, and GitLab injects the scoped secret regardless of ref protection. The
+  `scoped ∧ ¬protected` pair is a high-precision tell but must never fire on scoped variables alone.
+
+where:
+  all_of:
+    - has_scoped_unprotected_secret_var == true
+    - has_developer_pushable_unprotected_ref == true
+
+evidence:
+  - "Project `{{ _provenance.project_path }}` has an environment-scoped-but-unprotected secret-shaped variable in `{{ cicd_variables }}` reachable from a Developer-pushable unprotected ref in `{{ protected_branches }}`."
+
+remediation_hint: >
+  Mark the environment-scoped secret `protected` so a matching ref is required, and restrict push
+  on the covering protected-branch rule — environment scope selects a target, it bounds no ref.

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-creatable-tag.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-creatable-tag.yaml
@@ -1,0 +1,33 @@
+id: cat-03/group-protected-var-developer-creatable-tag
+scenario_id: cat-03/05
+title: "Group-inherited protected variable reached via a Developer-creatable protected tag in a descendant project"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A group (or ancestor-subgroup) CI/CD variable marked `protected == true` inherits into a
+  descendant whose protected-*tag* rule lists the Developer level (30) under *Allowed to create*,
+  or uses a broad wildcard pattern (`*`, `v*`) a Developer can satisfy. A protected-tag pipeline
+  runs as a trusted ref, so a Developer who creates a matching tag pointing at an attacker-authored
+  `.gitlab-ci.yml` receives the inherited group secret — sidestepping protected-branch controls
+  entirely. The finding is the cross-scope pairing; the loose tag rule alone is cat-05's lane.
+
+chain_of:
+  join: protected-var-reachability
+  where:
+    all_of:
+      - var.scope_level == "group"
+      - var.protected == true
+      - group.descendants ∋ tag._provenance.project_path
+      - any_of:
+          - tag.create_access_levels ∋ {30}
+          - tag.pattern matches "^(\\*|v\\*)$"
+      - member._provenance.project_path == tag._provenance.project_path
+      - member.access_level == 30
+
+evidence:
+  - "Group protected variable `{{ var.key }}` inherits into descendant `{{ tag._provenance.project_path }}` whose protected tag `{{ tag.pattern }}` is Developer-creatable (members max role {{ member.access_level }})."
+
+remediation_hint: >
+  Restrict *Allowed to create* on the descendant's protected-tag rule to Maintainer+ and replace
+  broad wildcard patterns with specific ones, or scope the group secret to trusted projects.

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-creatable-tag.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-creatable-tag.yaml
@@ -14,15 +14,14 @@ description: >
 
 chain_of:
   join: protected-var-reachability
+  for_each: reachable_vars
   where:
     all_of:
       - var.scope_level == "group"
       - var.protected == true
-      - group.descendants ∋ tag._provenance.project_path
       - any_of:
           - tag.create_access_levels ∋ {30}
           - tag.pattern matches "^(\\*|v\\*)$"
-      - member._provenance.project_path == tag._provenance.project_path
       - member.access_level == 30
 
 evidence:

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-pushable-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-pushable-branch.yaml
@@ -14,13 +14,12 @@ description: >
 
 chain_of:
   join: protected-var-reachability
+  for_each: reachable_vars
   where:
     all_of:
       - var.scope_level == "group"
       - var.protected == true
-      - group.descendants ∋ branch._provenance.project_path
       - branch.push_access_levels ∋ {30}
-      - member._provenance.project_path == branch._provenance.project_path
       - member.access_level == 30
 
 evidence:

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-pushable-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-developer-pushable-branch.yaml
@@ -1,0 +1,31 @@
+id: cat-03/group-protected-var-developer-pushable-branch
+scenario_id: cat-03/03
+title: "Group-inherited protected variable reached via a Developer-pushable protected branch in a descendant project"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A group (or ancestor-subgroup) CI/CD variable marked `protected == true` inherits into a
+  descendant project whose protected-branch rule lists the Developer level (30) under *Allowed to
+  push and merge*. A Developer pushes an attacker-authored `.gitlab-ci.yml` directly onto that
+  protected ref — no review — and GitLab injects the group secret, crossing the group→project
+  boundary. The finding is the cross-scope pairing; the protected variable alone is hygiene and
+  the loose branch rule alone is cat-05's lane.
+
+chain_of:
+  join: protected-var-reachability
+  where:
+    all_of:
+      - var.scope_level == "group"
+      - var.protected == true
+      - group.descendants ∋ branch._provenance.project_path
+      - branch.push_access_levels ∋ {30}
+      - member._provenance.project_path == branch._provenance.project_path
+      - member.access_level == 30
+
+evidence:
+  - "Group protected variable `{{ var.key }}` inherits into descendant `{{ branch._provenance.project_path }}` whose protected branch `{{ branch.pattern }}` allows Developer push (members max role {{ member.access_level }})."
+
+remediation_hint: >
+  Restrict *Allowed to push and merge* on the descendant's protected-branch rule to Maintainer+,
+  or scope the group secret to trusted projects instead of relying on inherited protection.

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-lowered-default-branch-protection.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-lowered-default-branch-protection.yaml
@@ -1,0 +1,30 @@
+id: cat-03/group-protected-var-lowered-default-branch-protection
+scenario_id: cat-03/06
+title: "Group-inherited protected variable reached via lowered default-branch protection in a descendant project"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A group (or ancestor/instance) CI/CD variable marked `protected == true` inherits into a
+  descendant whose group/instance `default_branch_protection` default is lowered to
+  "Partially protected"/"Not protected", so Developers may push the descendant's default branch
+  directly. The default branch is still a protected ref, so it receives the inherited secret: a
+  Developer pushes an attacker-authored `.gitlab-ci.yml` to it and reads the group secret. The
+  finding is the cross-scope pairing; lowered default-branch protection alone is cat-05's lane.
+
+chain_of:
+  join: protected-var-reachability
+  where:
+    all_of:
+      - var.scope_level in {group, instance}
+      - var.protected == true
+      - group.default_branch_protection in {partial, none}
+      - group.descendants ∋ member._provenance.project_path
+      - member.access_level == 30
+
+evidence:
+  - "Group protected variable `{{ var.key }}` inherits into descendant `{{ member._provenance.project_path }}` whose default-branch protection is `{{ group.default_branch_protection }}`, letting Developers (max role {{ member.access_level }}) push the still-protected default ref."
+
+remediation_hint: >
+  Raise the group/instance `default_branch_protection_defaults` so Developers cannot push default
+  branches directly, or scope the group secret to trusted projects instead of inherited protection.

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-lowered-default-branch-protection.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/group-protected-var-lowered-default-branch-protection.yaml
@@ -14,12 +14,12 @@ description: >
 
 chain_of:
   join: protected-var-reachability
+  for_each: reachable_vars
   where:
     all_of:
       - var.scope_level in {group, instance}
       - var.protected == true
       - group.default_branch_protection in {partial, none}
-      - group.descendants ∋ member._provenance.project_path
       - member.access_level == 30
 
 evidence:

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/instance-protected-var-developer-pushable-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/instance-protected-var-developer-pushable-branch.yaml
@@ -1,0 +1,29 @@
+id: cat-03/instance-protected-var-developer-pushable-branch
+scenario_id: cat-03/04
+title: "Instance-level protected variable reached via a Developer-pushable protected branch in any project"
+subject: chain
+severity: high
+confidence: high
+description: >
+  An instance-scope CI/CD variable marked `protected == true` inherits into every project on the
+  instance. Any project whose protected-branch rule lists the Developer level (30) under *Allowed
+  to push and merge* becomes a landing pad: a Developer pushes an attacker-authored
+  `.gitlab-ci.yml` onto that protected ref and GitLab injects the instance secret, crossing the
+  instance→project boundary. The finding is the cross-scope pairing, not either half alone.
+
+chain_of:
+  join: protected-var-reachability
+  where:
+    all_of:
+      - var.scope_level == "instance"
+      - var.protected == true
+      - branch.push_access_levels ∋ {30}
+      - member._provenance.project_path == branch._provenance.project_path
+      - member.access_level == 30
+
+evidence:
+  - "Instance protected variable `{{ var.key }}` inherits into project `{{ branch._provenance.project_path }}` whose protected branch `{{ branch.pattern }}` allows Developer push (members max role {{ member.access_level }})."
+
+remediation_hint: >
+  Restrict *Allowed to push and merge* on the project's protected-branch rule to Maintainer+, or
+  avoid distributing high-trust secrets as instance-inherited protected variables.

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/instance-protected-var-developer-pushable-branch.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/instance-protected-var-developer-pushable-branch.yaml
@@ -13,12 +13,12 @@ description: >
 
 chain_of:
   join: protected-var-reachability
+  for_each: reachable_vars
   where:
     all_of:
       - var.scope_level == "instance"
       - var.protected == true
       - branch.push_access_levels ∋ {30}
-      - member._provenance.project_path == branch._provenance.project_path
       - member.access_level == 30
 
 evidence:

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/masked-not-protected-secret-untrusted-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/masked-not-protected-secret-untrusted-ref.yaml
@@ -1,0 +1,24 @@
+id: cat-03/masked-not-protected-secret-untrusted-ref
+scenario_id: cat-03/01
+title: "Masked-but-not-protected CI/CD variable is readable from an untrusted ref"
+subject: project
+severity: high
+confidence: high
+description: >
+  A secret-shaped CI/CD variable is `masked == true` but `protected == false`, and the project
+  has a Developer-pushable ref not covered by a restrictive protected-branch rule. Masking only
+  redacts a log string — it is not a ref boundary — so the value is injected into a feature-branch
+  pipeline any Developer can push, where a trivial base64/network transform defeats masking and
+  exposes a secret their role cannot view in settings.
+
+where:
+  all_of:
+    - has_masked_unprotected_secret_var == true
+    - has_developer_pushable_unprotected_ref == true
+
+evidence:
+  - "Project `{{ _provenance.project_path }}` has a masked-but-unprotected secret-shaped variable in `{{ cicd_variables }}` reachable from a Developer-pushable unprotected ref in `{{ protected_branches }}`."
+
+remediation_hint: >
+  Mark the variable `protected` so it is injected only on protected refs, and restrict push on
+  the covering protected-branch rule to a trusted role — masking alone bounds nothing by ref.

--- a/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/plain-unprotected-secret-untrusted-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-03-cicd-variable-secret-exposure/plain-unprotected-secret-untrusted-ref.yaml
@@ -1,0 +1,24 @@
+id: cat-03/plain-unprotected-secret-untrusted-ref
+scenario_id: cat-03/02
+title: "Plain unprotected secret CI/CD variable is readable from an untrusted ref"
+subject: project
+severity: high
+confidence: high
+description: >
+  A secret-shaped CI/CD variable is `protected == false` and `masked == false`, and the project
+  has a Developer-pushable ref not covered by a restrictive protected-branch rule. The raw secret
+  is injected into any feature-branch pipeline a Developer pushes and can be printed directly with
+  no transform, exposing a value only Maintainers can manage in settings. The secret-name heuristic
+  carries the precision here and must never fire on unprotected variables alone.
+
+where:
+  all_of:
+    - has_plain_unprotected_secret_var == true
+    - has_developer_pushable_unprotected_ref == true
+
+evidence:
+  - "Project `{{ _provenance.project_path }}` has a plain unprotected secret-shaped variable in `{{ cicd_variables }}` reachable from a Developer-pushable unprotected ref in `{{ protected_branches }}`."
+
+remediation_hint: >
+  Mark the secret variable `protected` (and `masked`), and restrict push on the covering
+  protected-branch rule to a trusted role so feature-branch pipelines cannot read it.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-03 — cicd variable secret exposure**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Masked-but-not-protected CI/CD variable is readable from an untrusted ref
- Plain unprotected secret CI/CD variable is readable from an untrusted ref
- Group-inherited protected variable reached via a Developer-pushable protected branch in a descendant project
- Instance-level protected variable reached via a Developer-pushable protected branch in any project
- Group-inherited protected variable reached via a Developer-creatable protected tag in a descendant project
- Group-inherited protected variable reached via lowered default-branch protection in a descendant project
- Environment-scoped-but-not-protected CI/CD variable is readable from an untrusted ref

Part of LAB-4982.
