### PR TITLE
GitLab detection rules: cat-15 kubernetes agent ci access

### DIFF
--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/config-project-implicit-authorization.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/config-project-implicit-authorization.yaml
@@ -1,0 +1,22 @@
+id: cat-15/config-project-implicit-authorization
+scenario_id: cat-15/03
+title: "Agent configuration project is implicitly authorized for ci_access, so any Developer who can push it reaches the cluster without appearing in any grant"
+subject: agent
+severity: high
+confidence: medium
+description: >
+  The project hosting `.gitlab/agents/<name>/config.yaml` is authorized to its own agent
+  implicitly — with `access_as: agent` and no `protected_branches_only` — whether or not it
+  appears in any grant list. When that configuration project has lower-trust Developer members
+  or a Developer-pushable non-protected branch, any of them receives the injected `$KUBECONFIG`
+  as the agent's ServiceAccount from an ordinary feature-branch job.
+where:
+  all_of:
+    - implicit_config_project == true
+    - impersonation == null
+    - config_project_developer_reachable == true
+evidence:
+  - "The agent configuration project ({{ config_path }}) is implicitly authorized with no impersonation and is reachable by lower-trust Developers, who receive the agent's kubeconfig."
+remediation_hint: >
+  Restrict the configuration project's membership and protected branches to cluster operators, or
+  host the agent config in a project whose only members operate the cluster.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/environment-filter-free-tier.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/environment-filter-free-tier.yaml
@@ -1,0 +1,23 @@
+id: cat-15/environment-filter-free-tier
+scenario_id: cat-15/07
+title: "Kubernetes agent ci_access environments filter on a Free-tier namespace, where protected environments do not exist so the filter is decorative"
+subject: agent
+severity: high
+confidence: low
+description: >
+  On a Free-tier namespace an operator adds an `environments:` filter to an agent's `ci_access`
+  grant, but protected environments — the only mechanism that makes an environment name require
+  deploy authorization — are Premium/Ultimate-only. Every filter name is therefore a free-text
+  label a Developer writes on a non-protected-branch job. With impersonation also unavailable on
+  Free, the passing job receives the injected `$KUBECONFIG` as the agent's ServiceAccount.
+where:
+  all_of:
+    - namespace_plan == "free"
+    - environments_filter != []
+    - protected_branches_only != true
+    - grant_developer_authors_matching_env_job == true
+evidence:
+  - "Agent environments filter {{ environments_filter }} is on a Free-tier namespace where no environment can be protected, so the filter is decorative and a Developer forges a matching name to receive the agent's kubeconfig."
+remediation_hint: >
+  Do not rely on `ci_access.environments` for scoping on Free; set `protected_branches_only: true`
+  and narrow the grant to a vetted project list, or upgrade to gain protected environments.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/environment-filter-unprotected-named.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/environment-filter-unprotected-named.yaml
@@ -1,0 +1,26 @@
+id: cat-15/environment-filter-unprotected-named
+scenario_id: cat-15/06
+title: "Kubernetes agent ci_access environments filter names an environment that is not protected, so a Developer forges the name to reach the cluster"
+subject: agent
+severity: high
+confidence: low
+description: >
+  The `ci_access.environments` filter names a specific, non-wildcard environment the operator
+  relies on to scope cluster access, but that environment is not in the in-scope project's
+  protected-environments list — so declaring it carries no deploy-authorization check. A
+  Developer writes the trusted name on a non-protected-branch job and passes the filter; with no
+  `access_as:` impersonation the job receives the injected `$KUBECONFIG` as the agent's
+  ServiceAccount.
+where:
+  all_of:
+    - environments_filter != []
+    - environments_filter_wildcard != true
+    - environments_filter_unprotected == true
+    - impersonation == null
+    - protected_branches_only != true
+    - grant_developer_authors_matching_env_job == true
+evidence:
+  - "Agent environments filter {{ environments_filter }} names an environment absent from the in-scope project's protected-environments list, so a Developer forges the name to receive the agent's kubeconfig."
+remediation_hint: >
+  Mark the named environment protected with a Maintainer-only deployer list, or scope the grant
+  with `protected_branches_only: true` and `access_as:` impersonation.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/environment-filter-wildcard.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/environment-filter-wildcard.yaml
@@ -1,0 +1,24 @@
+id: cat-15/environment-filter-wildcard
+scenario_id: cat-15/05
+title: "Kubernetes agent ci_access environments filter uses a wildcard, which any Developer-authored environment slug matches"
+subject: agent
+severity: high
+confidence: low
+description: >
+  The `ci_access.environments` filter contains a wildcard (`*` or a prefix wildcard such as
+  `review/*`). Because a job's `environment:` value is a free-text string the author writes,
+  a Developer names a matching slug on a non-protected-branch job and passes the filter. With no
+  `access_as:` impersonation and `protected_branches_only` false/absent, the forged-through job
+  receives the injected `$KUBECONFIG` as the agent's ServiceAccount.
+where:
+  all_of:
+    - environments_filter != []
+    - environments_filter_wildcard == true
+    - impersonation == null
+    - protected_branches_only != true
+    - grant_developer_authors_matching_env_job == true
+evidence:
+  - "Agent environments filter {{ environments_filter }} contains a wildcard with no impersonation or branch gate, so a Developer forges a matching environment slug to receive the agent's kubeconfig."
+remediation_hint: >
+  Replace wildcard entries in `ci_access.environments` with fixed names backed by protected
+  environments, and configure `access_as:` impersonation.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/group-tree-no-impersonation.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/group-tree-no-impersonation.yaml
@@ -1,0 +1,24 @@
+id: cat-15/group-tree-no-impersonation
+scenario_id: cat-15/01
+title: "Kubernetes agent ci_access authorizes a whole group tree with no impersonation, giving any in-scope Developer a cluster kubeconfig"
+subject: agent
+severity: high
+confidence: medium
+description: >
+  A Kubernetes agent's `ci_access.groups` grant authorizes the named group and — because
+  subgroups auto-include — its entire subtree, while no `access_as:` impersonation is set,
+  so authorized jobs run as the agent's ServiceAccount. With `protected_branches_only`
+  false/absent and no `environments:` filter, any in-scope Developer pushes a non-protected
+  branch and their job receives the injected `$KUBECONFIG`.
+where:
+  all_of:
+    - ci_access_scope == "group"
+    - impersonation == null
+    - protected_branches_only != true
+    - environments_filter == []
+    - grant_has_lower_trust_developer == true
+evidence:
+  - "Agent grant is group-scoped ({{ ci_access_targets }}) with no impersonation and no branch/environment gate, so a lower-trust Developer in the authorized subtree receives the agent's kubeconfig."
+remediation_hint: >
+  Narrow the grant to a vetted `ci_access.projects` list, set `protected_branches_only: true`,
+  and configure `access_as:` impersonation so jobs do not run as the agent ServiceAccount.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/instance-wide-grant-self-managed.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/instance-wide-grant-self-managed.yaml
@@ -1,0 +1,23 @@
+id: cat-15/instance-wide-grant-self-managed
+scenario_id: cat-15/04
+title: "Kubernetes agent ci_access grants instance scope on a self-managed instance, authorizing every project's pipelines to the cluster"
+subject: agent
+severity: high
+confidence: medium
+description: >
+  A `ci_access.instance` grant on a self-managed instance authorizes every project on the
+  instance to reach the cluster, not a chosen group or project. With the enabling admin setting
+  on, no `access_as:` impersonation, and `protected_branches_only` false/absent, any authenticated
+  user who can run a pipeline anywhere receives the injected `$KUBECONFIG` as the agent's
+  ServiceAccount — including tenants with no relationship to the cluster.
+where:
+  all_of:
+    - ci_access_scope == "instance"
+    - instance_agent_authorization_enabled == true
+    - impersonation == null
+    - protected_branches_only != true
+evidence:
+  - "Agent grant is instance-scoped with instance-level authorization enabled and no impersonation, so any pipeline on the instance receives the agent's kubeconfig."
+remediation_hint: >
+  Replace the `ci_access.instance` grant with a scoped `ci_access.projects`/`groups` list, or
+  disable instance-level agent authorization in admin settings.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/protected-branch-developer-pushable.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/protected-branch-developer-pushable.yaml
@@ -1,0 +1,23 @@
+id: cat-15/protected-branch-developer-pushable
+scenario_id: cat-15/08
+title: "Kubernetes agent ci_access has protected_branches_only enabled, but the in-scope project's protected branch is Developer-pushable, so the branch gate authorizes the very actor it should exclude"
+subject: agent
+severity: high
+confidence: low
+description: >
+  The agent grant sets `protected_branches_only: true` — the safe value — but the in-scope
+  project's protected-ref access rules include the Developer level: a protected branch a Developer
+  may push, a wildcard protected pattern a Developer may create matching branches under, or a
+  protected tag a Developer may create. The Developer lands a pipeline on a gate-satisfying ref
+  and, with no `access_as:` impersonation, receives the injected `$KUBECONFIG` as the agent's
+  ServiceAccount.
+where:
+  all_of:
+    - protected_branches_only == true
+    - impersonation == null
+    - grant_protected_ref_developer_writable == true
+evidence:
+  - "Agent grant relies on protected_branches_only but the in-scope project has a protected branch or tag writable by the Developer level, so a Developer lands a protected-ref pipeline and receives the agent's kubeconfig."
+remediation_hint: >
+  Restrict the in-scope project's protected-branch push/merge and protected-tag create access to
+  Maintainers, and configure `access_as:` impersonation.

