### PR TITLE
GitLab detection rules: cat-11 long lived credentials

### DIFF
--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/human-pat-as-cicd-variable.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/human-pat-as-cicd-variable.yaml
@@ -1,0 +1,23 @@
+id: cat-11/human-pat-as-cicd-variable
+scenario_id: cat-11/03
+title: "Human personal access token wired into a pipeline as a CI/CD variable"
+subject: credential
+severity: critical
+confidence: low
+description: >
+  An unprotected CI/CD variable whose key matches a PAT/token naming pattern
+  (`*PAT*`, `*_TOKEN`, `GITLAB_TOKEN`, `PRIVATE_TOKEN`) suggests a human personal access token is
+  wired into a pipeline a Developer can run. A human PAT inherits the token owner's entire
+  account — every project and group they belong to — so the Developer escalates from a
+  single-project role to the owner's account-wide access. A human PAT hidden in a variable is not
+  API-enumerable and the value is never returned, so this is a soft (low) signal.
+where:
+  all_of:
+    - kind == "personal_access_token"
+    - in_unprotected_variable == true
+    - key_pattern == "pat"
+evidence:
+  - "Unprotected CI/CD variable key matches a personal-access-token pattern ({{ key_pattern }}), suggesting a human PAT reachable by a Developer pipeline; the owner spans {{ backing_identity_breadth }}."
+remediation_hint: >
+  Replace the human PAT with a resource-scoped project/group access token or a job token, and
+  never store a personal access token as a CI/CD variable.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/long-lived-service-account-token-in-ci.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/long-lived-service-account-token-in-ci.yaml
@@ -1,0 +1,30 @@
+id: cat-11/long-lived-service-account-token-in-ci
+scenario_id: cat-11/04
+title: "Long-lived service-account token wired into a Developer-runnable pipeline"
+subject: credential
+severity: critical
+confidence: medium
+description: >
+  A service-account token carries the account's own cross-project permissions and, with
+  service-account expiration enforcement cleared, is minted non-expiring or with a very long
+  (~1-year) default lifetime. When it holds `api`/write scope, the account is a member of
+  projects beyond the attacker's, and it sits in an unprotected CI/CD variable, a Developer who
+  runs a pipeline captures a long-lived cross-project credential that outlives every rotation
+  window. The variable value confirming reachability is never returned by the API, so this is medium.
+where:
+  all_of:
+    - kind == "personal_access_token"
+    - service_account == true
+    - revoked != true
+    - long_lived == true
+    - in_unprotected_variable == true
+    - backing_identity_breadth != []
+    - any_of:
+        - scopes ∋ {api}
+        - scopes ∋ {write_repository}
+        - scopes ∋ {write_registry}
+evidence:
+  - "Service-account token with scopes {{ scopes }}, long-lived {{ long_lived }}, member of {{ backing_identity_breadth }}, co-exists with an unprotected CI/CD variable reachable by a Developer pipeline."
+remediation_hint: >
+  Enforce service-account token expiration, scope the account to only the projects it needs, and
+  store its token in a `protected` variable used from protected refs.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/non-expiring-group-deploy-token-auto-injected.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/non-expiring-group-deploy-token-auto-injected.yaml
@@ -1,0 +1,25 @@
+id: cat-11/non-expiring-group-deploy-token-auto-injected
+scenario_id: cat-11/05
+title: "Non-expiring group deploy token auto-injected as `gitlab-deploy-token`"
+subject: credential
+severity: critical
+confidence: high
+description: >
+  A group-level deploy token named `gitlab-deploy-token` is auto-injected into every CI/CD job
+  as `CI_DEPLOY_USER`/`CI_DEPLOY_PASSWORD` with no variable wiring. It carries `write_registry`
+  (container-registry write) and has no expiry, so any Developer who runs any pipeline in the
+  group receives a standing, group-wide, never-expiring container-registry-write credential valid
+  across every project in the group. All signals are token metadata, so this is high confidence.
+where:
+  all_of:
+    - kind == "deploy_token"
+    - scope_level == "group"
+    - revoked != true
+    - non_expiring == true
+    - auto_injected == true
+    - scopes ∋ {write_registry}
+evidence:
+  - "Group deploy token `{{ name }}` is auto-injected ({{ auto_injected }}), never expires ({{ non_expiring }}), and carries {{ scopes }} across every project in the group."
+remediation_hint: >
+  Set an expiry on the deploy token, drop `write_registry` if only pull is needed, and avoid the
+  auto-injected `gitlab-deploy-token` name for a group-wide write credential.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/non-expiring-package-registry-deploy-token.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/non-expiring-package-registry-deploy-token.yaml
@@ -1,0 +1,25 @@
+id: cat-11/non-expiring-package-registry-deploy-token
+scenario_id: cat-11/07
+title: "Non-expiring `write_package_registry` deploy token reachable from a pipeline"
+subject: credential
+severity: high
+confidence: high
+description: >
+  A deploy token carries `write_package_registry` (npm/PyPI/Maven/Generic publish) and has no
+  expiry, and is named `gitlab-deploy-token` so it is auto-injected into every CI/CD job as
+  `CI_DEPLOY_USER`/`CI_DEPLOY_PASSWORD` with no variable wiring. Any Developer who runs a pipeline
+  gains a standing, never-expiring package-publish credential; for a group token it writes into
+  package namespaces they are not a member of. Reachability is inferable from the token name, so
+  this is high confidence.
+where:
+  all_of:
+    - kind == "deploy_token"
+    - revoked != true
+    - non_expiring == true
+    - auto_injected == true
+    - scopes ∋ {write_package_registry}
+evidence:
+  - "Deploy token `{{ name }}` is auto-injected ({{ auto_injected }}), never expires ({{ non_expiring }}), and carries {{ scopes }} package-publish access."
+remediation_hint: >
+  Set an expiry on the deploy token, drop `write_package_registry` if only read is needed, and
+  avoid the auto-injected `gitlab-deploy-token` name for a package-publish credential.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/non-expiring-project-deploy-token-in-variable.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/non-expiring-project-deploy-token-in-variable.yaml
@@ -1,0 +1,26 @@
+id: cat-11/non-expiring-project-deploy-token-in-variable
+scenario_id: cat-11/06
+title: "Non-expiring, container-registry-write project deploy token in an unprotected variable"
+subject: credential
+severity: high
+confidence: medium
+description: >
+  A project deploy token carries `write_registry` (container-image write) and has no expiry, and
+  its value sits in an unprotected CI/CD variable whose key matches a deploy-token/credential
+  pattern. Any Developer who runs a pipeline on any branch reads it, capturing a standing,
+  never-expiring container-registry-write credential not tied to their account that outlives
+  their membership. The variable value confirming reachability is never returned by the API, so
+  this is medium.
+where:
+  all_of:
+    - kind == "deploy_token"
+    - scope_level == "project"
+    - revoked != true
+    - non_expiring == true
+    - in_unprotected_variable == true
+    - scopes ∋ {write_registry}
+evidence:
+  - "Project deploy token `{{ name }}` never expires ({{ non_expiring }}), carries {{ scopes }}, and co-exists with an unprotected CI/CD variable reachable by a Developer pipeline."
+remediation_hint: >
+  Set an expiry on the deploy token, drop `write_registry` if only pull is needed, and store its
+  password only in a `protected` variable used from protected refs.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/over-scoped-group-access-token-inheritance.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/over-scoped-group-access-token-inheritance.yaml
@@ -1,0 +1,28 @@
+id: cat-11/over-scoped-group-access-token-inheritance
+scenario_id: cat-11/02
+title: "Over-scoped group access token whose bot inherits into a Developer-runnable pipeline"
+subject: credential
+severity: critical
+confidence: medium
+description: >
+  A group access token is minted with the full `api` scope (or `write_repository` /
+  `write_registry`) and role Developer or higher (`access_level >= 30`). Because its backing bot
+  is a member of every subgroup and project in the tree, even a Developer-role token is a
+  tree-wide credential. Stored in a group-inherited unprotected CI/CD variable, any descendant
+  Developer who runs a pipeline captures a group-wide bot credential. The variable value
+  confirming reachability is never returned by the API, so this is medium.
+where:
+  all_of:
+    - kind == "group_access_token"
+    - revoked != true
+    - access_level >= 30
+    - in_unprotected_variable == true
+    - any_of:
+        - scopes ∋ {api}
+        - scopes ∋ {write_repository}
+        - scopes ∋ {write_registry}
+evidence:
+  - "Group access token with scopes {{ scopes }} and role {{ access_level }} inherits tree-wide and co-exists with an unprotected group CI/CD variable reachable by a descendant Developer pipeline."
+remediation_hint: >
+  Re-mint the group automation token with the narrowest scope and role it needs, scope it to the
+  projects that actually use it, and keep it in a `protected` variable used only from protected refs.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/over-scoped-project-access-token.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/over-scoped-project-access-token.yaml
@@ -1,0 +1,28 @@
+id: cat-11/over-scoped-project-access-token
+scenario_id: cat-11/01
+title: "Over-scoped project access token reachable from a Developer-runnable pipeline"
+subject: credential
+severity: critical
+confidence: medium
+description: >
+  A project access token is minted with the full `api` scope (or `write_repository` /
+  `write_registry`) and a Maintainer/Owner role (`access_level >= 40`), far beyond a narrow
+  automation need, and its value sits in an unprotected CI/CD variable a Developer-pushable
+  pipeline can read. A Developer captures a standing Maintainer/Owner-equivalent bot credential
+  and gains full read/write API control the Developer role was designed to withhold. The
+  variable value confirming reachability is never returned by the API, so this is medium.
+where:
+  all_of:
+    - kind == "project_access_token"
+    - revoked != true
+    - access_level >= 40
+    - in_unprotected_variable == true
+    - any_of:
+        - scopes ∋ {api}
+        - scopes ∋ {write_repository}
+        - scopes ∋ {write_registry}
+evidence:
+  - "Project access token with scopes {{ scopes }} and role {{ access_level }} co-exists with an unprotected CI/CD variable reachable by a Developer pipeline."
+remediation_hint: >
+  Re-mint the automation token with the narrowest scope and role it actually needs
+  (e.g. `read_repository`), and store it only in a `protected` variable used from protected refs.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/reused-readwrite-deploy-key-cross-trust.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/reused-readwrite-deploy-key-cross-trust.yaml
@@ -13,6 +13,7 @@ description: >
   Whether the private half is genuinely reachable is the deferred leg, so this is medium.
 chain_of:
   join: deploy-key-reuse
