### PR TITLE
GitLab detection rules: cat-04 ci job token abuse

### DIFF
--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/cross-project-git-push-via-job-token.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/cross-project-git-push-via-job-token.yaml
@@ -1,0 +1,34 @@
+id: cat-04/cross-project-git-push-via-job-token
+scenario_id: cat-04/06
+title: "Cross-project Git push via CI_JOB_TOKEN with both write toggles enabled"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  Both target write toggles are on — "Allow Git push requests to the repository" and "Allow
+  cross-project Git push requests from allowlisted projects" — and the allowlist trusts the
+  source. The source CI performs a cross-project `git push` with `gitlab-ci-token:$CI_JOB_TOKEN`.
+  Under a Developer+ triggerer with writable source CI, the deputy token pushes commits into the
+  target repository (firing no target pipeline, evading its CI/review gates).
+
+chain_of:
+  join: job-token-allowlist
+  for_each: edges
+  where:
+    all_of:
+      - target.job_token_push_allowed == true
+      - target.job_token_cross_project_push_allowed == true
+      - target.job_token_allowlist.trusts_source == true
+      - source.job_token_cross_project_use == "git_push"
+      - triggerer.access_level >= "developer"
+      - source.source_ci_writable_by_lower_trust == true
+      - any_of:
+          - target.developer_writable_protected_branch == true
+          - target.has_developer_pushable_unprotected_ref == true
+
+evidence:
+  - "Target {{ target._provenance.project_path }} has both job-token push toggles on (push {{ target.job_token_push_allowed }}, cross-project {{ target.job_token_cross_project_push_allowed }}) and a destination ref the triggering identity can push (protected-writable {{ target.developer_writable_protected_branch }}, unprotected-pushable {{ target.has_developer_pushable_unprotected_ref }}); source {{ source._provenance.project_path }} pushes cross-project under triggerer role {{ triggerer.access_level }}."
+
+remediation_hint: >
+  Disable "Allow Git push requests to the repository" and the cross-project push toggle on the
+  target, and narrow the allowlist entry's fine-grained permissions so it cannot push.

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/cross-project-git-push-via-job-token.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/cross-project-git-push-via-job-token.yaml
@@ -20,7 +20,7 @@ chain_of:
       - target.job_token_cross_project_push_allowed == true
       - target.job_token_allowlist.trusts_source == true
       - source.job_token_cross_project_use == "git_push"
-      - triggerer.access_level >= "developer"
+      - triggerer.access_level >= 30
       - source.source_ci_writable_by_lower_trust == true
       - any_of:
           - target.developer_writable_protected_branch == true

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/disabled-inbound-job-token-allowlist.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/disabled-inbound-job-token-allowlist.yaml
@@ -19,7 +19,7 @@ chain_of:
       - target.job_token_allowlist.mode == "disabled"
       - source.job_token_cross_project_use != "none"
       - source.source_ci_writable_by_lower_trust == true
-      - triggerer.access_level >= "developer"
+      - triggerer.access_level >= 30
 
 evidence:
   - "Target {{ target._provenance.project_path }} has inbound job-token allowlist mode {{ target.job_token_allowlist.mode }}; source {{ source._provenance.project_path }} makes a cross-project token call ({{ source.job_token_cross_project_use }}) under triggerer role {{ triggerer.access_level }}."

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/disabled-inbound-job-token-allowlist.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/disabled-inbound-job-token-allowlist.yaml
@@ -1,0 +1,29 @@
+id: cat-04/disabled-inbound-job-token-allowlist
+scenario_id: cat-04/01
+title: "Disabled inbound job-token allowlist (\"All groups and projects\") reached by a privileged triggering identity"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  The target's inbound `CI_JOB_TOKEN` allowlist is disabled ("All groups and projects"), so
+  layer A trusts every project. A source project whose CI is writable by a lower-trust member
+  makes a cross-project job-token call, and the pipeline runs under a triggering identity that
+  is a Developer+ member of the target — so the confused-deputy token reaches the target the
+  attacker holds no membership on.
+
+chain_of:
+  join: job-token-allowlist
+  for_each: edges
+  where:
+    all_of:
+      - target.job_token_allowlist.mode == "disabled"
+      - source.job_token_cross_project_use != "none"
+      - source.source_ci_writable_by_lower_trust == true
+      - triggerer.access_level >= "developer"
+
+evidence:
+  - "Target {{ target._provenance.project_path }} has inbound job-token allowlist mode {{ target.job_token_allowlist.mode }}; source {{ source._provenance.project_path }} makes a cross-project token call ({{ source.job_token_cross_project_use }}) under triggerer role {{ triggerer.access_level }}."
+
+remediation_hint: >
+  Enable the inbound job-token allowlist on the target and restrict it to the minimum set of
+  genuinely trusted projects rather than "All groups and projects".

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/group-scoped-inbound-allowlist-entry.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/group-scoped-inbound-allowlist-entry.yaml
@@ -20,7 +20,7 @@ chain_of:
       - target.job_token_allowlist.fine_grained == false
       - source.job_token_cross_project_use != "none"
       - source.source_ci_writable_by_lower_trust == true
