### PR TITLE
GitLab detection rules: cat-13 ai agent in ci

### DIFF
--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/code-review-flow-fork-mr-guardrail-not-interrupt.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/code-review-flow-fork-mr-guardrail-not-interrupt.yaml
@@ -1,0 +1,30 @@
+id: cat-13/code-review-flow-fork-mr-guardrail-not-interrupt
+scenario_id: cat-13/01
+title: "Duo Code Review flow runs in CI on a fork merge request with prompt-injection guardrail not set to Interrupt and secrets in scope"
+subject: job
+severity: critical
+confidence: low
+description: >
+  The Duo Code Review flow runs as a `gitlab-duo` CI job that ingests fork-MR
+  description/diff/comments as untrusted context while its group prompt-injection guardrail is
+  detect-only (`LOG_ONLY`), the job carries an unprotected CI/CD variable and/or a broad job
+  token, and the agent has write-capable actions with no per-action approval — so a fork-MR
+  author who never held membership can steer the agent to exfiltrate secrets or act as its
+  service account.
+
+where:
+  all_of:
+    - is_duo_flow == true
+    - duo_flow_context_sources ∋ {fork_mr}
+    - duo_group_features_enabled == true
+    - duo_guardrail_level == "log_only"
+    - runner_tags ∋ {gitlab-duo}
+    - duo_flow_secrets_in_scope == true
+    - duo_flow_autonomous_write == true
+
+evidence:
+  - "Duo Code Review flow job `{{ _provenance.config_file }}` ingests fork-MR content, runs on a `gitlab-duo` runner with secrets in scope, and its group guardrail is `{{ duo_guardrail_level }}` (not Interrupt) with write-capable autonomous actions."
+
+remediation_hint: >
+  Set the group prompt-injection protection level to `INTERRUPT`, remove unprotected secrets from
+  the flow job, and require per-action human approval for write actions on fork-MR-triggered flows.

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/code-review-flow-fork-mr-guardrail-not-interrupt.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/code-review-flow-fork-mr-guardrail-not-interrupt.yaml
@@ -17,7 +17,7 @@ where:
     - is_duo_flow == true
     - duo_flow_context_sources ∋ {fork_mr}
     - duo_group_features_enabled == true
-    - duo_guardrail_level == "log_only"
+    - duo_guardrail_level == "LOG_ONLY"
     - runner_tags ∋ {gitlab-duo}
     - duo_flow_secrets_in_scope == true
     - duo_flow_autonomous_write == true

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/external-agent-flow-scanning-structurally-absent.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/external-agent-flow-scanning-structurally-absent.yaml
@@ -1,0 +1,29 @@
+id: cat-13/external-agent-flow-scanning-structurally-absent
+scenario_id: cat-13/06
+title: "Duo CI flow wired to an external agent (third-party model provider) whose output GitLab does not scan, with secrets and write actions in scope"
+subject: job
+severity: critical
+confidence: low
+description: >
+  A Duo flow is wired through `.gitlab/duo/flows/*.yaml` to an external agent (third-party model
+  provider) whose endpoint is outside the org trust boundary. GitLab documents that prompt scanning
+  is not available for external agents, so the `INTERRUPT` guardrail is structurally absent over
+  that channel regardless of its level. The job carries an unprotected CI/CD variable and/or a
+  broad job token and the agent has write-capable autonomous actions, making every response an
+  unfiltered injection channel controlled by a non-member.
+
+where:
+  all_of:
+    - is_duo_flow == true
+    - duo_external_agent_untrusted_host == true
+    - duo_group_features_enabled == true
+    - runner_tags ∋ {gitlab-duo}
+    - duo_flow_secrets_in_scope == true
+    - duo_flow_autonomous_write == true
+
+evidence:
+  - "Duo flow job `{{ _provenance.config_file }}` is wired to an out-of-trust external agent (unscanned by GitLab), runs on a `gitlab-duo` runner with secrets in scope, and has write-capable autonomous actions."
+
+remediation_hint: >
+  Do not attach untrusted external agents to secret-bearing autonomous flows; isolate returned
+  output as untrusted and remove secrets and write actions from the flow's CI job.

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/external-mcp-server-untrusted-tool-output.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/external-mcp-server-untrusted-tool-output.yaml
@@ -1,0 +1,30 @@
+id: cat-13/external-mcp-server-untrusted-tool-output
+scenario_id: cat-13/05
+title: "Duo CI agent wired via mcp.json to an external MCP server whose tool output is trusted context, with secrets and write actions in scope"
+subject: job
+severity: critical
+confidence: low
+description: >
+  A Duo CI agent is wired through `.gitlab/duo/mcp.json` to an MCP server whose endpoint is outside
+  the org trust boundary, with `duoWorkflowMcpEnabled` on at the group. Every tool call returns
+  content the operator does not control, fed to the model as trusted context. The job carries an
+  unprotected CI/CD variable and/or a broad job token and the agent has write-capable autonomous
+  actions — and the prompt-injection guardrail does not filter MCP tool output, so it is not the
+  lever here.
+
+where:
+  all_of:
+    - is_duo_flow == true
+    - duo_mcp_endpoint_untrusted_host == true
+    - duo_group_features_enabled == true
+    - duo_workflow_mcp_enabled == true
+    - runner_tags ∋ {gitlab-duo}
+    - duo_flow_secrets_in_scope == true
+    - duo_flow_autonomous_write == true
+
+evidence:
+  - "Duo CI agent job `{{ _provenance.config_file }}` is wired via mcp.json to an out-of-trust MCP endpoint with `duoWorkflowMcpEnabled` on, runs on a `gitlab-duo` runner with secrets in scope, and has write-capable autonomous actions."
+
+remediation_hint: >
+  Restrict the agent's MCP servers to org-internal/allowlisted endpoints, isolate tool output as
+  untrusted, and remove secrets and autonomous write actions from the agent's CI job.

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/issue-comment-flow-guardrail-not-interrupt.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/issue-comment-flow-guardrail-not-interrupt.yaml
@@ -17,7 +17,7 @@ where:
     - is_duo_flow == true
     - duo_flow_context_sources ∋ {issue_comment}
     - duo_group_features_enabled == true