--- a/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/unprotected-branch-single-project.yaml
+++ b/internal/detection-rules/gitlab/cat-15-kubernetes-agent-ci-access/unprotected-branch-single-project.yaml
@@ -1,0 +1,23 @@
+id: cat-15/unprotected-branch-single-project
+scenario_id: cat-15/02
+title: "Kubernetes agent ci_access grant leaves protected_branches_only false, so a Developer's throwaway branch reaches the cluster"
+subject: agent
+severity: high
+confidence: low
+description: >
+  A narrow, single-project `ci_access` grant leaves `protected_branches_only` at its false
+  default, so every pipeline in the authorized project — including a Developer's non-protected
+  feature branch — receives the injected `$KUBECONFIG`. With no `access_as:` impersonation the
+  job runs as the agent's ServiceAccount, defeating the operator's belief that only the
+  protected deploy branch reaches the cluster.
+where:
+  all_of:
+    - ci_access_scope == "project"
+    - protected_branches_only != true
+    - impersonation == null
+    - grant_developer_pushable_unprotected_branch == true
+evidence:
+  - "Single-project agent grant ({{ ci_access_targets }}) has protected_branches_only false and no impersonation, so a Developer pushing a non-protected branch receives the agent's kubeconfig."
+remediation_hint: >
+  Set `protected_branches_only: true` on the grant so only protected-ref pipelines receive the
+  kubeconfig, and configure `access_as:` impersonation.


