### PR TITLE
GitLab detection rules: cat-10 oidc cloud trust

### DIFF
--- a/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/id-tokens-mintable-from-untrusted-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/id-tokens-mintable-from-untrusted-ref.yaml
@@ -1,0 +1,28 @@
+id: cat-10/id-tokens-mintable-from-untrusted-ref
+scenario_id: cat-10/02
+title: "OIDC id_tokens job mintable from an untrusted ref (fork-MR-in-parent / non-protected branch), token carries the trusted project identity"
+subject: job
+severity: high
+confidence: high
+description: >
+  An `id_tokens:` minting job is reachable by a low-trust actor in the trusted project's context —
+  either a fork MR run in the parent project (executing the fork's attacker-controlled
+  `.gitlab-ci.yml`) or a Developer feature branch with no protected-ref gating. Either way the
+  minted token carries the parent project's `project_id`/`project_path`, which cloud/Vault policies
+  overwhelmingly bind on. The minting config lives off the reviewed default branch.
+
+where:
+  all_of:
+    - mints_id_token == true
+    - any_of:
+        - runs_fork_mr_in_parent == true
+        - all_of:
+            - runs_on_untrusted_ref == true
+            - protected_ref_gate != "strong"
+
+evidence:
+  - "id_tokens job is mintable by a low-trust actor (fork-in-parent {{ runs_fork_mr_in_parent }}, untrusted ref {{ runs_on_untrusted_ref }}); the token names the trusted project via id_token_aud {{ id_token_aud }}."
+
+remediation_hint: >
+  Disable `ci_allow_fork_pipelines_to_run_in_parent_project` and gate id_tokens jobs to a protected
+  ref, so only trusted pipelines can mint a token in the project's identity.

--- a/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/id-tokens-minted-in-unpinned-include.yaml
+++ b/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/id-tokens-minted-in-unpinned-include.yaml
@@ -1,0 +1,28 @@
+id: cat-10/id-tokens-minted-in-unpinned-include
+scenario_id: cat-10/04
+title: "OIDC id_tokens minted inside an unpinned / mutable include or CI component"
+subject: job
+severity: high
+confidence: medium
+description: >
+  The `id_tokens:` minting job (or the script consuming the token) is contributed by an
+  `include:`/component resolved from a mutable, cross-trust ref — a branch, `~latest`, a moving tag,
+  or an unpinned remote URL a lower-trust party controls. That party can redirect the `aud`,
+  exfiltrate the JWT, or swap the exchange, capturing the consuming project's real cloud identity
+  even on a fully-trusted protected run. Include-source writer trust and the cloud policy are
+  deferred, so confidence is medium.
+
+where:
+  all_of:
+    - mints_id_token == true
+    - any_of:
+        - mutable_cross_trust_project_include == true
+        - mutable_component_version == true
+        - remote_include_untrusted_host == true
+
+evidence:
+  - "id_tokens minting logic (aud {{ id_token_aud }}) is sourced from a mutable cross-trust include/component a lower-trust party can move, poisoning the token on any run."
+
+remediation_hint: >
+  Pin the include/component that carries the id_tokens job to a 40-hex commit SHA or immutable
+  version, and only source OIDC minting config from within your trust boundary.

--- a/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/id-tokens-no-environment-scope.yaml
+++ b/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/id-tokens-no-environment-scope.yaml
@@ -1,0 +1,26 @@
+id: cat-10/id-tokens-no-environment-scope
+scenario_id: cat-10/03
+title: "OIDC id_tokens job declares no environment, so the token carries no environment claim to bind on"
+subject: job
+severity: medium
+confidence: low
+description: >
+  An `id_tokens:` job declares no `environment:` keyword, so GitLab populates none of the
+  `environment`/`environment_protected` claims a relying party would use to scope trust to a
+  protected deployment. Reachable on a non-protected ref, it lets a Developer mint a token that a
+  loosely-written cloud/Vault policy accepts. Exploitability hinges on the deferred policy actually
+  binding on `environment`, so confidence is low.
+
+where:
+  all_of:
+    - mints_id_token == true
+    - deploys_environment != true
+    - runs_on_untrusted_ref == true
+    - protected_ref_gate != "strong"
+
+evidence:
+  - "id_tokens job (aud {{ id_token_aud }}) declares no environment and is reachable on an untrusted ref (gate {{ protected_ref_gate }}), so its token carries no environment claim to scope trust."
+
+remediation_hint: >
+  Add an `environment:` scoped to the protected deployment on the id_tokens job and have the cloud
+  trust policy require the `environment`/`environment_protected` claim.

--- a/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/narrowed-sub-claim-drops-ref.yaml
+++ b/internal/detection-rules/gitlab/cat-10-oidc-cloud-trust/narrowed-sub-claim-drops-ref.yaml
@@ -1,0 +1,26 @@
+id: cat-10/narrowed-sub-claim-drops-ref
+scenario_id: cat-10/01
+title: "OIDC subject claim narrowed to drop the ref, so every branch mints the same identity as protected main"
+subject: job
+severity: high
+confidence: medium
+description: >
+  The project narrowed `ci_id_token_sub_claim_components` away from the secure default so the
+  id_token `sub` no longer carries the ref — every branch now mints an identical `sub`. An
+  `id_tokens:` job reachable on a non-protected ref therefore mints a token byte-identical to the
+  trusted `main` pipeline's. Exploitability leans on the deferred cloud/Vault policy having pinned
+  the ref via `sub`, so confidence is medium.
+
+where:
+  all_of:
+    - mints_id_token == true
+    - sub_claim_omits_ref == true
+    - runs_on_untrusted_ref == true
+    - protected_ref_gate != "strong"
+
+evidence:
+  - "id_tokens job mints on an untrusted ref (gate {{ protected_ref_gate }}) while sub_claim_components {{ sub_claim_omits_ref }} omit the ref, so its sub equals protected main's."
+
+remediation_hint: >
+  Restore `ci_id_token_sub_claim_components` to include `ref_type` and `ref`, or gate the id_tokens
+  job to a protected ref so a Developer branch cannot mint the trusted identity.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-10 — oidc cloud trust**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- OIDC subject claim narrowed to drop the ref, so every branch mints the same identity as protected main
- OIDC id_tokens job mintable from an untrusted ref (fork-MR-in-parent / non-protected branch), token carries the trusted project identity
- OIDC id_tokens job declares no environment, so the token carries no environment claim to bind on
- OIDC id_tokens minted inside an unpinned / mutable include or CI component

Part of LAB-4983.