-      - triggerer.access_level >= "developer"
+      - triggerer.access_level >= 30
 
 evidence:
   - "Target {{ target._provenance.project_path }} allowlist mode {{ target.job_token_allowlist.mode }} (fine_grained {{ target.job_token_allowlist.fine_grained }}); source {{ source._provenance.project_path }} in the trusted group makes a cross-project token call under triggerer role {{ triggerer.access_level }}."

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/group-scoped-inbound-allowlist-entry.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/group-scoped-inbound-allowlist-entry.yaml
@@ -1,0 +1,30 @@
+id: cat-04/group-scoped-inbound-allowlist-entry
+scenario_id: cat-04/02
+title: "Group-scoped inbound job-token allowlist entry with no fine-grained permissions"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  The target's inbound allowlist trusts a whole group (17.0+ group-granularity) with no
+  fine-grained permissions, so it grants the full default action set to every project in that
+  group. A lower-trust member of a group project whose CI is writable makes a cross-project
+  job-token call, and the pipeline runs under a Developer+ target member — so the deputy token
+  reaches the target under the full default action set.
+
+chain_of:
+  join: job-token-allowlist
+  for_each: edges
+  where:
+    all_of:
+      - target.job_token_allowlist.mode == "group_scoped"
+      - target.job_token_allowlist.fine_grained == false
+      - source.job_token_cross_project_use != "none"
+      - source.source_ci_writable_by_lower_trust == true
+      - triggerer.access_level >= "developer"
+
+evidence:
+  - "Target {{ target._provenance.project_path }} allowlist mode {{ target.job_token_allowlist.mode }} (fine_grained {{ target.job_token_allowlist.fine_grained }}); source {{ source._provenance.project_path }} in the trusted group makes a cross-project token call under triggerer role {{ triggerer.access_level }}."
+
+remediation_hint: >
+  Replace the group-scoped allowlist entry with specific vetted projects, and configure
+  fine-grained job-token permissions to narrow the entry to the minimum required actions.

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/schedule-owner-privileged-triggerer.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/schedule-owner-privileged-triggerer.yaml
@@ -17,7 +17,7 @@ chain_of:
   where:
     all_of:
       - triggerer.is_schedule_owner == true
-      - triggerer.access_level >= "developer"
+      - triggerer.access_level >= 30
       - source.job_token_cross_project_use != "none"
       - source.source_ci_writable_by_lower_trust == true
       - target.job_token_allowlist.trusts_source == true

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/schedule-owner-privileged-triggerer.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/schedule-owner-privileged-triggerer.yaml
@@ -1,0 +1,30 @@
+id: cat-04/schedule-owner-privileged-triggerer
+scenario_id: cat-04/03
+title: "Pipeline schedule owned by a privileged user, on a ref a lower-trust member can edit"
+subject: chain
+severity: high
+confidence: high
+description: >
+  A pipeline schedule in the source is owned by a Maintainer/Owner who is a Developer+ member of
+  a sensitive target, but the schedule's ref (or an include it resolves) is writable by a
+  lower-trust member. The scheduled run mechanically executes the edited ref under the owner's
+  identity, so a cross-project job-token call in that CI carries the owner's cross-project reach
+  into the target the attacker holds no membership on.
+
+chain_of:
+  join: job-token-allowlist
+  for_each: edges
+  where:
+    all_of:
+      - triggerer.is_schedule_owner == true
+      - triggerer.access_level >= "developer"
+      - source.job_token_cross_project_use != "none"
+      - source.source_ci_writable_by_lower_trust == true
+      - target.job_token_allowlist.trusts_source == true
+
+evidence:
+  - "Source {{ source._provenance.project_path }} has a schedule owned by a Developer+ target member (role {{ triggerer.access_level }}); its writable ref makes a cross-project token call ({{ source.job_token_cross_project_use }}) reaching target {{ target._provenance.project_path }}."
+
+remediation_hint: >
+  Reassign the schedule to a least-privilege identity, or lock the scheduled ref's
+  `.gitlab-ci.yml` behind a protected branch with CODEOWNERS on the CI config.

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/shared-automation-bot-confused-deputy.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/shared-automation-bot-confused-deputy.yaml
@@ -1,0 +1,31 @@
+id: cat-04/shared-automation-bot-confused-deputy
+scenario_id: cat-04/04
+title: "Shared automation bot (single service account across trust boundaries) as job-token confused deputy"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  A single shared bot / service account is a member of both a low-trust source project and a
+  sensitive target with Developer+, with no per-project isolation — a standing confused deputy.
+  A lower-trust member who controls the source CI the bot executes makes a cross-project
+  job-token call that carries the bot's target reach. Whether the bot actually runs the
+  attacker-influenceable code under its own identity at run time is deferred behavioral state,
+  hence medium confidence.
+
+chain_of:
+  join: job-token-allowlist
+  for_each: edges
+  where:
+    all_of:
+      - triggerer.is_bot == true
+      - triggerer.access_level >= "developer"
+      - source.job_token_cross_project_use != "none"
+      - source.source_ci_writable_by_lower_trust == true
+      - target.job_token_allowlist.trusts_source == true
+
+evidence:
+  - "A shared bot identity (is_bot {{ triggerer.is_bot }}, role {{ triggerer.access_level }}) spans source {{ source._provenance.project_path }} and target {{ target._provenance.project_path }}; the writable source CI makes a cross-project token call ({{ source.job_token_cross_project_use }})."
+
+remediation_hint: >
+  Split the shared automation identity into per-project, least-privilege service accounts so no
+  single bot spans a low-trust source and a sensitive target.

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/shared-automation-bot-confused-deputy.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/shared-automation-bot-confused-deputy.yaml
@@ -18,7 +18,7 @@ chain_of:
   where:
     all_of:
       - triggerer.is_bot == true