+  for_each: reused_keys
   where:
     all_of:
       - key.kind == "deploy_key"

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/reused-readwrite-deploy-key-cross-trust.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/reused-readwrite-deploy-key-cross-trust.yaml
@@ -1,0 +1,27 @@
+id: cat-11/reused-readwrite-deploy-key-cross-trust
+scenario_id: cat-11/08
+title: "Read/write deploy key reused across a trust boundary, pushing to trigger privileged CI"
+subject: chain
+severity: high
+confidence: medium
+description: >
+  The same deploy-key fingerprint is enabled on more than one project with `can_push == true`
+  on at least one, spanning a trust boundary. When such a key pushes a commit, the pushed
+  pipeline runs with the key creator's access to protected environments and secret variables. An
+  attacker who reads the private half from a low-trust project's unprotected variable pushes into
+  a higher-trust project and executes a privileged pipeline their own role could not trigger.
+  Whether the private half is genuinely reachable is the deferred leg, so this is medium.
+chain_of:
+  join: deploy-key-reuse
+  where:
+    all_of:
+      - key.kind == "deploy_key"
+      - key.can_push == true
+      - source.in_unprotected_variable == true
+      - target.holds_protected_resources == true
+      - key.creator_has_target_protected_access == true
+evidence:
+  - "Deploy key {{ key.deploy_key_fingerprint }} (can_push {{ key.can_push }}) is reused on a low-trust project with a reachable private half in an unprotected variable and on a higher-trust project holding protected resources, where its creator has protected-resource access the pushed pipeline inherits."
+remediation_hint: >
+  Use a distinct, read-only deploy key per project, never share a read/write key across a trust
+  boundary, and keep any private key out of unprotected CI/CD variables.