-    - duo_guardrail_level == "log_only"
+    - duo_guardrail_level == "LOG_ONLY"
     - runner_tags ∋ {gitlab-duo}
     - duo_flow_secrets_in_scope == true
     - duo_flow_autonomous_write == true

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/issue-comment-flow-guardrail-not-interrupt.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/issue-comment-flow-guardrail-not-interrupt.yaml
@@ -1,0 +1,30 @@
+id: cat-13/issue-comment-flow-guardrail-not-interrupt
+scenario_id: cat-13/02
+title: "Duo flow runs in CI on issue/comment text with prompt-injection guardrail not set to Interrupt and secrets in scope"
+subject: job
+severity: critical
+confidence: low
+description: >
+  A Duo flow runs as a `gitlab-duo` CI job whose context includes attacker-authored issue or
+  comment text while its group prompt-injection guardrail is detect-only (`LOG_ONLY`), the job
+  carries an unprotected CI/CD variable and/or a broad job token, and the agent has write-capable
+  actions with no per-action approval — so any user who can file an issue or comment, a far wider
+  population than those with push access, can steer the agent to exfiltrate secrets or act as its
+  service account.
+
+where:
+  all_of:
+    - is_duo_flow == true
+    - duo_flow_context_sources ∋ {issue_comment}
+    - duo_group_features_enabled == true
+    - duo_guardrail_level == "log_only"
+    - runner_tags ∋ {gitlab-duo}
+    - duo_flow_secrets_in_scope == true
+    - duo_flow_autonomous_write == true
+
+evidence:
+  - "Duo flow job `{{ _provenance.config_file }}` ingests issue/comment text, runs on a `gitlab-duo` runner with secrets in scope, and its group guardrail is `{{ duo_guardrail_level }}` (not Interrupt) with write-capable autonomous actions."
+
+remediation_hint: >
+  Set the group prompt-injection protection level to `INTERRUPT`, remove unprotected secrets from
+  the flow job, and require per-action human approval before the agent acts on issue/comment context.

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/prompt-injection-scanner-disabled-no-checks.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/prompt-injection-scanner-disabled-no-checks.yaml
@@ -1,0 +1,31 @@
+id: cat-13/prompt-injection-scanner-disabled-no-checks
+scenario_id: cat-13/03
+title: "Duo prompt-injection scanner disabled (NO_CHECKS) on a secret-bearing autonomous flow reading untrusted content"
+subject: job
+severity: critical
+confidence: low
+description: >
+  A Duo flow runs as a `gitlab-duo` CI job that ingests attacker-reachable content (fork MR or
+  issue/comment) while its group prompt-injection guardrail is deliberately set to `NO_CHECKS` —
+  scanning is off entirely, worse than the `LOG_ONLY` default and leaving no log trail. The job
+  carries an unprotected CI/CD variable and/or a broad job token and the agent has write-capable
+  actions with no per-action approval, so a low-trust content author can steer it unfiltered.
+
+where:
+  all_of:
+    - is_duo_flow == true
+    - any_of:
+        - duo_flow_context_sources ∋ {fork_mr}
+        - duo_flow_context_sources ∋ {issue_comment}
+    - duo_group_features_enabled == true
+    - duo_guardrail_level == "no_checks"
+    - runner_tags ∋ {gitlab-duo}
+    - duo_flow_secrets_in_scope == true
+    - duo_flow_autonomous_write == true
+
+evidence:
+  - "Duo flow job `{{ _provenance.config_file }}` ingests untrusted content and runs on a `gitlab-duo` runner with secrets in scope, while its group guardrail is `{{ duo_guardrail_level }}` (scanning disabled) with write-capable autonomous actions."
+
+remediation_hint: >
+  Set the group prompt-injection protection level to `INTERRUPT` rather than `NO_CHECKS`, and
+  remove unprotected secrets and autonomous write actions from flows reading untrusted content.

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/prompt-injection-scanner-disabled-no-checks.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/prompt-injection-scanner-disabled-no-checks.yaml
@@ -18,7 +18,7 @@ where:
         - duo_flow_context_sources ∋ {fork_mr}
         - duo_flow_context_sources ∋ {issue_comment}
     - duo_group_features_enabled == true