-      - triggerer.access_level >= "developer"
+      - triggerer.access_level >= 30
       - source.job_token_cross_project_use != "none"
       - source.source_ci_writable_by_lower_trust == true
       - target.job_token_allowlist.trusts_source == true

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/terraform-state-read-poison-via-job-token-backend.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/terraform-state-read-poison-via-job-token-backend.yaml
@@ -22,7 +22,7 @@ chain_of:
       - any_of:
           - target.job_token_allowlist.fine_grained == false
           - target.job_token_allowlist.policies ∋ {ADMIN_TERRAFORM_STATE}
-      - triggerer.access_level >= "developer"
+      - triggerer.access_level >= 30
       - source.source_ci_writable_by_lower_trust == true
 
 evidence:

--- a/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/terraform-state-read-poison-via-job-token-backend.yaml
+++ b/internal/detection-rules/gitlab/cat-04-ci-job-token-abuse/terraform-state-read-poison-via-job-token-backend.yaml
@@ -1,0 +1,33 @@
+id: cat-04/terraform-state-read-poison-via-job-token-backend
+scenario_id: cat-04/05
+title: "Cross-project Terraform/OpenTofu state read and poison via the job-token state backend"
+subject: chain
+severity: critical
+confidence: high
+description: >
+  The source CI calls a different project's managed Terraform/OpenTofu state backend
+  (`/terraform/state/`) with `gitlab-ci-token:$CI_JOB_TOKEN`, and the target's allowlist entry
+  grants state admin — either fine-grained permissions absent (full default set) or an explicit
+  `ADMIN_TERRAFORM_STATE`. Under a Developer+ triggerer with writable source CI, the deputy
+  token reads the target's plaintext state (secrets, resource IDs) and PUTs a poisoned state.
+
+chain_of:
+  join: job-token-allowlist
+  for_each: edges
+  where:
+    all_of:
+      - source.job_token_cross_project_use == "terraform_state"
+      - target.uses_managed_terraform_state == true
+      - target.job_token_allowlist.trusts_source == true
+      - any_of:
+          - target.job_token_allowlist.fine_grained == false
+          - target.job_token_allowlist.policies ∋ {ADMIN_TERRAFORM_STATE}
+      - triggerer.access_level >= "developer"
+      - source.source_ci_writable_by_lower_trust == true
+
+evidence:
+  - "Source {{ source._provenance.project_path }} calls target {{ target._provenance.project_path }}'s managed Terraform state backend cross-project; allowlist entry grants state admin (fine_grained {{ target.job_token_allowlist.fine_grained }}) under triggerer role {{ triggerer.access_level }}."
+
+remediation_hint: >
+  Narrow the allowlist entry's fine-grained permissions to `READ_TERRAFORM_STATE` (or remove
+  Terraform-state access), and scope the entry to specific trusted projects only.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-04 — ci job token abuse**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Disabled inbound job-token allowlist ("All groups and projects") reached by a privileged triggering identity
- Group-scoped inbound job-token allowlist entry with no fine-grained permissions
- Pipeline schedule owned by a privileged user, on a ref a lower-trust member can edit
- Shared automation bot (single service account across trust boundaries) as job-token confused deputy
- Cross-project Terraform/OpenTofu state read and poison via the job-token state backend
- Cross-project Git push via CI_JOB_TOKEN with both write toggles enabled

Part of LAB-4982.