--- a/internal/detection-rules/gitlab/cat-11-long-lived-credentials/static-cloud-credential-in-variable-instead-of-oidc.yaml
+++ b/internal/detection-rules/gitlab/cat-11-long-lived-credentials/static-cloud-credential-in-variable-instead-of-oidc.yaml
@@ -1,0 +1,25 @@
+id: cat-11/static-cloud-credential-in-variable-instead-of-oidc
+scenario_id: cat-11/09
+title: "Long-lived static cloud credential kept in a CI/CD variable instead of short-lived OIDC"
+subject: credential
+severity: high
+confidence: low
+description: >
+  An unprotected CI/CD variable whose key matches a well-known static cloud-credential pattern
+  (`AWS_SECRET_ACCESS_KEY`, `AZURE_CLIENT_SECRET`, `GCP_SA_KEY`, etc.), in a project whose
+  resolved `.gitlab-ci.yml` defines no `id_tokens:` OIDC path, indicates a standing static cloud
+  key was retained over short-lived OIDC. CI/CD variables have no expiry, so the credential is
+  long-lived by construction; any Developer who pushes a branch reads it and gains cloud access
+  that survives their membership. Whether the value is a live cloud key is deferred, so this is a
+  soft (low) signal.
+where:
+  all_of:
+    - kind == "static_cloud_cred"
+    - in_unprotected_variable == true
+    - key_pattern == "cloud"
+    - project_uses_oidc != true
+evidence:
+  - "Unprotected CI/CD variable key matches a static cloud-credential pattern ({{ key_pattern }}) in a project with no `id_tokens:` OIDC path."
+remediation_hint: >
+  Adopt `id_tokens:` OIDC to mint short-lived, ref/environment-bound cloud tokens at run time and
+  remove the standing static cloud credential from CI/CD variables.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-11 — long lived credentials**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Over-scoped project access token reachable from a Developer-runnable pipeline
- Over-scoped group access token whose bot inherits into a Developer-runnable pipeline
- Human personal access token wired into a pipeline as a CI/CD variable
- Long-lived service-account token wired into a Developer-runnable pipeline
- Non-expiring group deploy token auto-injected as `gitlab-deploy-token`
- Non-expiring, container-registry-write project deploy token in an unprotected variable
- Non-expiring `write_package_registry` deploy token reachable from a pipeline
- Read/write deploy key reused across a trust boundary, pushing to trigger privileged CI
- Long-lived static cloud credential kept in a CI/CD variable instead of short-lived OIDC

Closes LAB-4982.