-    - duo_guardrail_level == "no_checks"
+    - duo_guardrail_level == "NO_CHECKS"
     - runner_tags ∋ {gitlab-duo}
     - duo_flow_secrets_in_scope == true
     - duo_flow_autonomous_write == true

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/self-managed-instance-duo-guardrail-not-interrupt.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/self-managed-instance-duo-guardrail-not-interrupt.yaml
@@ -18,7 +18,7 @@ where:
         - duo_flow_context_sources ∋ {fork_mr}
         - duo_flow_context_sources ∋ {issue_comment}
     - duo_instance_features_enabled == true
-    - duo_instance_guardrail_level != "interrupt"
+    - duo_instance_guardrail_level != "INTERRUPT"
     - runner_tags ∋ {gitlab-duo}
     - duo_flow_secrets_in_scope == true
     - duo_flow_autonomous_write == true

--- a/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/self-managed-instance-duo-guardrail-not-interrupt.yaml
+++ b/internal/detection-rules/gitlab/cat-13-ai-agent-in-ci/self-managed-instance-duo-guardrail-not-interrupt.yaml
@@ -1,0 +1,31 @@
+id: cat-13/self-managed-instance-duo-guardrail-not-interrupt
+scenario_id: cat-13/04
+title: "Self-managed instance Duo enabled with instance-level prompt-injection guardrail not set to Interrupt and secrets in a flow's CI job"
+subject: job
+severity: critical
+confidence: low
+description: >
+  On self-managed GitLab the Duo posture is an instance-level admin decision. A flow runs as a CI
+  job on an operator-provisioned `gitlab-duo` runner, ingesting untrusted content, while the
+  instance prompt-injection guardrail is not `INTERRUPT` (either `LOG_ONLY` or `NO_CHECKS`). The
+  job carries an unprotected CI/CD variable and/or a broad job token and the agent has write-capable
+  actions with no per-action approval — the self-managed analog of the SaaS group-level scenarios.
+
+where:
+  all_of:
+    - is_duo_flow == true
+    - any_of:
+        - duo_flow_context_sources ∋ {fork_mr}
+        - duo_flow_context_sources ∋ {issue_comment}
+    - duo_instance_features_enabled == true
+    - duo_instance_guardrail_level != "interrupt"
+    - runner_tags ∋ {gitlab-duo}
+    - duo_flow_secrets_in_scope == true
+    - duo_flow_autonomous_write == true
+
+evidence:
+  - "Duo flow job `{{ _provenance.config_file }}` runs on an operator-provisioned `gitlab-duo` runner with secrets in scope while the instance guardrail is `{{ duo_instance_guardrail_level }}` (not Interrupt) with write-capable autonomous actions."
+
+remediation_hint: >
+  Set the instance-level prompt-injection protection level to `INTERRUPT` under Admin > GitLab Duo,
+  and remove unprotected secrets and autonomous write actions from flows reading untrusted content.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-13 — ai agent in ci**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Duo Code Review flow runs in CI on a fork merge request with prompt-injection guardrail not set to Interrupt and secrets in scope
- Duo flow runs in CI on issue/comment text with prompt-injection guardrail not set to Interrupt and secrets in scope
- Duo prompt-injection scanner disabled (NO_CHECKS) on a secret-bearing autonomous flow reading untrusted content
- Self-managed instance Duo enabled with instance-level prompt-injection guardrail not set to Interrupt and secrets in a flow's CI job
- Duo CI agent wired via mcp.json to an external MCP server whose tool output is trusted context, with secrets and write actions in scope
- Duo CI flow wired to an external agent (third-party model provider) whose output GitLab does not scan, with secrets and write actions in scope

Part of LAB-4983.