### PR DESCRIPTION
GitLab CI/CD detection rules for **cat-15 — kubernetes agent ci access**, authored as declarative YAML on the shared rule-DSL engine under `internal/detection-rules/gitlab/`, backtracked 1:1 from the GitLab detection corpus (one rule per scenario).

Rules:
- Kubernetes agent ci_access authorizes a whole group tree with no impersonation, giving any in-scope Developer a cluster kubeconfig
- Kubernetes agent ci_access grant leaves protected_branches_only false, so a Developer's throwaway branch reaches the cluster
- Agent configuration project is implicitly authorized for ci_access, so any Developer who can push it reaches the cluster without appearing in any grant
- Kubernetes agent ci_access grants instance scope on a self-managed instance, authorizing every project's pipelines to the cluster
- Kubernetes agent ci_access environments filter uses a wildcard, which any Developer-authored environment slug matches
- Kubernetes agent ci_access environments filter names an environment that is not protected, so a Developer forges the name to reach the cluster
- Kubernetes agent ci_access environments filter on a Free-tier namespace, where protected environments do not exist so the filter is decorative
- Kubernetes agent ci_access has protected_branches_only enabled, but the in-scope project's protected branch is Developer-pushable, so the branch gate authorizes the very actor it should exclude

Closes LAB-4983.
