### PR TITLE
ado: add collect phase for the internal phased pipeline

### DIFF
--- a/cmd/trajan/ado/collect.go
+++ b/cmd/trajan/ado/collect.go
@@ -21,6 +21,7 @@ func newCollectCmd() *cobra.Command {
 			if len(args) > 0 {
 				locator = args[0]
 			}
+			cfg.Token, _ = cmd.Flags().GetString("token") // honor the global --token (persistent flag)
 			_, err := adocollect.Collect(cmd.Context(), cfg, locator)
 			return err
 		},

--- a/cmd/trajan/ado/collect.go
+++ b/cmd/trajan/ado/collect.go
@@ -1,0 +1,31 @@
+package ado
+
+import (
+	"github.com/spf13/cobra"
+
+	adocollect "github.com/praetorian-inc/trajan/internal/ado"
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// newCollectCmd wires the new-stack Azure DevOps collector (internal/ado) into
+// the ado command tree. Locator is "<org>", "<org>/<project>", or
+// "<org>/<project>/<repo>"; empty falls back to the ORG_NAME env var.
+func newCollectCmd() *cobra.Command {
+	cfg := &engine.Config{}
+	c := &cobra.Command{
+		Use:   "collect [locator]",
+		Short: "Collect raw Azure DevOps configuration for an org/project (phased pipeline)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			locator := ""
+			if len(args) > 0 {
+				locator = args[0]
+			}
+			_, err := adocollect.Collect(cmd.Context(), cfg, locator)
+			return err
+		},
+	}
+	c.Flags().IntVar(&cfg.Concurrency, "concurrency", 8, "max concurrent API workers")
+	c.Flags().StringVar(&cfg.OutputDir, "output-dir", "./trajan-out", "run output directory")
+	return c
+}

--- a/cmd/trajan/ado/root.go
+++ b/cmd/trajan/ado/root.go
@@ -21,6 +21,7 @@ func init() {
 	AdoCmd.AddCommand(scanCmd)
 	AdoCmd.AddCommand(attackCmd)
 	AdoCmd.AddCommand(retrieveCmd)
+	AdoCmd.AddCommand(newCollectCmd())
 }
 
 func getToken(cmd *cobra.Command) string {

--- a/internal/ado/auth.go
+++ b/internal/ado/auth.go
@@ -6,13 +6,16 @@ import (
 	"strings"
 )
 
-// ErrNoToken is returned when no Azure DevOps PAT is found in the environment.
-var ErrNoToken = errors.New("no Azure DevOps PAT: set ADO_PAT, AZURE_DEVOPS_PAT, or AZDO_PAT")
+// ErrNoToken is returned when no Azure DevOps PAT is found.
+var ErrNoToken = errors.New("no Azure DevOps PAT: pass --token or set ADO_PAT, AZURE_DEVOPS_PAT, or AZDO_PAT")
 
-// ResolveToken reads the PAT from the environment. ADO_PAT is checked first to
-// match the firing-range convention; the AZURE_DEVOPS_PAT / AZDO_PAT names are
-// the ones the legacy CLI already documents.
-func ResolveToken() (string, error) {
+// ResolveToken returns the PAT: an explicit value (the global --token flag) wins,
+// otherwise the environment. ADO_PAT is checked first to match the firing-range
+// convention; AZURE_DEVOPS_PAT / AZDO_PAT are the names the legacy CLI documents.
+func ResolveToken(explicit string) (string, error) {
+	if v := strings.TrimSpace(explicit); v != "" {
+		return v, nil
+	}
 	for _, k := range []string{"ADO_PAT", "AZURE_DEVOPS_PAT", "AZDO_PAT"} {
 		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
 			return v, nil

--- a/internal/ado/auth.go
+++ b/internal/ado/auth.go
@@ -1,0 +1,22 @@
+package ado
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// ErrNoToken is returned when no Azure DevOps PAT is found in the environment.
+var ErrNoToken = errors.New("no Azure DevOps PAT: set ADO_PAT, AZURE_DEVOPS_PAT, or AZDO_PAT")
+
+// ResolveToken reads the PAT from the environment. ADO_PAT is checked first to
+// match the firing-range convention; the AZURE_DEVOPS_PAT / AZDO_PAT names are
+// the ones the legacy CLI already documents.
+func ResolveToken() (string, error) {
+	for _, k := range []string{"ADO_PAT", "AZURE_DEVOPS_PAT", "AZDO_PAT"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v, nil
+		}
+	}
+	return "", ErrNoToken
+}

--- a/internal/ado/client.go
+++ b/internal/ado/client.go
@@ -1,0 +1,227 @@
+package ado
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	userAgent = "trajan-prototype/0.1"
+
+	// API version defaults. Individual surfaces override where a preview is required.
+	APIVersion        = "7.1"
+	APIVersionPreview = "7.1-preview.1"
+	APIVersionSEP     = "7.1-preview.4" // service endpoints
+	APIVersionGraph   = "7.1-preview.1" // vssps graph
+)
+
+// Multi-host bases (var, not const, so tests can repoint them at an httptest
+// server). Keyed by the short host name collectors pass.
+var hostBase = map[string]string{
+	"core":      "https://dev.azure.com",
+	"vsrm":      "https://vsrm.dev.azure.com",
+	"feeds":     "https://feeds.dev.azure.com",
+	"extmgmt":   "https://extmgmt.dev.azure.com",
+	"vssps":     "https://vssps.dev.azure.com",
+	"almsearch": "https://almsearch.dev.azure.com",
+}
+
+// ADO is the surface collectors depend on; Client is the production impl.
+type ADO interface {
+	Get(ctx context.Context, host, api, path string, params url.Values, allow404 bool) (json.RawMessage, http.Header, error)
+	GetRaw(ctx context.Context, host, api, path string, params url.Values) ([]byte, http.Header, error)
+	Post(ctx context.Context, host, api, path string, params url.Values, body any) (json.RawMessage, error)
+	Paginate(ctx context.Context, host, api, path string, params url.Values) ([]json.RawMessage, error)
+}
+
+type Client struct {
+	http  *http.Client
+	org   string
+	basic string // "Basic base64(:pat)"
+}
+
+var _ ADO = (*Client)(nil)
+
+func NewClient(org, pat string) *Client {
+	return &Client{
+		http:  &http.Client{Timeout: 90 * time.Second},
+		org:   org,
+		basic: "Basic " + base64.StdEncoding.EncodeToString([]byte(":"+pat)),
+	}
+}
+
+type AdoError struct {
+	Status int
+	URL    string
+	Body   string
+}
+
+func (e *AdoError) Error() string {
+	b := e.Body
+	if len(b) > 400 {
+		b = b[:400]
+	}
+	return fmt.Sprintf("HTTP %d from %s: %s", e.Status, e.URL, b)
+}
+
+// overridable so tests can record sleeps without waiting
+var sleepFn = sleep
+
+func sleep(ctx context.Context, sec float64) {
+	if sec <= 0 {
+		return
+	}
+	t := time.NewTimer(time.Duration(sec * float64(time.Second)))
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func (c *Client) buildURL(host, path string, params url.Values, api string) (string, error) {
+	base, ok := hostBase[host]
+	if !ok {
+		return "", fmt.Errorf("unknown ado host %q", host)
+	}
+	q := url.Values{}
+	for k, v := range params {
+		q[k] = v
+	}
+	if q.Get("api-version") == "" && api != "" {
+		q.Set("api-version", api)
+	}
+	u := base + "/" + c.org + path
+	if enc := q.Encode(); enc != "" {
+		u += "?" + enc
+	}
+	return u, nil
+}
+
+func (c *Client) do(ctx context.Context, method, rawURL, accept string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", c.basic)
+	req.Header.Set("Accept", accept)
+	req.Header.Set("User-Agent", userAgent)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.http.Do(req)
+}
+
+func readAllClose(resp *http.Response) []byte {
+	b, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return b
+}
+
+// sleepForRateLimit honors Retry-After on 429; returns true if it slept.
+func (c *Client) sleepForRateLimit(ctx context.Context, resp *http.Response) bool {
+	if resp.StatusCode != http.StatusTooManyRequests {
+		return false
+	}
+	sec := 30.0
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if d, err := strconv.ParseFloat(ra, 64); err == nil {
+			sec = d
+		}
+	}
+	sleepFn(ctx, min(sec, 120))
+	return true
+}
+
+// request is the shared retry loop for JSON/raw GETs and POSTs. body is []byte
+// (not io.Reader) so it can be re-sent on each retry — an io.Reader would be at
+// EOF after the first attempt, sending an empty body on a 429/5xx retry. A 404
+// with allow404 yields (nil, header, nil). HTML (invalid PAT) is surfaced as an
+// AdoError so it soft-fails rather than corrupting stored JSON.
+func (c *Client) request(ctx context.Context, method, u, accept string, body []byte, allow404 bool) ([]byte, http.Header, error) {
+	var lastStatus int
+	var lastBody []byte
+	for attempt := 0; attempt < 5; attempt++ {
+		var rdr io.Reader
+		if body != nil {
+			rdr = bytes.NewReader(body)
+		}
+		resp, err := c.do(ctx, method, u, accept, rdr)
+		if err != nil {
+			return nil, nil, err
+		}
+		switch {
+		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			hdr := resp.Header
+			b := readAllClose(resp)
+			if strings.HasPrefix(hdr.Get("Content-Type"), "text/html") {
+				return nil, nil, &AdoError{Status: resp.StatusCode, URL: u,
+					Body: "server returned HTML (invalid or expired PAT)"}
+			}
+			return b, hdr, nil
+		case resp.StatusCode == 404 && allow404:
+			hdr := resp.Header
+			resp.Body.Close()
+			return nil, hdr, nil
+		case resp.StatusCode >= 500:
+			lastStatus, lastBody = resp.StatusCode, readAllClose(resp)
+			sleepFn(ctx, 1.5*float64(attempt+1))
+			continue
+		default:
+			if c.sleepForRateLimit(ctx, resp) {
+				lastStatus, lastBody = resp.StatusCode, readAllClose(resp)
+				continue
+			}
+			b := readAllClose(resp)
+			return nil, nil, &AdoError{Status: resp.StatusCode, URL: u, Body: string(b)}
+		}
+	}
+	return nil, nil, &AdoError{Status: lastStatus, URL: u, Body: string(lastBody)}
+}
+
+func (c *Client) Get(ctx context.Context, host, api, path string, params url.Values, allow404 bool) (json.RawMessage, http.Header, error) {
+	u, err := c.buildURL(host, path, params, api)
+	if err != nil {
+		return nil, nil, err
+	}
+	b, hdr, err := c.request(ctx, http.MethodGet, u, "application/json", nil, allow404)
+	if err != nil {
+		return nil, nil, err
+	}
+	return json.RawMessage(b), hdr, nil
+}
+
+// GetRaw fetches text content (e.g. pipeline YAML via git items with
+// Accept: text/plain).
+func (c *Client) GetRaw(ctx context.Context, host, api, path string, params url.Values) ([]byte, http.Header, error) {
+	u, err := c.buildURL(host, path, params, api)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c.request(ctx, http.MethodGet, u, "text/plain", nil, true)
+}
+
+func (c *Client) Post(ctx context.Context, host, api, path string, params url.Values, body any) (json.RawMessage, error) {
+	u, err := c.buildURL(host, path, params, api)
+	if err != nil {
+		return nil, err
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	b, _, err := c.request(ctx, http.MethodPost, u, "application/json", buf, false)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(b), nil
+}

--- a/internal/ado/client_paginate.go
+++ b/internal/ado/client_paginate.go
@@ -1,0 +1,95 @@
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"net/http"
+	"net/url"
+)
+
+// Paginate accumulates the `value` array across pages, following the
+// x-ms-continuationtoken response header (resent as the continuationToken query
+// param). A single-object (non-list) response is returned as one element so
+// callers stay uniform.
+func (c *Client) Paginate(ctx context.Context, host, api, path string, params url.Values) ([]json.RawMessage, error) {
+	p := maps.Clone(params)
+	if p == nil {
+		p = url.Values{}
+	}
+	var items []json.RawMessage
+	prevCont := ""
+	// Page cap backstops a server that returns an unchanging continuation token
+	// (would otherwise loop forever); 10k pages * 100+/page far exceeds any real list.
+	for page := 0; page < 10000; page++ {
+		raw, hdr, err := c.Get(ctx, host, api, path, p, false)
+		if err != nil {
+			return nil, err
+		}
+		// A {count,value} list envelope has BOTH keys; require value present so a
+		// detail object that merely carries a "count" field isn't misread as a list.
+		var env struct {
+			Count *int              `json:"count"`
+			Value []json.RawMessage `json:"value"`
+		}
+		if err := json.Unmarshal(raw, &env); err == nil && env.Count != nil && env.Value != nil {
+			items = append(items, env.Value...)
+		} else {
+			// not a list envelope: return the whole body as one item
+			items = append(items, raw)
+			return items, nil
+		}
+		cont := hdr.Get("x-ms-continuationtoken")
+		if cont == "" || cont == prevCont {
+			break
+		}
+		prevCont = cont
+		p.Set("continuationToken", cont)
+	}
+	return items, nil
+}
+
+func softStatus(err error) int {
+	var adoErr *AdoError
+	if errors.As(err, &adoErr) {
+		return adoErr.Status
+	}
+	return 0
+}
+
+// isSoft reports an optional-surface failure that should skip-and-mark rather
+// than abort: 401/403 (permission) or 404 (absent).
+func isSoft(err error) bool {
+	switch softStatus(err) {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	}
+	return false
+}
+
+func decodeString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		return ""
+	}
+	return s
+}
+
+func objField(raw json.RawMessage, key string) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]json.RawMessage
+	if json.Unmarshal(raw, &m) != nil {
+		return nil
+	}
+	return m[key]
+}
+
+func strField(raw json.RawMessage, key string) string {
+	return decodeString(objField(raw, key))
+}

--- a/internal/ado/client_test.go
+++ b/internal/ado/client_test.go
@@ -1,0 +1,216 @@
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+func engineCP(dir string) engine.CurrentPhase { return engine.CurrentPhase{RunDir: dir} }
+
+func readData(t *testing.T, dir, rel string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatal(err)
+	}
+	return env.Data
+}
+
+func withServer(t *testing.T, h http.HandlerFunc) *Client {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	prev := hostBase["core"]
+	hostBase["core"] = srv.URL
+	t.Cleanup(func() { hostBase["core"] = prev })
+	return NewClient("org", "pat")
+}
+
+// Paginate must follow the x-ms-continuationtoken header and accumulate value[].
+func TestPaginate_Continuation(t *testing.T) {
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("continuationToken") == "" {
+			w.Header().Set("x-ms-continuationtoken", "TOK")
+			w.Write([]byte(`{"count":2,"value":[{"id":1},{"id":2}]}`))
+			return
+		}
+		w.Write([]byte(`{"count":1,"value":[{"id":3}]}`))
+	})
+	items, err := c.Paginate(context.Background(), "core", APIVersion, "/list", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("want 3 items across 2 pages, got %d", len(items))
+	}
+}
+
+// A non-envelope (single object) body is returned as one item, not treated as a list.
+func TestPaginate_SingleObject(t *testing.T) {
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"enforceJobAuthScope":true}`))
+	})
+	items, err := c.Paginate(context.Background(), "core", APIVersion, "/generalsettings", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || !boolField(items[0], "enforceJobAuthScope") {
+		t.Fatalf("single object not passed through: %v", items)
+	}
+}
+
+func TestGet_Allow404(t *testing.T) {
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	})
+	raw, _, err := c.Get(context.Background(), "core", APIVersion, "/missing", nil, true)
+	if err != nil {
+		t.Fatalf("allow404 should swallow 404: %v", err)
+	}
+	if raw != nil {
+		t.Fatalf("want nil body on 404, got %s", raw)
+	}
+}
+
+func TestSoftClassification(t *testing.T) {
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	})
+	_, _, err := c.Get(context.Background(), "core", APIVersion, "/x", nil, false)
+	if err == nil || !isSoft(err) {
+		t.Fatalf("403 should be soft, got %v", err)
+	}
+	if softStatus(err) != http.StatusForbidden {
+		t.Fatalf("softStatus = %d", softStatus(err))
+	}
+	// a 500 is not soft
+	if isSoft(&AdoError{Status: 500}) {
+		t.Fatal("500 must not be soft")
+	}
+}
+
+// A 429 with Retry-After must retry (not abort) and then succeed.
+func TestRetryOn429(t *testing.T) {
+	prev := sleepFn
+	sleepFn = func(context.Context, float64) {}
+	t.Cleanup(func() { sleepFn = prev })
+
+	var calls atomic.Int32
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, "slow down", http.StatusTooManyRequests)
+			return
+		}
+		w.Write([]byte(`{"ok":true}`))
+	})
+	raw, _, err := c.Get(context.Background(), "core", APIVersion, "/x", nil, false)
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	var m map[string]any
+	if json.Unmarshal(raw, &m); m["ok"] != true {
+		t.Fatalf("unexpected body: %s", raw)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("want 2 calls (429 then 200), got %d", calls.Load())
+	}
+}
+
+// A retried POST (after 429) must re-send the body — an io.Reader would be at EOF.
+func TestPostRetryResendsBody(t *testing.T) {
+	prev := sleepFn
+	sleepFn = func(context.Context, float64) {}
+	t.Cleanup(func() { sleepFn = prev })
+
+	var calls atomic.Int32
+	var lastBody atomic.Value
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		lastBody.Store(string(b))
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, "slow down", http.StatusTooManyRequests)
+			return
+		}
+		w.Write([]byte(`{"finalYaml":"ok"}`))
+	})
+	_, err := c.Post(context.Background(), "core", APIVersionPreview, "/preview", nil, map[string]any{"previewRun": true})
+	if err != nil {
+		t.Fatalf("post after retry failed: %v", err)
+	}
+	if got := lastBody.Load().(string); got != `{"previewRun":true}` {
+		t.Fatalf("retried POST sent %q, want the original body", got)
+	}
+}
+
+// A server that returns the SAME continuation token every page must not loop forever.
+func TestPaginate_NonAdvancingTokenTerminates(t *testing.T) {
+	var calls atomic.Int32
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("x-ms-continuationtoken", "STUCK")
+		w.Write([]byte(`{"count":1,"value":[{"id":1}]}`))
+	})
+	done := make(chan struct{})
+	go func() {
+		c.Paginate(context.Background(), "core", APIVersion, "/list", nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Paginate did not terminate on a non-advancing continuation token")
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("want 2 calls (page + one repeat then stop), got %d", calls.Load())
+	}
+}
+
+func TestWriteOrMark(t *testing.T) {
+	dir := t.TempDir()
+	cp := engineCP(dir)
+	// soft-failed surface -> marker
+	if err := writeOrMark(cp, "x/marked.json", "t", "/p", nil, 403); err != nil {
+		t.Fatal(err)
+	}
+	got := readData(t, dir, "x/marked.json")
+	if got["_unobserved"] != float64(403) {
+		t.Fatalf("want _unobserved:403 marker, got %v", got)
+	}
+	// success -> data
+	if err := writeOrMark(cp, "x/ok.json", "t", "/p", []byte(`{"a":1}`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if readData(t, dir, "x/ok.json")["a"] != float64(1) {
+		t.Fatal("data surface not written through")
+	}
+}
+
+// HTML body (invalid PAT) is surfaced as an error, never stored as JSON.
+func TestHTMLBodyIsError(t *testing.T) {
+	c := withServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<!DOCTYPE html><html>sign in</html>"))
+	})
+	_, _, err := c.Get(context.Background(), "core", APIVersion, "/x", nil, false)
+	if err == nil {
+		t.Fatal("HTML response must be an error")
+	}
+}

--- a/internal/ado/collect.go
+++ b/internal/ado/collect.go
@@ -23,7 +23,7 @@ func Collect(ctx context.Context, cfg *engine.Config, locator string) (string, e
 	if err != nil {
 		return "", err
 	}
-	token, err := ResolveToken()
+	token, err := ResolveToken(cfg.Token)
 	if err != nil {
 		return "", err
 	}
@@ -140,13 +140,13 @@ func collectOneProject(ctx context.Context, cl ADO, cp engine.CurrentPhase, scop
 	// $expand=machines option is no longer supported, so per-machine detail would
 	// need per-group queries (deferred — none exist in the target estate).
 	softSurface(timer, lbl("deployment-groups"), func() error {
-		items, _, e := softList(ctx, cl, "core", APIVersionPreview,
+		items, status, e := softList(ctx, cl, "core", APIVersionPreview,
 			"/"+pe+"/_apis/distributedtask/deploymentgroups", nil)
 		if e != nil {
 			return e
 		}
-		return envelope(cp, engine.CollectADODeploymentGroups(project), "deployment-groups",
-			"/"+project+"/_apis/distributedtask/deploymentgroups", rawArray(items))
+		return writeListOrMark(cp, engine.CollectADODeploymentGroups(project), "deployment-groups",
+			"/"+project+"/_apis/distributedtask/deploymentgroups", items, status)
 	})
 	softSurface(timer, lbl("task-groups"), func() error {
 		_, e := listSurface(ctx, cl, cp, project, "core", APIVersionPreview,
@@ -161,8 +161,8 @@ func collectOneProject(ctx context.Context, cl ADO, cp engine.CurrentPhase, scop
 		if e != nil {
 			return e
 		}
-		if e := envelope(cp, engine.CollectADOReleases(project), "release-definitions",
-			"/"+project+"/_apis/release/definitions", rawArray(items)); e != nil {
+		if e := writeListOrMark(cp, engine.CollectADOReleases(project), "release-definitions",
+			"/"+project+"/_apis/release/definitions", items, status); e != nil {
 			return e
 		}
 		if status == 0 {
@@ -176,24 +176,24 @@ func collectOneProject(ctx context.Context, cl ADO, cp engine.CurrentPhase, scop
 	// one endpoint is still collected.
 	pipelineNames := map[int64]string{}
 	softSurface(timer, lbl("build-definitions"), func() error {
-		items, _, e := softList(ctx, cl, "core", APIVersion, "/"+pe+"/_apis/build/definitions", nil)
+		items, status, e := softList(ctx, cl, "core", APIVersion, "/"+pe+"/_apis/build/definitions", nil)
 		if e != nil {
 			return e
 		}
-		if e := envelope(cp, engine.CollectADOBuildDefs(project), "build-definitions",
-			"/"+project+"/_apis/build/definitions", rawArray(items)); e != nil {
+		if e := writeListOrMark(cp, engine.CollectADOBuildDefs(project), "build-definitions",
+			"/"+project+"/_apis/build/definitions", items, status); e != nil {
 			return e
 		}
 		addPipelineIDs(pipelineNames, items)
 		return nil
 	})
 	softSurface(timer, lbl("pipelines"), func() error {
-		items, _, e := softList(ctx, cl, "core", APIVersion, "/"+pe+"/_apis/pipelines", nil)
+		items, status, e := softList(ctx, cl, "core", APIVersion, "/"+pe+"/_apis/pipelines", nil)
 		if e != nil {
 			return e
 		}
-		if e := envelope(cp, engine.CollectADOPipelines(project), "pipelines",
-			"/"+project+"/_apis/pipelines", rawArray(items)); e != nil {
+		if e := writeListOrMark(cp, engine.CollectADOPipelines(project), "pipelines",
+			"/"+project+"/_apis/pipelines", items, status); e != nil {
 			return e
 		}
 		addPipelineIDs(pipelineNames, items)

--- a/internal/ado/collect.go
+++ b/internal/ado/collect.go
@@ -1,0 +1,284 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+func Collect(ctx context.Context, cfg *engine.Config, locator string) (string, error) {
+	if strings.TrimSpace(locator) == "" {
+		locator = strings.TrimSpace(os.Getenv("ORG_NAME"))
+	}
+	scope, err := ParseScope(locator)
+	if err != nil {
+		return "", err
+	}
+	token, err := ResolveToken()
+	if err != nil {
+		return "", err
+	}
+	cl := NewClient(scope.Org, token)
+
+	runDir, err := engine.MintRunDir(cfg, "ado", scope.Slug)
+	if err != nil {
+		return "", err
+	}
+	state, err := engine.LoadState(runDir)
+	if err != nil {
+		return "", err
+	}
+	if err := state.CheckPhase(engine.PhaseCollect); err != nil {
+		return "", err
+	}
+	for _, d := range state.StaleDirs(engine.PhaseCollect) {
+		if err := os.RemoveAll(filepath.Join(runDir, d)); err != nil {
+			return "", err
+		}
+	}
+	state.Platform = "ado"
+	state.Scope = scopeString(scope)
+	state.Org = scope.Org
+	state.Invocation = os.Args[1:]
+	if state.StartedAt == "" {
+		state.StartedAt = engine.IsoformatUTC(timeNow())
+	}
+
+	timer := engine.StartPhaseTimer(engine.PhaseCollect, "collect")
+	cp := engine.CurrentPhase{RunDir: runDir}
+
+	collectErr := runCollect(ctx, cfg, cl, cp, scope, timer)
+
+	timer.OutputFiles = countJSON(runDir)
+	rec := timer.Stop(collectErr)
+	state.RecordPhase(rec)
+	if err := state.Save(runDir); err != nil {
+		return runDir, err
+	}
+	return runDir, collectErr
+}
+
+func runCollect(ctx context.Context, cfg *engine.Config, cl ADO, cp engine.CurrentPhase, scope Scope, timer *engine.PhaseTimer) error {
+	org := scope.Org
+
+	softSurface(timer, "connection-data", func() error { return collectConnectionData(ctx, cl, cp, org) })
+	softSurface(timer, "security-namespaces", func() error { return collectSecurityNamespaces(ctx, cl, cp, org) })
+	softSurface(timer, "graph", func() error { return collectGraph(ctx, cl, cp, org) })
+	softSurface(timer, "extensions", func() error { return collectExtensions(ctx, cl, cp, org) })
+	softSurface(timer, "service-hooks", func() error { return collectServiceHooks(ctx, cl, cp, org) })
+	softSurface(timer, "feeds", func() error { return collectFeeds(ctx, cl, cp, org) })
+	softSurface(timer, "agent-pools", func() error { return collectAgentPools(ctx, cl, cp) })
+
+	projects, err := collectProjects(ctx, cl, cp, org)
+	if err != nil {
+		return err
+	}
+	if scope.Project != "" {
+		projects = filterProjects(projects, scope.Project)
+	}
+	timer.InputFiles = len(projects)
+
+	engine.RunPartial(ctx, cfg.Concurrency, projects,
+		func(ctx context.Context, p projectRef) (int, error) {
+			return 0, collectOneProject(ctx, cl, cp, scope, p, timer)
+		},
+		func(p projectRef, e error) {
+			appendErr(timer, fmt.Sprintf("project %s: %v", p.Name, e))
+		},
+	)
+	return nil
+}
+
+func collectOneProject(ctx context.Context, cl ADO, cp engine.CurrentPhase, scope Scope, pt projectRef, timer *engine.PhaseTimer) error {
+	project, pid := pt.Name, pt.ID
+	lbl := func(s string) string { return project + "/" + s }
+
+	softSurface(timer, lbl("detail"), func() error { return collectProjectDetail(ctx, cl, cp, project) })
+	softSurface(timer, lbl("general-settings"), func() error { return collectGeneralSettings(ctx, cl, cp, project) })
+	softSurface(timer, lbl("project-properties"), func() error { return collectProjectProperties(ctx, cl, cp, pid, project) })
+	softSurface(timer, lbl("policies"), func() error { return collectPolicies(ctx, cl, cp, project) })
+	softSurface(timer, lbl("build-acl"), func() error { return collectBuildACL(ctx, cl, cp, project, pid) })
+
+	pe := url.PathEscape(project)
+
+	var repos []repoRef
+	softSurface(timer, lbl("repos"), func() error {
+		r, e := collectRepos(ctx, cl, cp, project)
+		repos = r
+		return e
+	})
+
+	var resources []resourceRef
+	collectList := func(label, host, api, apiPath, rel, collector, rtype string) {
+		softSurface(timer, lbl(label), func() error {
+			refs, e := listSurface(ctx, cl, cp, project, host, api, apiPath, rel, collector, rtype)
+			resources = append(resources, refs...)
+			return e
+		})
+	}
+	collectList("service-connections", "core", APIVersionSEP, "/"+pe+"/_apis/serviceendpoint/endpoints",
+		engine.CollectADOServiceConnections(project), "service-connections", "endpoint")
+	collectList("variable-groups", "core", APIVersion, "/"+pe+"/_apis/distributedtask/variablegroups",
+		engine.CollectADOVariableGroups(project), "variable-groups", "variablegroup")
+	collectList("secure-files", "core", APIVersion, "/"+pe+"/_apis/distributedtask/securefiles",
+		engine.CollectADOSecureFiles(project), "secure-files", "securefile")
+	collectList("environments", "core", APIVersion, "/"+pe+"/_apis/distributedtask/environments",
+		engine.CollectADOEnvironments(project), "environments", "environment")
+	collectList("agent-queues", "core", APIVersion, "/"+pe+"/_apis/distributedtask/queues",
+		engine.CollectADOAgentQueues(project), "agent-queues", "queue")
+
+	// deployment groups: the preview api-version is required (GA 400s); the
+	// $expand=machines option is no longer supported, so per-machine detail would
+	// need per-group queries (deferred — none exist in the target estate).
+	softSurface(timer, lbl("deployment-groups"), func() error {
+		items, _, e := softList(ctx, cl, "core", APIVersionPreview,
+			"/"+pe+"/_apis/distributedtask/deploymentgroups", nil)
+		if e != nil {
+			return e
+		}
+		return envelope(cp, engine.CollectADODeploymentGroups(project), "deployment-groups",
+			"/"+project+"/_apis/distributedtask/deploymentgroups", rawArray(items))
+	})
+	softSurface(timer, lbl("task-groups"), func() error {
+		_, e := listSurface(ctx, cl, cp, project, "core", APIVersionPreview,
+			"/"+pe+"/_apis/distributedtask/taskgroups", engine.CollectADOTaskGroups(project), "task-groups", "")
+		return e
+	})
+	// classic release definitions: list (summary) then fan out full detail —
+	// approvals/gates/artifacts live only on the per-definition GET (cat-14).
+	var releaseIDs []int64
+	softSurface(timer, lbl("releases"), func() error {
+		items, status, e := softList(ctx, cl, "vsrm", APIVersion, "/"+pe+"/_apis/release/definitions", nil)
+		if e != nil {
+			return e
+		}
+		if e := envelope(cp, engine.CollectADOReleases(project), "release-definitions",
+			"/"+project+"/_apis/release/definitions", rawArray(items)); e != nil {
+			return e
+		}
+		if status == 0 {
+			releaseIDs = collectIDs(items)
+		}
+		return nil
+	})
+
+	// Pipeline id set = /build/definitions (YAML type-2 AND classic/designer type-1
+	// builds) UNION /pipelines (newer abstraction), so a pipeline surfaced by only
+	// one endpoint is still collected.
+	pipelineNames := map[int64]string{}
+	softSurface(timer, lbl("build-definitions"), func() error {
+		items, _, e := softList(ctx, cl, "core", APIVersion, "/"+pe+"/_apis/build/definitions", nil)
+		if e != nil {
+			return e
+		}
+		if e := envelope(cp, engine.CollectADOBuildDefs(project), "build-definitions",
+			"/"+project+"/_apis/build/definitions", rawArray(items)); e != nil {
+			return e
+		}
+		addPipelineIDs(pipelineNames, items)
+		return nil
+	})
+	softSurface(timer, lbl("pipelines"), func() error {
+		items, _, e := softList(ctx, cl, "core", APIVersion, "/"+pe+"/_apis/pipelines", nil)
+		if e != nil {
+			return e
+		}
+		if e := envelope(cp, engine.CollectADOPipelines(project), "pipelines",
+			"/"+project+"/_apis/pipelines", rawArray(items)); e != nil {
+			return e
+		}
+		addPipelineIDs(pipelineNames, items)
+		return nil
+	})
+
+	// per pipeline: full definition; YAML pipelines (process.type==2) additionally
+	// get preview + template closure; classic/designer pipelines (type 1) carry
+	// their steps in the full definition's process.phases, so nothing more is fetched.
+	for _, id := range sortedIDs(pipelineNames) {
+		softSurface(timer, lbl(fmt.Sprintf("pipeline/%d", id)), func() error {
+			full, e := collectBuildDefFull(ctx, cl, cp, project, id)
+			if e != nil || full == nil {
+				return e
+			}
+			if numField(objField(full, "process"), "type") != 2 {
+				return nil // classic/designer: steps already captured in the full definition
+			}
+			if e := collectPipelinePreview(ctx, cl, cp, project, id); e != nil {
+				return e
+			}
+			return collectPipelineYAML(ctx, cl, cp, project, repos, id, full)
+		})
+	}
+	for _, id := range releaseIDs {
+		softSurface(timer, lbl(fmt.Sprintf("release/%d", id)), func() error {
+			return collectReleaseFull(ctx, cl, cp, project, id)
+		})
+	}
+
+	// per resource: pipeline permissions + checks
+	for _, r := range resources {
+		softSurface(timer, lbl("perms/"+r.Type+"/"+r.ID), func() error { return collectPipelinePermissions(ctx, cl, cp, project, r) })
+		softSurface(timer, lbl("checks/"+r.Type+"/"+r.ID), func() error { return collectChecks(ctx, cl, cp, project, r) })
+		switch r.Type {
+		case "environment":
+			if envID, err := strconv.ParseInt(r.ID, 10, 64); err == nil {
+				softSurface(timer, lbl("env-detail/"+r.ID), func() error { return collectEnvironmentDetail(ctx, cl, cp, project, envID) })
+			}
+		case "endpoint":
+			softSurface(timer, lbl("endpoint-acl/"+r.ID), func() error { return collectEndpointACL(ctx, cl, cp, project, pid, r.ID) })
+		}
+	}
+
+	// per repo: git ACL (skip others if a repo scope was requested)
+	for _, repo := range repos {
+		if scope.Repo != "" && !strings.EqualFold(repo.Name, scope.Repo) {
+			continue
+		}
+		softSurface(timer, lbl("repo-acl/"+repo.Name), func() error { return collectRepoACL(ctx, cl, cp, project, pid, repo) })
+	}
+	return nil
+}
+
+func filterProjects(projects []projectRef, name string) []projectRef {
+	for _, p := range projects {
+		if strings.EqualFold(p.Name, name) {
+			return []projectRef{p}
+		}
+	}
+	return nil
+}
+
+var errMu sync.Mutex
+
+func softSurface(timer *engine.PhaseTimer, label string, fn func() error) {
+	if err := fn(); err != nil {
+		appendErr(timer, fmt.Sprintf("%s: %v", label, err))
+	}
+}
+
+func appendErr(timer *engine.PhaseTimer, msg string) {
+	errMu.Lock()
+	timer.Errors = append(timer.Errors, msg)
+	errMu.Unlock()
+	slog.Warn("collect surface degraded", "detail", msg)
+}
+
+func countJSON(runDir string) int {
+	n := 0
+	_ = filepath.WalkDir(filepath.Join(runDir, "00-collect"), func(_ string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && strings.HasSuffix(d.Name(), ".json") {
+			n++
+		}
+		return nil
+	})
+	return n
+}

--- a/internal/ado/collect_classic_test.go
+++ b/internal/ado/collect_classic_test.go
@@ -1,0 +1,105 @@
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+func raws(ss ...string) []json.RawMessage {
+	out := make([]json.RawMessage, len(ss))
+	for i, s := range ss {
+		out[i] = json.RawMessage(s)
+	}
+	return out
+}
+
+// Union of /build/definitions and /pipelines: dedup by id (first name wins),
+// sorted output.
+func TestPipelineIDUnion(t *testing.T) {
+	m := map[int64]string{}
+	addPipelineIDs(m, raws(`{"id":3,"name":"c"}`, `{"id":1,"name":"a"}`, `{"id":0}`))
+	addPipelineIDs(m, raws(`{"id":1,"name":"dup"}`, `{"id":2,"name":"b"}`))
+	got := sortedIDs(m)
+	if len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
+		t.Fatalf("union ids = %v, want [1 2 3]", got)
+	}
+	if m[1] != "a" {
+		t.Errorf("first name should win: id 1 = %q, want a", m[1])
+	}
+	if ids := collectIDs(raws(`{"id":7}`, `{"id":0}`, `{"name":"x"}`)); len(ids) != 1 || ids[0] != 7 {
+		t.Errorf("collectIDs = %v, want [7] (id 0 and absent dropped)", ids)
+	}
+}
+
+// panicADO fails the test if the collector makes any HTTP call.
+type panicADO struct{ t *testing.T }
+
+func (p panicADO) Get(context.Context, string, string, string, url.Values, bool) (json.RawMessage, http.Header, error) {
+	p.t.Fatal("classic pipeline must not trigger a git-items fetch")
+	return nil, nil, nil
+}
+func (p panicADO) GetRaw(context.Context, string, string, string, url.Values) ([]byte, http.Header, error) {
+	p.t.Fatal("unexpected GetRaw")
+	return nil, nil, nil
+}
+func (p panicADO) Post(context.Context, string, string, string, url.Values, any) (json.RawMessage, error) {
+	p.t.Fatal("unexpected Post")
+	return nil, nil
+}
+func (p panicADO) Paginate(context.Context, string, string, string, url.Values) ([]json.RawMessage, error) {
+	p.t.Fatal("unexpected Paginate")
+	return nil, nil
+}
+
+// A classic/designer definition (no yamlFilename) must be skipped for YAML
+// collection — its steps live in the full definition's process.phases.
+func TestCollectPipelineYAML_SkipsClassic(t *testing.T) {
+	cp := engineCP(t.TempDir())
+	full := json.RawMessage(`{"repository":{"id":"r","type":"TfsGit","defaultBranch":"refs/heads/main"},"process":{"type":1}}`)
+	if err := collectPipelineYAML(context.Background(), panicADO{t}, cp, "Proj", nil, 5, full); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(cp.RunDir, "00-collect", "pipeline-yaml")); !os.IsNotExist(err) {
+		t.Fatal("classic pipeline should write no pipeline-yaml files")
+	}
+}
+
+// getADO serves a single canned body for any Get.
+type getADO struct{ body json.RawMessage }
+
+func (g getADO) Get(context.Context, string, string, string, url.Values, bool) (json.RawMessage, http.Header, error) {
+	return g.body, http.Header{}, nil
+}
+func (g getADO) GetRaw(context.Context, string, string, string, url.Values) ([]byte, http.Header, error) {
+	return nil, nil, nil
+}
+func (g getADO) Post(context.Context, string, string, string, url.Values, any) (json.RawMessage, error) {
+	return nil, nil
+}
+func (g getADO) Paginate(context.Context, string, string, string, url.Values) ([]json.RawMessage, error) {
+	return nil, nil
+}
+
+// collectReleaseFull stores the full classic-release definition (approvals/gates).
+func TestCollectReleaseFull(t *testing.T) {
+	cp := engineCP(t.TempDir())
+	rel := `{"id":9,"name":"prod","environments":[{"name":"prod","preDeployApprovals":{"approvals":[{"approver":{"id":"u"}}]}}]}`
+	if err := collectReleaseFull(context.Background(), getADO{json.RawMessage(rel)}, cp, "Proj", 9); err != nil {
+		t.Fatal(err)
+	}
+	data := readData(t, cp.RunDir, engine.CollectADOReleaseFull("Proj", 9))
+	if data["name"] != "prod" {
+		t.Fatalf("release full not stored: %v", data)
+	}
+	envs, ok := data["environments"].([]any)
+	if !ok || len(envs) != 1 {
+		t.Fatalf("environments not preserved: %v", data["environments"])
+	}
+}

--- a/internal/ado/collect_review_test.go
+++ b/internal/ado/collect_review_test.go
@@ -1,0 +1,97 @@
+package ado
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// A soft-failed list surface must write an {_unobserved} marker, not an empty [],
+// so downstream can tell "no access" from "genuinely empty".
+func TestWriteListOrMark(t *testing.T) {
+	dir := t.TempDir()
+	cp := engine.CurrentPhase{RunDir: dir}
+
+	// soft fail -> marker
+	if err := writeListOrMark(cp, engine.CollectADOServiceConnections("P"), "service-connections", "/p", nil, 403); err != nil {
+		t.Fatal(err)
+	}
+	var env map[string]any
+	if err := engine.ReadJSON(filepath.Join(dir, engine.CollectADOServiceConnections("P")), &env); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := env["data"].(map[string]any)
+	if data == nil || data["_unobserved"] == nil {
+		t.Errorf("soft-fail list did not write _unobserved marker: %v", env["data"])
+	}
+
+	// success -> the list (never nil)
+	if err := writeListOrMark(cp, engine.CollectADOVariableGroups("P"), "variable-groups", "/p", nil, 0); err != nil {
+		t.Fatal(err)
+	}
+	var env2 map[string]any
+	if err := engine.ReadJSON(filepath.Join(dir, engine.CollectADOVariableGroups("P")), &env2); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := env2["data"].([]any); !ok {
+		t.Errorf("success list should serialize as [], got %T", env2["data"])
+	}
+}
+
+// A malicious template path must not escape the collection directory: the path is
+// flattened by adoKey when the on-disk name is built.
+func TestPipelineYAMLPathNoTraversal(t *testing.T) {
+	name := "repoid@main__../../../../state.json"
+	rel := engine.CollectADOPipelineYAML("Proj", 7, name)
+	if strings.Contains(rel, "..") && strings.Contains(rel, "/..") {
+		t.Errorf("traversal not flattened: %q", rel)
+	}
+	// the whole reconstructed name collapses to a single path segment (no separators)
+	if c := strings.Count(strings.TrimPrefix(rel, "00-collect/pipeline-yaml/"), "/"); c != 1 {
+		t.Errorf("template name introduced extra path segments: %q", rel)
+	}
+}
+
+func TestRefVersion(t *testing.T) {
+	cases := []struct{ ref, ver, typ string }{
+		{"refs/tags/v1.0", "v1.0", "tag"},
+		{"refs/heads/main", "main", "branch"},
+		{"release", "release", "branch"},
+	}
+	for _, c := range cases {
+		v, tp := refVersion(c.ref)
+		if v != c.ver || tp != c.typ {
+			t.Errorf("refVersion(%q) = %q/%q, want %q/%q", c.ref, v, tp, c.ver, c.typ)
+		}
+	}
+}
+
+// A cross-project repo that merely shares a name with a local repo must be treated
+// as external, not matched to the local one.
+func TestResolveRepoName(t *testing.T) {
+	if n, ext := resolveRepoName("MyRepo", "Proj"); n != "MyRepo" || ext {
+		t.Errorf("bare name: got %q ext=%v", n, ext)
+	}
+	if n, ext := resolveRepoName("Proj/MyRepo", "Proj"); n != "MyRepo" || ext {
+		t.Errorf("same-project qualified: got %q ext=%v", n, ext)
+	}
+	if _, ext := resolveRepoName("OtherProject/MyRepo", "Proj"); !ext {
+		t.Error("cross-project repo should be external")
+	}
+}
+
+// A same-repo relative template resolves against the including file's directory;
+// a leading "/" is repo-root absolute.
+func TestResolveTemplatePath(t *testing.T) {
+	if got := resolveTemplatePath("/ci/pipeline.yml", "templates/build.yml"); got != "/ci/templates/build.yml" {
+		t.Errorf("relative = %q, want /ci/templates/build.yml", got)
+	}
+	if got := resolveTemplatePath("/ci/pipeline.yml", "/shared/base.yml"); got != "/shared/base.yml" {
+		t.Errorf("absolute = %q, want /shared/base.yml", got)
+	}
+	if got := resolveTemplatePath("/ci/pipeline.yml", "../common/x.yml"); got != "/common/x.yml" {
+		t.Errorf("dotdot = %q, want /common/x.yml", got)
+	}
+}

--- a/internal/ado/collect_surfaces.go
+++ b/internal/ado/collect_surfaces.go
@@ -59,6 +59,23 @@ func writeOrMark(cp engine.CurrentPhase, rel, collector, sourcePath string, raw 
 	return envelope(cp, rel, collector, sourcePath, raw)
 }
 
+// listOrMark returns the list (never nil) on success, or a {"_unobserved":<status>}
+// marker when it soft-failed (401/403/404) — so downstream can tell "no access"
+// from "genuinely empty" (CLAUDE.md: 403/404 → skip AND mark). Used for both
+// top-level list surfaces and embedded sub-lists (feed views/permissions).
+func listOrMark(items []json.RawMessage, status int) any {
+	if status != 0 {
+		return map[string]any{"_unobserved": status}
+	}
+	return rawArray(items)
+}
+
+// writeListOrMark envelopes a list surface via listOrMark. The list analog of
+// writeOrMark; a forbidden list must not read to the scanner as "none exist".
+func writeListOrMark(cp engine.CurrentPhase, rel, collector, sourcePath string, items []json.RawMessage, status int) error {
+	return envelope(cp, rel, collector, sourcePath, listOrMark(items, status))
+}
+
 // softGet returns (raw, status): status is 0 on success, or the soft HTTP code
 // (401/403/404) when the resource was unobservable (raw nil). A non-soft error
 // propagates.
@@ -158,11 +175,11 @@ type resourceRef struct {
 // ================= ORG =================
 
 func collectProjects(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) ([]projectRef, error) {
-	items, _, err := softList(ctx, cl, "core", APIVersion, "/_apis/projects", nil)
+	items, status, err := softList(ctx, cl, "core", APIVersion, "/_apis/projects", nil)
 	if err != nil {
 		return nil, err
 	}
-	if err := envelope(cp, engine.CollectADOProjects(org), "projects", "/_apis/projects", rawArray(items)); err != nil {
+	if err := writeListOrMark(cp, engine.CollectADOProjects(org), "projects", "/_apis/projects", items, status); err != nil {
 		return nil, err
 	}
 	out := make([]projectRef, 0, len(items))
@@ -260,11 +277,11 @@ func boolField(raw json.RawMessage, key string) bool {
 }
 
 func collectSecurityNamespaces(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
-	items, _, err := softList(ctx, cl, "core", APIVersion, "/_apis/securitynamespaces", nil)
+	items, status, err := softList(ctx, cl, "core", APIVersion, "/_apis/securitynamespaces", nil)
 	if err != nil {
 		return err
 	}
-	return envelope(cp, engine.CollectADOSecurityNS(org), "security-namespaces", "/_apis/securitynamespaces", rawArray(items))
+	return writeListOrMark(cp, engine.CollectADOSecurityNS(org), "security-namespaces", "/_apis/securitynamespaces", items, status)
 }
 
 func collectGraph(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
@@ -272,7 +289,7 @@ func collectGraph(ctx context.Context, cl ADO, cp engine.CurrentPhase, org strin
 	if err != nil {
 		return err
 	}
-	users, _, err := softList(ctx, cl, "vssps", APIVersionGraph, "/_apis/graph/users", nil)
+	users, ustatus, err := softList(ctx, cl, "vssps", APIVersionGraph, "/_apis/graph/users", nil)
 	if err != nil {
 		return err
 	}
@@ -296,8 +313,12 @@ func collectGraph(ctx context.Context, cl ADO, cp engine.CurrentPhase, org strin
 		}
 	}
 	data := map[string]any{"groups": rawArray(groups), "users": rawArray(users), "memberships": memberships}
+	// Mark the bundle if either principal list was unobservable (groups and users
+	// need the same graph-read scope, but a partial failure must still signal).
 	if gstatus != 0 {
 		data["_unobserved"] = gstatus
+	} else if ustatus != 0 {
+		data["_unobserved"] = ustatus
 	}
 	return envelope(cp, engine.CollectADOGraph(org), "graph", "/_apis/graph/{groups,users,memberships}", data)
 }
@@ -315,11 +336,11 @@ func collectExtensions(ctx context.Context, cl ADO, cp engine.CurrentPhase, org 
 }
 
 func collectServiceHooks(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
-	items, _, err := softList(ctx, cl, "core", APIVersionPreview, "/_apis/hooks/subscriptions", nil)
+	items, status, err := softList(ctx, cl, "core", APIVersionPreview, "/_apis/hooks/subscriptions", nil)
 	if err != nil {
 		return err
 	}
-	return envelope(cp, engine.CollectADOServiceHooks(org), "service-hooks", "/_apis/hooks/subscriptions", rawArray(items))
+	return writeListOrMark(cp, engine.CollectADOServiceHooks(org), "service-hooks", "/_apis/hooks/subscriptions", items, status)
 }
 
 // collectFeeds pulls org-scoped feeds (feeds are org-scoped in practice) plus
@@ -330,12 +351,12 @@ func collectFeeds(ctx context.Context, cl ADO, cp engine.CurrentPhase, org strin
 		return err
 	}
 	if status != 0 {
-		return envelope(cp, engine.CollectADOFeeds(org), "feeds", "/_apis/packaging/feeds", []json.RawMessage{})
+		return envelope(cp, engine.CollectADOFeeds(org), "feeds", "/_apis/packaging/feeds", map[string]any{"_unobserved": status})
 	}
 	type feedBundle struct {
-		Feed        json.RawMessage   `json:"feed"`
-		Views       []json.RawMessage `json:"views"`
-		Permissions []json.RawMessage `json:"permissions"`
+		Feed        json.RawMessage `json:"feed"`
+		Views       any             `json:"views"`       // list, or {_unobserved} on soft-fail
+		Permissions any             `json:"permissions"` // list, or {_unobserved} on soft-fail
 	}
 	bundles := make([]feedBundle, 0, len(feeds))
 	for _, f := range feeds {
@@ -344,9 +365,9 @@ func collectFeeds(ctx context.Context, cl ADO, cp engine.CurrentPhase, org strin
 			bundles = append(bundles, feedBundle{Feed: f, Views: []json.RawMessage{}, Permissions: []json.RawMessage{}})
 			continue
 		}
-		views, _, _ := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds/"+fid+"/views", nil)
-		perms, _, _ := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds/"+fid+"/permissions", nil)
-		bundles = append(bundles, feedBundle{Feed: f, Views: rawArray(views), Permissions: rawArray(perms)})
+		views, vstatus, _ := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds/"+fid+"/views", nil)
+		perms, pstatus, _ := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds/"+fid+"/permissions", nil)
+		bundles = append(bundles, feedBundle{Feed: f, Views: listOrMark(views, vstatus), Permissions: listOrMark(perms, pstatus)})
 	}
 	return envelope(cp, engine.CollectADOFeeds(org), "feeds", "/_apis/packaging/feeds", bundles)
 }
@@ -381,12 +402,12 @@ func collectProjectProperties(ctx context.Context, cl ADO, cp engine.CurrentPhas
 }
 
 func collectRepos(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string) ([]repoRef, error) {
-	items, _, err := softList(ctx, cl, "core", APIVersion, "/"+url.PathEscape(project)+"/_apis/git/repositories", nil)
+	items, status, err := softList(ctx, cl, "core", APIVersion, "/"+url.PathEscape(project)+"/_apis/git/repositories", nil)
 	if err != nil {
 		return nil, err
 	}
-	if err := envelope(cp, engine.CollectADORepos(project), "repositories",
-		"/"+project+"/_apis/git/repositories", rawArray(items)); err != nil {
+	if err := writeListOrMark(cp, engine.CollectADORepos(project), "repositories",
+		"/"+project+"/_apis/git/repositories", items, status); err != nil {
 		return nil, err
 	}
 	out := make([]repoRef, 0, len(items))
@@ -401,14 +422,14 @@ func collectRepos(ctx context.Context, cl ADO, cp engine.CurrentPhase, project s
 // listSurface fetches a project list, stores it, and returns resourceRefs of the
 // given type for downstream pipeline-permissions / checks fan-out.
 func listSurface(ctx context.Context, cl ADO, cp engine.CurrentPhase, project, host, api, apiPath, rel, collector, rtype string) ([]resourceRef, error) {
-	items, _, err := softList(ctx, cl, host, api, apiPath, nil)
+	items, status, err := softList(ctx, cl, host, api, apiPath, nil)
 	if err != nil {
 		return nil, err
 	}
-	if err := envelope(cp, rel, collector, apiPath, rawArray(items)); err != nil {
+	if err := writeListOrMark(cp, rel, collector, apiPath, items, status); err != nil {
 		return nil, err
 	}
-	if rtype == "" {
+	if rtype == "" || status != 0 {
 		return nil, nil
 	}
 	out := make([]resourceRef, 0, len(items))

--- a/internal/ado/collect_surfaces.go
+++ b/internal/ado/collect_surfaces.go
@@ -1,0 +1,544 @@
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"slices"
+	"time"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// Security namespace GUIDs (verified against the live org, see api-exploration).
+const (
+	gitNS      = "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87"
+	buildNS    = "33344d9c-fc72-4d6f-aba5-fa317101a7e9"
+	endpointNS = "49b48001-ca20-4adc-8111-5b60c903a50c"
+)
+
+const (
+	collectorVer = "@0.1"
+	sourceAPI    = "azure_devops_rest"
+)
+
+var timeNow = time.Now
+
+func nowISO() string { return engine.IsoformatUTC(timeNow()) }
+
+type collectMeta struct {
+	CollectedAt string         `json:"collected_at"`
+	Collector   string         `json:"collector"`
+	Source      collectMetaSrc `json:"source"`
+}
+
+type collectMetaSrc struct {
+	API  string `json:"api"`
+	Path string `json:"path"`
+}
+
+func envelope(cp engine.CurrentPhase, rel, collector, sourcePath string, data any) error {
+	return cp.Write(rel, map[string]any{
+		"_meta": collectMeta{
+			CollectedAt: nowISO(),
+			Collector:   collector + collectorVer,
+			Source:      collectMetaSrc{API: sourceAPI, Path: sourcePath},
+		},
+		"data": data,
+	})
+}
+
+// writeOrMark writes the collected data, or a {"_unobserved":<status>} marker
+// when the surface soft-failed (401/403/404) — so downstream can tell "no access"
+// from "never collected" (CLAUDE.md: 403/404 → skip AND mark).
+func writeOrMark(cp engine.CurrentPhase, rel, collector, sourcePath string, raw json.RawMessage, status int) error {
+	if status != 0 {
+		return envelope(cp, rel, collector, sourcePath, map[string]any{"_unobserved": status})
+	}
+	return envelope(cp, rel, collector, sourcePath, raw)
+}
+
+// softGet returns (raw, status): status is 0 on success, or the soft HTTP code
+// (401/403/404) when the resource was unobservable (raw nil). A non-soft error
+// propagates.
+func softGet(ctx context.Context, cl ADO, host, api, p string, params url.Values) (json.RawMessage, int, error) {
+	raw, _, err := cl.Get(ctx, host, api, p, params, true)
+	if err != nil {
+		if isSoft(err) {
+			return nil, softStatus(err), nil
+		}
+		return nil, 0, err
+	}
+	if raw == nil {
+		return nil, 404, nil
+	}
+	return raw, 0, nil
+}
+
+func softList(ctx context.Context, cl ADO, host, api, p string, params url.Values) ([]json.RawMessage, int, error) {
+	items, err := cl.Paginate(ctx, host, api, p, params)
+	if err != nil {
+		if isSoft(err) {
+			return nil, softStatus(err), nil
+		}
+		return nil, 0, err
+	}
+	return items, 0, nil
+}
+
+// rawArray ensures a nil slice marshals as [] (rules key on it).
+func rawArray(items []json.RawMessage) []json.RawMessage {
+	if items == nil {
+		return []json.RawMessage{}
+	}
+	return items
+}
+
+func numField(raw json.RawMessage, key string) int64 {
+	v := objField(raw, key)
+	if len(v) == 0 {
+		return 0
+	}
+	var n int64
+	if json.Unmarshal(v, &n) != nil {
+		return 0
+	}
+	return n
+}
+
+// collectIDs extracts numeric "id" fields from a list of raw items.
+func collectIDs(items []json.RawMessage) []int64 {
+	var out []int64
+	for _, raw := range items {
+		if id := numField(raw, "id"); id != 0 {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// addPipelineIDs merges numeric ids (first name wins) into a shared id->name map,
+// used to union /build/definitions and /pipelines.
+func addPipelineIDs(dst map[int64]string, items []json.RawMessage) {
+	for _, raw := range items {
+		if id := numField(raw, "id"); id != 0 {
+			if _, ok := dst[id]; !ok {
+				dst[id] = strField(raw, "name")
+			}
+		}
+	}
+}
+
+func sortedIDs(m map[int64]string) []int64 {
+	out := make([]int64, 0, len(m))
+	for id := range m {
+		out = append(out, id)
+	}
+	slices.Sort(out)
+	return out
+}
+
+type projectRef struct {
+	ID   string
+	Name string
+}
+
+type repoRef struct {
+	ID   string
+	Name string
+}
+
+type resourceRef struct {
+	Type string
+	ID   string
+	Name string
+}
+
+// ================= ORG =================
+
+func collectProjects(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) ([]projectRef, error) {
+	items, _, err := softList(ctx, cl, "core", APIVersion, "/_apis/projects", nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := envelope(cp, engine.CollectADOProjects(org), "projects", "/_apis/projects", rawArray(items)); err != nil {
+		return nil, err
+	}
+	out := make([]projectRef, 0, len(items))
+	for _, raw := range items {
+		id, name := strField(raw, "id"), strField(raw, "name")
+		if id != "" && name != "" {
+			out = append(out, projectRef{ID: id, Name: name})
+		}
+	}
+	return out, nil
+}
+
+func collectAgentPools(ctx context.Context, cl ADO, cp engine.CurrentPhase) error {
+	pools, status, err := softList(ctx, cl, "core", APIVersion, "/_apis/distributedtask/pools", nil)
+	if err != nil {
+		return err
+	}
+	if status != 0 {
+		return nil
+	}
+	for _, raw := range pools {
+		id := numField(raw, "id")
+		if id == 0 {
+			continue
+		}
+		if err := envelope(cp, engine.CollectADOPool(id), "agent-pool",
+			fmt.Sprintf("/_apis/distributedtask/pools/%d", id), raw); err != nil {
+			return err
+		}
+		if boolField(raw, "isHosted") {
+			continue // Microsoft-hosted pools have no self-hosted agents or elastic config
+		}
+		// Agents (with capabilities). A failed sub-call marks that pool's agents and
+		// continues — one flaky pool must not sink the whole surface.
+		agentsPath := fmt.Sprintf("/_apis/distributedtask/pools/%d/agents", id)
+		agents, astatus, aerr := softList(ctx, cl, "core", APIVersion, agentsPath,
+			url.Values{"includeCapabilities": []string{"true"}})
+		var agentData any = rawArray(agents)
+		if aerr != nil {
+			agentData = map[string]any{"_error": aerr.Error()}
+		} else if astatus != 0 {
+			agentData = map[string]any{"_unobserved": astatus}
+		}
+		if err := envelope(cp, engine.CollectADOPoolAgents(id), "pool-agents", agentsPath, agentData); err != nil {
+			return err
+		}
+		// Elastic/VMSS pool config (singleUseAgents/recycle) lives on a separate
+		// endpoint; a 404 just means the pool is static self-hosted (expected, no mark).
+		ep, estatus, eerr := softGet(ctx, cl, "core", APIVersionPreview,
+			fmt.Sprintf("/_apis/distributedtask/elasticpools/%d", id), nil)
+		if eerr != nil {
+			return eerr
+		}
+		if estatus == 0 {
+			if err := envelope(cp, engine.CollectADOElasticPool(id), "elastic-pool",
+				fmt.Sprintf("/_apis/distributedtask/elasticpools/%d", id), ep); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func collectConnectionData(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
+	raw, status, err := softGet(ctx, cl, "core", APIVersionPreview, "/_apis/connectionData", nil)
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOConnectionData(org), "connection-data", "/_apis/connectionData", raw, status)
+}
+
+// collectEndpointACL pulls the ServiceEndpoints-namespace ACL for one connection
+// (Administer bit). Soft — needs vso.security_manage.
+func collectEndpointACL(ctx context.Context, cl ADO, cp engine.CurrentPhase, project, projectID, connID string) error {
+	token := fmt.Sprintf("endpoints/%s/%s", projectID, connID)
+	raw, status, err := softGet(ctx, cl, "core", APIVersion, "/_apis/accesscontrollists/"+endpointNS,
+		url.Values{"token": []string{token}, "includeExtendedInfo": []string{"true"}})
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOEndpointACL(project, connID), "endpoint-acl",
+		"/_apis/accesscontrollists/"+endpointNS, raw, status)
+}
+
+func boolField(raw json.RawMessage, key string) bool {
+	v := objField(raw, key)
+	if len(v) == 0 {
+		return false
+	}
+	var b bool
+	if json.Unmarshal(v, &b) != nil {
+		return false
+	}
+	return b
+}
+
+func collectSecurityNamespaces(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
+	items, _, err := softList(ctx, cl, "core", APIVersion, "/_apis/securitynamespaces", nil)
+	if err != nil {
+		return err
+	}
+	return envelope(cp, engine.CollectADOSecurityNS(org), "security-namespaces", "/_apis/securitynamespaces", rawArray(items))
+}
+
+func collectGraph(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
+	groups, gstatus, err := softList(ctx, cl, "vssps", APIVersionGraph, "/_apis/graph/groups", nil)
+	if err != nil {
+		return err
+	}
+	users, _, err := softList(ctx, cl, "vssps", APIVersionGraph, "/_apis/graph/users", nil)
+	if err != nil {
+		return err
+	}
+	// direction=down memberships per group give the nested-group edges normalize
+	// needs to resolve effectiveAllow ACL descriptors to users (transitive closure
+	// is normalize's job; collect provides one hop per group). Every group is
+	// already listed, so no recursion is required here.
+	memberships := map[string][]json.RawMessage{}
+	for _, g := range groups {
+		desc := strField(g, "descriptor")
+		if desc == "" {
+			continue
+		}
+		mem, mstatus, merr := softList(ctx, cl, "vssps", APIVersionGraph,
+			"/_apis/graph/memberships/"+url.PathEscape(desc), url.Values{"direction": []string{"down"}})
+		if merr != nil {
+			return merr
+		}
+		if mstatus == 0 {
+			memberships[desc] = rawArray(mem)
+		}
+	}
+	data := map[string]any{"groups": rawArray(groups), "users": rawArray(users), "memberships": memberships}
+	if gstatus != 0 {
+		data["_unobserved"] = gstatus
+	}
+	return envelope(cp, engine.CollectADOGraph(org), "graph", "/_apis/graph/{groups,users,memberships}", data)
+}
+
+func collectExtensions(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
+	raw, status, err := softGet(ctx, cl, "extmgmt", APIVersionPreview, "/_apis/extensionmanagement/installedextensions", nil)
+	if err != nil {
+		return err
+	}
+	if status != 0 {
+		raw = json.RawMessage("null")
+	}
+	return envelope(cp, engine.CollectADOExtensions(org), "extensions",
+		"/_apis/extensionmanagement/installedextensions", raw)
+}
+
+func collectServiceHooks(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
+	items, _, err := softList(ctx, cl, "core", APIVersionPreview, "/_apis/hooks/subscriptions", nil)
+	if err != nil {
+		return err
+	}
+	return envelope(cp, engine.CollectADOServiceHooks(org), "service-hooks", "/_apis/hooks/subscriptions", rawArray(items))
+}
+
+// collectFeeds pulls org-scoped feeds (feeds are org-scoped in practice) plus
+// each feed's views and permissions.
+func collectFeeds(ctx context.Context, cl ADO, cp engine.CurrentPhase, org string) error {
+	feeds, status, err := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds", nil)
+	if err != nil {
+		return err
+	}
+	if status != 0 {
+		return envelope(cp, engine.CollectADOFeeds(org), "feeds", "/_apis/packaging/feeds", []json.RawMessage{})
+	}
+	type feedBundle struct {
+		Feed        json.RawMessage   `json:"feed"`
+		Views       []json.RawMessage `json:"views"`
+		Permissions []json.RawMessage `json:"permissions"`
+	}
+	bundles := make([]feedBundle, 0, len(feeds))
+	for _, f := range feeds {
+		fid := strField(f, "id")
+		if fid == "" {
+			bundles = append(bundles, feedBundle{Feed: f, Views: []json.RawMessage{}, Permissions: []json.RawMessage{}})
+			continue
+		}
+		views, _, _ := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds/"+fid+"/views", nil)
+		perms, _, _ := softList(ctx, cl, "feeds", APIVersionPreview, "/_apis/packaging/feeds/"+fid+"/permissions", nil)
+		bundles = append(bundles, feedBundle{Feed: f, Views: rawArray(views), Permissions: rawArray(perms)})
+	}
+	return envelope(cp, engine.CollectADOFeeds(org), "feeds", "/_apis/packaging/feeds", bundles)
+}
+
+// ================= PROJECT list surfaces =================
+
+func collectProjectDetail(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string) error {
+	raw, status, err := softGet(ctx, cl, "core", APIVersion,
+		"/_apis/projects/"+url.PathEscape(project), url.Values{"includeCapabilities": []string{"true"}})
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOProject(project), "project", "/_apis/projects/"+project, raw, status)
+}
+
+func collectGeneralSettings(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string) error {
+	raw, status, err := softGet(ctx, cl, "core", APIVersion, "/"+url.PathEscape(project)+"/_apis/build/generalsettings", nil)
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOGeneralSettings(project), "general-settings",
+		"/"+project+"/_apis/build/generalsettings", raw, status)
+}
+
+func collectProjectProperties(ctx context.Context, cl ADO, cp engine.CurrentPhase, projectID, project string) error {
+	raw, status, err := softGet(ctx, cl, "core", APIVersionPreview, "/_apis/projects/"+projectID+"/properties", nil)
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOProjectProps(project), "project-properties",
+		"/_apis/projects/"+projectID+"/properties", raw, status)
+}
+
+func collectRepos(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string) ([]repoRef, error) {
+	items, _, err := softList(ctx, cl, "core", APIVersion, "/"+url.PathEscape(project)+"/_apis/git/repositories", nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := envelope(cp, engine.CollectADORepos(project), "repositories",
+		"/"+project+"/_apis/git/repositories", rawArray(items)); err != nil {
+		return nil, err
+	}
+	out := make([]repoRef, 0, len(items))
+	for _, raw := range items {
+		if id, name := strField(raw, "id"), strField(raw, "name"); id != "" {
+			out = append(out, repoRef{ID: id, Name: name})
+		}
+	}
+	return out, nil
+}
+
+// listSurface fetches a project list, stores it, and returns resourceRefs of the
+// given type for downstream pipeline-permissions / checks fan-out.
+func listSurface(ctx context.Context, cl ADO, cp engine.CurrentPhase, project, host, api, apiPath, rel, collector, rtype string) ([]resourceRef, error) {
+	items, _, err := softList(ctx, cl, host, api, apiPath, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := envelope(cp, rel, collector, apiPath, rawArray(items)); err != nil {
+		return nil, err
+	}
+	if rtype == "" {
+		return nil, nil
+	}
+	out := make([]resourceRef, 0, len(items))
+	for _, raw := range items {
+		id := strField(raw, "id")
+		if id == "" {
+			if n := numField(raw, "id"); n != 0 {
+				id = fmt.Sprintf("%d", n)
+			}
+		}
+		if id != "" {
+			out = append(out, resourceRef{Type: rtype, ID: id, Name: strField(raw, "name")})
+		}
+	}
+	return out, nil
+}
+
+func collectPolicies(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string) error {
+	pe := url.PathEscape(project)
+	_, err := listSurface(ctx, cl, cp, project, "core", APIVersion,
+		"/"+pe+"/_apis/policy/configurations", engine.CollectADOPolicies(project), "policy-configurations", "")
+	if err != nil {
+		return err
+	}
+	_, err = listSurface(ctx, cl, cp, project, "core", APIVersion,
+		"/"+pe+"/_apis/policy/types", engine.CollectADOPolicyTypes(project), "policy-types", "")
+	return err
+}
+
+func collectBuildACL(ctx context.Context, cl ADO, cp engine.CurrentPhase, project, projectID string) error {
+	raw, status, err := softGet(ctx, cl, "core", APIVersion, "/_apis/accesscontrollists/"+buildNS,
+		url.Values{"token": []string{projectID}, "includeExtendedInfo": []string{"true"}})
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOBuildACL(project), "build-acl",
+		"/_apis/accesscontrollists/"+buildNS, raw, status)
+}
+
+func collectRepoACL(ctx context.Context, cl ADO, cp engine.CurrentPhase, project, projectID string, repo repoRef) error {
+	token := fmt.Sprintf("repoV2/%s/%s", projectID, repo.ID)
+	raw, status, err := softGet(ctx, cl, "core", APIVersion, "/_apis/accesscontrollists/"+gitNS,
+		url.Values{"token": []string{token}, "includeExtendedInfo": []string{"true"}, "recurse": []string{"true"}})
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADORepoACL(project, repo.Name), "repo-acl",
+		"/_apis/accesscontrollists/"+gitNS, raw, status)
+}
+
+// ================= PER-RESOURCE (checks + pipeline permissions) =================
+
+func collectPipelinePermissions(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, r resourceRef) error {
+	p := fmt.Sprintf("/%s/_apis/pipelines/pipelinepermissions/%s/%s", url.PathEscape(project), r.Type, url.PathEscape(r.ID))
+	raw, status, err := softGet(ctx, cl, "core", APIVersionPreview, p, nil)
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOPipelinePerms(project, r.Type, r.ID), "pipeline-permissions", p, raw, status)
+}
+
+func collectChecks(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, r resourceRef) error {
+	p := fmt.Sprintf("/%s/_apis/pipelines/checks/configurations", url.PathEscape(project))
+	params := url.Values{
+		"resourceType": []string{r.Type},
+		"resourceId":   []string{r.ID},
+		"$expand":      []string{"settings"},
+	}
+	items, status, err := softList(ctx, cl, "core", APIVersionPreview, p, params)
+	if err != nil || status != 0 {
+		return err
+	}
+	return envelope(cp, engine.CollectADOChecks(project, r.Type, r.ID), "checks", p, rawArray(items))
+}
+
+// ================= PER-ENV =================
+
+func collectEnvironmentDetail(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, envID int64) error {
+	p := fmt.Sprintf("/%s/_apis/distributedtask/environments/%d", url.PathEscape(project), envID)
+	raw, status, err := softGet(ctx, cl, "core", APIVersion, p, url.Values{"expands": []string{"resourceReferences"}})
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOEnvironmentDetail(project, envID), "environment-detail", p, raw, status)
+}
+
+// ================= PER-PIPELINE (build def full + preview) =================
+
+// collectBuildDefFull returns the full definition so the caller can drive YAML +
+// template-closure collection.
+func collectBuildDefFull(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, id int64) (json.RawMessage, error) {
+	p := fmt.Sprintf("/%s/_apis/build/definitions/%d", url.PathEscape(project), id)
+	raw, status, err := softGet(ctx, cl, "core", APIVersion, p, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != 0 {
+		// unobservable: mark and skip downstream YAML/preview (caller checks nil)
+		return nil, writeOrMark(cp, engine.CollectADOBuildDefFull(project, id), "build-definition", p, nil, status)
+	}
+	if err := envelope(cp, engine.CollectADOBuildDefFull(project, id), "build-definition", p, raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// collectReleaseFull fetches one classic release definition's full detail
+// (environments, pre/post-deploy approvals, gates, artifacts, triggers) — the
+// list endpoint returns only summaries. cat-14.
+func collectReleaseFull(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, id int64) error {
+	p := fmt.Sprintf("/%s/_apis/release/definitions/%d", url.PathEscape(project), id)
+	raw, status, err := softGet(ctx, cl, "vsrm", APIVersion, p, nil)
+	if err != nil {
+		return err
+	}
+	return writeOrMark(cp, engine.CollectADOReleaseFull(project, id), "release-definition", p, raw, status)
+}
+
+// collectPipelinePreview soft-fails per pipeline (a template-consumer whose
+// resource-repo alias can't resolve returns HTTP 400).
+func collectPipelinePreview(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, id int64) error {
+	p := fmt.Sprintf("/%s/_apis/pipelines/%d/preview", url.PathEscape(project), id)
+	raw, err := cl.Post(ctx, "core", APIVersionPreview, p, nil, map[string]any{"previewRun": true})
+	if err != nil {
+		// preview validation errors (400) and permission (403) are non-fatal here
+		if isSoft(err) || softStatus(err) == 400 {
+			return envelope(cp, engine.CollectADOPipelinePreview(project, id), "pipeline-preview", p,
+				map[string]any{"_error": err.Error()})
+		}
+		return err
+	}
+	return envelope(cp, engine.CollectADOPipelinePreview(project, id), "pipeline-preview", p, raw)
+}

--- a/internal/ado/collect_templates.go
+++ b/internal/ado/collect_templates.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	yaml "go.yaml.in/yaml/v4"
@@ -37,41 +38,45 @@ func collectPipelineYAML(ctx context.Context, cl ADO, cp engine.CurrentPhase, pr
 	}
 
 	visited := map[string]bool{}
-	return fetchYAMLClosure(ctx, cl, cp, project, byName, id, repoID, yamlPath, branch, 0, visited)
+	return fetchYAMLClosure(ctx, cl, cp, project, byName, id, repoID, normalizePath(yamlPath), branch, "branch", 0, visited)
 }
 
-func fetchYAMLClosure(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, reposByName map[string]string, pipelineID int64, repoID, path, version string, depth int, visited map[string]bool) error {
-	key := repoID + "|" + path + "|" + version
+func fetchYAMLClosure(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, reposByName map[string]string, pipelineID int64, repoID, filePath, version, versionType string, depth int, visited map[string]bool) error {
+	key := repoID + "|" + filePath + "|" + version
 	if visited[key] || depth > maxTemplateDepth {
 		return nil
 	}
 	visited[key] = true
 
-	raw, content, status, err := fetchItem(ctx, cl, project, repoID, path, version)
+	raw, content, status, err := fetchItem(ctx, cl, project, repoID, filePath, version, versionType)
 	if err != nil {
 		return err
 	}
-	name := fmt.Sprintf("%s@%s__%s", repoID, version, path)
+	name := fmt.Sprintf("%s@%s__%s", repoID, version, filePath)
 	if status != 0 {
 		return envelope(cp, engine.CollectADOPipelineYAML(project, pipelineID, name), "pipeline-yaml",
-			itemPath(project, repoID, path, version),
-			map[string]any{"_unresolved": true, "_status": status, "repo_id": repoID, "path": path, "version": version})
+			itemPath(project, repoID, filePath, version),
+			map[string]any{"_unresolved": true, "_status": status, "repo_id": repoID, "path": filePath, "version": version})
 	}
 	if err := envelope(cp, engine.CollectADOPipelineYAML(project, pipelineID, name), "pipeline-yaml",
-		itemPath(project, repoID, path, version), raw); err != nil {
+		itemPath(project, repoID, filePath, version), raw); err != nil {
 		return err
 	}
 
 	refs, aliases := parseTemplateRefs(content)
 	for _, r := range refs {
-		targetRepo, targetVer := repoID, version
+		targetRepo, targetVer, targetVerType := repoID, version, versionType
+		// Same-repo template paths resolve relative to the including file's directory;
+		// a leading "/" is repo-root absolute (ADO template resolution semantics).
+		childPath := resolveTemplatePath(filePath, r.path)
 		if r.alias != "" {
 			res, ok := aliases[strings.ToLower(r.alias)]
 			if !ok {
 				continue // unknown alias
 			}
-			rid, ok := reposByName[strings.ToLower(lastSegment(res.name))]
-			if !ok {
+			localName, external := resolveRepoName(res.name, project)
+			rid, ok := reposByName[strings.ToLower(localName)]
+			if external || !ok {
 				// cross-project or external template repo: record the reference, don't fetch
 				_ = envelope(cp, engine.CollectADOPipelineYAML(project, pipelineID,
 					fmt.Sprintf("unresolved__%s__%s", r.alias, adoName(r.path))), "pipeline-yaml", "",
@@ -79,24 +84,26 @@ func fetchYAMLClosure(ctx context.Context, cl ADO, cp engine.CurrentPhase, proje
 				continue
 			}
 			targetRepo = rid
-			if v := stripRef(res.ref); v != "" {
-				targetVer = v
+			if v, vt := refVersion(res.ref); v != "" {
+				targetVer, targetVerType = v, vt
 			}
+			// a cross-repo path is relative to that repo's root, not the including file
+			childPath = normalizePath(r.path)
 		}
-		if err := fetchYAMLClosure(ctx, cl, cp, project, reposByName, pipelineID, targetRepo, normalizePath(r.path), targetVer, depth+1, visited); err != nil {
+		if err := fetchYAMLClosure(ctx, cl, cp, project, reposByName, pipelineID, targetRepo, childPath, targetVer, targetVerType, depth+1, visited); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func fetchItem(ctx context.Context, cl ADO, project, repoID, path, version string) (json.RawMessage, string, int, error) {
+func fetchItem(ctx context.Context, cl ADO, project, repoID, filePath, version, versionType string) (json.RawMessage, string, int, error) {
 	p := fmt.Sprintf("/%s/_apis/git/repositories/%s/items", url.PathEscape(project), repoID)
 	params := url.Values{
-		"path":                          []string{normalizePath(path)},
+		"path":                          []string{normalizePath(filePath)},
 		"includeContent":                []string{"true"},
 		"versionDescriptor.version":     []string{version},
-		"versionDescriptor.versionType": []string{"branch"},
+		"versionDescriptor.versionType": []string{versionType},
 	}
 	raw, _, err := cl.Get(ctx, "core", APIVersion, p, params, true)
 	if err != nil {
@@ -204,11 +211,36 @@ func normalizePath(p string) string {
 	return p
 }
 
-func lastSegment(s string) string {
-	if i := strings.LastIndex(s, "/"); i >= 0 {
-		return s[i+1:]
+// refVersion resolves a resources.repositories ref to (version, versionType). A
+// tag ref must be fetched with versionType "tag" — sending it as a branch 404s.
+func refVersion(ref string) (version, versionType string) {
+	if strings.HasPrefix(ref, "refs/tags/") {
+		return strings.TrimPrefix(ref, "refs/tags/"), "tag"
 	}
-	return s
+	return stripRef(ref), "branch"
+}
+
+// resolveRepoName returns the local repo name to look up and whether the reference
+// is cross-project/external. A bare "Repo" is same-project; "Project/Repo" is
+// external unless Project is the current one — so a cross-project repo that merely
+// shares a name with a local repo is NOT matched to the local one.
+func resolveRepoName(name, project string) (local string, external bool) {
+	if i := strings.Index(name, "/"); i >= 0 {
+		if !strings.EqualFold(name[:i], project) {
+			return "", true
+		}
+		return name[i+1:], false
+	}
+	return name, false
+}
+
+// resolveTemplatePath resolves a same-repo template reference relative to the
+// including file's directory (ADO semantics); a leading "/" is repo-root absolute.
+func resolveTemplatePath(includingFile, ref string) string {
+	if strings.HasPrefix(ref, "/") {
+		return ref
+	}
+	return path.Join(path.Dir(includingFile), ref)
 }
 
 func adoName(s string) string {

--- a/internal/ado/collect_templates.go
+++ b/internal/ado/collect_templates.go
@@ -1,0 +1,216 @@
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+const maxTemplateDepth = 5
+
+// collectPipelineYAML fetches the entry YAML for a build definition and then
+// recursively fetches its extends/template closure (cat-08). Template bodies are
+// recoverable from neither the build definition nor preview, so collect must
+// resolve and fetch them here.
+func collectPipelineYAML(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, repos []repoRef, id int64, full json.RawMessage) error {
+	repoObj := objField(full, "repository")
+	repoID := strField(repoObj, "id")
+	repoType := strField(repoObj, "type")
+	yamlPath := strField(objField(full, "process"), "yamlFilename")
+	if repoID == "" || yamlPath == "" || !strings.EqualFold(repoType, "TfsGit") {
+		return nil // classic pipeline or non-Azure-Repos source: git items won't serve it
+	}
+	branch := stripRef(strField(repoObj, "defaultBranch"))
+	if branch == "" {
+		branch = "main"
+	}
+
+	byName := make(map[string]string, len(repos))
+	for _, r := range repos {
+		byName[strings.ToLower(r.Name)] = r.ID
+	}
+
+	visited := map[string]bool{}
+	return fetchYAMLClosure(ctx, cl, cp, project, byName, id, repoID, yamlPath, branch, 0, visited)
+}
+
+func fetchYAMLClosure(ctx context.Context, cl ADO, cp engine.CurrentPhase, project string, reposByName map[string]string, pipelineID int64, repoID, path, version string, depth int, visited map[string]bool) error {
+	key := repoID + "|" + path + "|" + version
+	if visited[key] || depth > maxTemplateDepth {
+		return nil
+	}
+	visited[key] = true
+
+	raw, content, status, err := fetchItem(ctx, cl, project, repoID, path, version)
+	if err != nil {
+		return err
+	}
+	name := fmt.Sprintf("%s@%s__%s", repoID, version, path)
+	if status != 0 {
+		return envelope(cp, engine.CollectADOPipelineYAML(project, pipelineID, name), "pipeline-yaml",
+			itemPath(project, repoID, path, version),
+			map[string]any{"_unresolved": true, "_status": status, "repo_id": repoID, "path": path, "version": version})
+	}
+	if err := envelope(cp, engine.CollectADOPipelineYAML(project, pipelineID, name), "pipeline-yaml",
+		itemPath(project, repoID, path, version), raw); err != nil {
+		return err
+	}
+
+	refs, aliases := parseTemplateRefs(content)
+	for _, r := range refs {
+		targetRepo, targetVer := repoID, version
+		if r.alias != "" {
+			res, ok := aliases[strings.ToLower(r.alias)]
+			if !ok {
+				continue // unknown alias
+			}
+			rid, ok := reposByName[strings.ToLower(lastSegment(res.name))]
+			if !ok {
+				// cross-project or external template repo: record the reference, don't fetch
+				_ = envelope(cp, engine.CollectADOPipelineYAML(project, pipelineID,
+					fmt.Sprintf("unresolved__%s__%s", r.alias, adoName(r.path))), "pipeline-yaml", "",
+					map[string]any{"_unresolved_external": true, "alias": r.alias, "repository": res.name, "ref": res.ref, "path": r.path})
+				continue
+			}
+			targetRepo = rid
+			if v := stripRef(res.ref); v != "" {
+				targetVer = v
+			}
+		}
+		if err := fetchYAMLClosure(ctx, cl, cp, project, reposByName, pipelineID, targetRepo, normalizePath(r.path), targetVer, depth+1, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fetchItem(ctx context.Context, cl ADO, project, repoID, path, version string) (json.RawMessage, string, int, error) {
+	p := fmt.Sprintf("/%s/_apis/git/repositories/%s/items", url.PathEscape(project), repoID)
+	params := url.Values{
+		"path":                          []string{normalizePath(path)},
+		"includeContent":                []string{"true"},
+		"versionDescriptor.version":     []string{version},
+		"versionDescriptor.versionType": []string{"branch"},
+	}
+	raw, _, err := cl.Get(ctx, "core", APIVersion, p, params, true)
+	if err != nil {
+		if isSoft(err) {
+			return nil, "", softStatus(err), nil
+		}
+		return nil, "", 0, err
+	}
+	if raw == nil {
+		return nil, "", 404, nil
+	}
+	return raw, strField(raw, "content"), 0, nil
+}
+
+func itemPath(project, repoID, path, version string) string {
+	return fmt.Sprintf("/%s/_apis/git/repositories/%s/items?path=%s&version=%s", project, repoID, normalizePath(path), version)
+}
+
+type templateRef struct {
+	path  string
+	alias string
+}
+
+type repoResource struct {
+	name string
+	ref  string
+}
+
+// parseTemplateRefs walks a pipeline/template YAML for every `template:` and
+// `extends.template` string reference, and the `resources.repositories` alias map.
+func parseTemplateRefs(content string) ([]templateRef, map[string]repoResource) {
+	var root any
+	if err := yaml.Unmarshal([]byte(content), &root); err != nil {
+		return nil, nil
+	}
+	var refs []templateRef
+	aliases := map[string]repoResource{}
+	collectRepoResources(root, aliases)
+	walkTemplateNodes(root, &refs)
+	return refs, aliases
+}
+
+func walkTemplateNodes(node any, refs *[]templateRef) {
+	switch v := node.(type) {
+	case map[string]any:
+		for k, val := range v {
+			if k == "template" {
+				if s, ok := val.(string); ok && s != "" {
+					*refs = append(*refs, splitTemplateRef(s))
+				}
+			}
+			walkTemplateNodes(val, refs)
+		}
+	case []any:
+		for _, e := range v {
+			walkTemplateNodes(e, refs)
+		}
+	}
+}
+
+func collectRepoResources(node any, out map[string]repoResource) {
+	m, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	if res, ok := m["resources"].(map[string]any); ok {
+		if list, ok := res["repositories"].([]any); ok {
+			for _, e := range list {
+				em, ok := e.(map[string]any)
+				if !ok {
+					continue
+				}
+				alias, _ := em["repository"].(string)
+				if alias == "" {
+					continue
+				}
+				name, _ := em["name"].(string)
+				ref, _ := em["ref"].(string)
+				out[strings.ToLower(alias)] = repoResource{name: name, ref: ref}
+			}
+		}
+	}
+}
+
+func splitTemplateRef(s string) templateRef {
+	if i := strings.LastIndex(s, "@"); i >= 0 {
+		return templateRef{path: s[:i], alias: s[i+1:]}
+	}
+	return templateRef{path: s}
+}
+
+func stripRef(ref string) string {
+	ref = strings.TrimPrefix(ref, "refs/heads/")
+	ref = strings.TrimPrefix(ref, "refs/tags/")
+	return ref
+}
+
+func normalizePath(p string) string {
+	if p == "" {
+		return p
+	}
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
+}
+
+func lastSegment(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+func adoName(s string) string {
+	return strings.ReplaceAll(strings.TrimPrefix(s, "/"), "/", "__")
+}

--- a/internal/ado/collect_templates_test.go
+++ b/internal/ado/collect_templates_test.go
@@ -1,0 +1,90 @@
+package ado
+
+import "testing"
+
+func TestSplitTemplateRef(t *testing.T) {
+	tests := []struct {
+		in    string
+		path  string
+		alias string
+	}{
+		{"base.yml@templates", "base.yml", "templates"},
+		{"local.yml", "local.yml", ""},
+		{"dir/base.yml@repo", "dir/base.yml", "repo"},
+		{"a@b@c", "a@b", "c"}, // split on the LAST @
+	}
+	for _, tt := range tests {
+		got := splitTemplateRef(tt.in)
+		if got.path != tt.path || got.alias != tt.alias {
+			t.Errorf("splitTemplateRef(%q) = {%q,%q}, want {%q,%q}", tt.in, got.path, got.alias, tt.path, tt.alias)
+		}
+	}
+}
+
+func TestStripRefAndNormalize(t *testing.T) {
+	if got := stripRef("refs/heads/main"); got != "main" {
+		t.Errorf("stripRef heads = %q", got)
+	}
+	if got := stripRef("refs/tags/v1.2"); got != "v1.2" {
+		t.Errorf("stripRef tags = %q", got)
+	}
+	if got := stripRef("release/1.0"); got != "release/1.0" {
+		t.Errorf("stripRef bare = %q", got)
+	}
+	if got := normalizePath("templates/x.yml"); got != "/templates/x.yml" {
+		t.Errorf("normalizePath rel = %q", got)
+	}
+	if got := normalizePath("/a.yml"); got != "/a.yml" {
+		t.Errorf("normalizePath abs = %q", got)
+	}
+}
+
+// Oracle: the real Imladris s08-01 consumer shape — extends a cross-repo template
+// declared via resources.repositories.
+func TestParseTemplateRefs(t *testing.T) {
+	yaml := `
+resources:
+  repositories:
+  - repository: templates
+    type: git
+    name: Imladris/BuildTemplates
+    ref: refs/heads/release
+variables:
+- group: prod-secrets
+extends:
+  template: base.yml@templates
+`
+	refs, aliases := parseTemplateRefs(yaml)
+	if len(refs) != 1 {
+		t.Fatalf("want 1 template ref, got %d: %+v", len(refs), refs)
+	}
+	if refs[0].path != "base.yml" || refs[0].alias != "templates" {
+		t.Errorf("ref = %+v", refs[0])
+	}
+	res, ok := aliases["templates"]
+	if !ok {
+		t.Fatalf("alias 'templates' not resolved; got %+v", aliases)
+	}
+	if res.name != "Imladris/BuildTemplates" || res.ref != "refs/heads/release" {
+		t.Errorf("repoResource = %+v", res)
+	}
+}
+
+// A template that includes another template inline (nested steps) must surface
+// both references.
+func TestParseTemplateRefs_Nested(t *testing.T) {
+	yaml := `
+steps:
+- template: steps/build.yml
+- script: echo hi
+- template: steps/deploy.yml@shared
+`
+	refs, _ := parseTemplateRefs(yaml)
+	if len(refs) != 2 {
+		t.Fatalf("want 2 refs, got %d: %+v", len(refs), refs)
+	}
+	paths := map[string]string{refs[0].path: refs[0].alias, refs[1].path: refs[1].alias}
+	if paths["steps/build.yml"] != "" || paths["steps/deploy.yml"] != "shared" {
+		t.Errorf("unexpected refs: %+v", refs)
+	}
+}

--- a/internal/ado/scope.go
+++ b/internal/ado/scope.go
@@ -1,0 +1,94 @@
+package ado
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type ScopeKind int
+
+const (
+	ScopeOrg ScopeKind = iota
+	ScopeProject
+	ScopeRepo
+)
+
+// Scope narrows a run. Org is always required; Project/Repo optionally restrict
+// the fan-out. Org and project surfaces are collected regardless of narrowing,
+// mirroring the GitHub collector (a repo-scoped run still collects the org).
+type Scope struct {
+	Kind    ScopeKind
+	Org     string
+	Project string
+	Repo    string
+	Slug    string
+}
+
+// ParseScope accepts "<org>", "<org>/<project>", "<org>/<project>/<repo>", or a
+// dev.azure.com URL. An empty locator yields the zero Scope so the caller can
+// fall back to ORG_NAME.
+func ParseScope(arg string) (Scope, error) {
+	s := strings.TrimSpace(arg)
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "https://"), "http://")
+	s = strings.Trim(s, "/")
+	parts := strings.Split(s, "/")
+	// drop a leading dev.azure.com host, or a visualstudio.com vanity host
+	if len(parts) > 0 && (strings.Contains(parts[0], "dev.azure.com") || strings.HasSuffix(parts[0], "visualstudio.com")) {
+		parts = parts[1:]
+	}
+	parts = slices.DeleteFunc(parts, func(p string) bool { return p == "" })
+	if len(parts) == 0 {
+		return Scope{}, fmt.Errorf("cannot parse scope from %q", arg)
+	}
+
+	sc := Scope{Kind: ScopeOrg, Org: parts[0]}
+	if len(parts) >= 2 {
+		sc.Kind = ScopeProject
+		sc.Project = parts[1]
+	}
+	if len(parts) >= 3 {
+		sc.Kind = ScopeRepo
+		// a repo path segment may itself contain "_git/<repo>"; keep the last part
+		sc.Repo = parts[len(parts)-1]
+	}
+	sc.Slug = slugify(sc)
+	return sc, nil
+}
+
+func slugify(sc Scope) string {
+	switch sc.Kind {
+	case ScopeRepo:
+		return slugComponent(sc.Org) + "__" + slugComponent(sc.Project) + "__" + slugComponent(sc.Repo)
+	case ScopeProject:
+		return slugComponent(sc.Org) + "__" + slugComponent(sc.Project)
+	default:
+		return slugComponent(sc.Org)
+	}
+}
+
+func slugComponent(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	return b.String()
+}
+
+func scopeString(s Scope) string {
+	switch s.Kind {
+	case ScopeRepo:
+		return s.Org + "/" + s.Project + "/" + s.Repo
+	case ScopeProject:
+		return s.Org + "/" + s.Project
+	default:
+		return s.Org
+	}
+}

--- a/internal/ado/scope.go
+++ b/internal/ado/scope.go
@@ -33,9 +33,15 @@ func ParseScope(arg string) (Scope, error) {
 	s = strings.TrimPrefix(strings.TrimPrefix(s, "https://"), "http://")
 	s = strings.Trim(s, "/")
 	parts := strings.Split(s, "/")
-	// drop a leading dev.azure.com host, or a visualstudio.com vanity host
-	if len(parts) > 0 && (strings.Contains(parts[0], "dev.azure.com") || strings.HasSuffix(parts[0], "visualstudio.com")) {
-		parts = parts[1:]
+	if len(parts) > 0 {
+		switch host := parts[0]; {
+		case strings.Contains(host, "dev.azure.com"):
+			parts = parts[1:] // dev.azure.com/<org>/<project>... — org is the first path segment
+		case strings.HasSuffix(host, ".visualstudio.com"):
+			// legacy vanity host: the org IS the subdomain (<org>.visualstudio.com/<project>),
+			// so replace the host with the org rather than dropping it (which loses the org).
+			parts[0] = strings.TrimSuffix(host, ".visualstudio.com")
+		}
 	}
 	parts = slices.DeleteFunc(parts, func(p string) bool { return p == "" })
 	if len(parts) == 0 {

--- a/internal/ado/scope_test.go
+++ b/internal/ado/scope_test.go
@@ -1,0 +1,46 @@
+package ado
+
+import "testing"
+
+func TestParseScope(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantErr bool
+		kind    ScopeKind
+		org     string
+		project string
+		repo    string
+		slug    string
+	}{
+		{in: "Middle-Earth-Arda", kind: ScopeOrg, org: "Middle-Earth-Arda", slug: "middle-earth-arda"},
+		{in: "org/Imladris", kind: ScopeProject, org: "org", project: "Imladris", slug: "org__imladris"},
+		{in: "org/proj/repo", kind: ScopeRepo, org: "org", project: "proj", repo: "repo", slug: "org__proj__repo"},
+		{in: "https://dev.azure.com/org/proj", kind: ScopeProject, org: "org", project: "proj"},
+		{in: "dev.azure.com/org", kind: ScopeOrg, org: "org"},
+		{in: "org/", kind: ScopeOrg, org: "org"},
+		{in: "  org/proj  ", kind: ScopeProject, org: "org", project: "proj"},
+		{in: "", wantErr: true},
+		{in: "   ", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			sc, err := ParseScope(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sc.Kind != tt.kind || sc.Org != tt.org || sc.Project != tt.project || sc.Repo != tt.repo {
+				t.Errorf("got {kind:%d org:%q project:%q repo:%q}, want {kind:%d org:%q project:%q repo:%q}",
+					sc.Kind, sc.Org, sc.Project, sc.Repo, tt.kind, tt.org, tt.project, tt.repo)
+			}
+			if tt.slug != "" && sc.Slug != tt.slug {
+				t.Errorf("slug = %q, want %q", sc.Slug, tt.slug)
+			}
+		})
+	}
+}

--- a/internal/ado/scope_test.go
+++ b/internal/ado/scope_test.go
@@ -17,6 +17,10 @@ func TestParseScope(t *testing.T) {
 		{in: "org/proj/repo", kind: ScopeRepo, org: "org", project: "proj", repo: "repo", slug: "org__proj__repo"},
 		{in: "https://dev.azure.com/org/proj", kind: ScopeProject, org: "org", project: "proj"},
 		{in: "dev.azure.com/org", kind: ScopeOrg, org: "org"},
+		// legacy vanity host: org is the subdomain, must NOT be dropped
+		{in: "org.visualstudio.com/proj", kind: ScopeProject, org: "org", project: "proj"},
+		{in: "https://org.visualstudio.com/proj", kind: ScopeProject, org: "org", project: "proj"},
+		{in: "org.visualstudio.com", kind: ScopeOrg, org: "org"},
 		{in: "org/", kind: ScopeOrg, org: "org"},
 		{in: "  org/proj  ", kind: ScopeProject, org: "org", project: "proj"},
 		{in: "", wantErr: true},

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -4,4 +4,5 @@ type Config struct {
 	Concurrency int
 	OutputDir   string
 	Dev         bool
+	Token       string // explicit API token from --token; overrides env when set
 }

--- a/internal/engine/paths.go
+++ b/internal/engine/paths.go
@@ -114,6 +114,136 @@ func CollectRefResolution(owner, actionRepo, ref string) string {
 		fmt.Sprintf("%s__%s@%s.json", owner, actionRepo, safeRef(ref)))
 }
 
+// ---- Azure DevOps collect paths ----
+//
+// adoKey sanitizes an ADO project/repo/host name for use as a path segment:
+// anything outside [A-Za-z0-9._-] becomes '-'. ADO names are already restricted,
+// so this only guards the rare space/slash.
+func adoKey(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-' {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	if b.Len() == 0 {
+		return "_"
+	}
+	return b.String()
+}
+
+func adoCollect(parts ...string) string {
+	return path.Join(append([]string{dirCollect}, parts...)...)
+}
+
+// Org-scope surfaces (key = org).
+func CollectADOConnectionData(org string) string {
+	return adoCollect("connection-data", adoKey(org)+".json")
+}
+func CollectADOProjects(org string) string { return adoCollect("projects", adoKey(org)+".json") }
+func CollectADOSecurityNS(org string) string {
+	return adoCollect("security-namespaces", adoKey(org)+".json")
+}
+func CollectADOGraph(org string) string      { return adoCollect("graph", adoKey(org)+".json") }
+func CollectADOExtensions(org string) string { return adoCollect("extensions", adoKey(org)+".json") }
+func CollectADOServiceHooks(org string) string {
+	return adoCollect("service-hooks", adoKey(org)+".json")
+}
+func CollectADOFeeds(org string) string { return adoCollect("feeds", adoKey(org)+".json") }
+
+// Org agent pools (key = poolID).
+func CollectADOPool(poolID int64) string {
+	return adoCollect("pools", fmt.Sprintf("%d.json", poolID))
+}
+func CollectADOPoolAgents(poolID int64) string {
+	return adoCollect("pool-agents", fmt.Sprintf("%d.json", poolID))
+}
+func CollectADOElasticPool(poolID int64) string {
+	return adoCollect("elastic-pools", fmt.Sprintf("%d.json", poolID))
+}
+func CollectADOEndpointACL(project, connID string) string {
+	return adoCollect("acl-endpoint", adoKey(project), adoKey(connID)+".json")
+}
+
+// Project-scope surfaces (key = project).
+func CollectADOProject(project string) string { return adoCollect("project", adoKey(project)+".json") }
+func CollectADOGeneralSettings(project string) string {
+	return adoCollect("general-settings", adoKey(project)+".json")
+}
+func CollectADOProjectProps(project string) string {
+	return adoCollect("project-properties", adoKey(project)+".json")
+}
+func CollectADORepos(project string) string { return adoCollect("repos", adoKey(project)+".json") }
+func CollectADOPolicies(project string) string {
+	return adoCollect("policies", adoKey(project)+".json")
+}
+func CollectADOPolicyTypes(project string) string {
+	return adoCollect("policy-types", adoKey(project)+".json")
+}
+func CollectADOServiceConnections(project string) string {
+	return adoCollect("service-connections", adoKey(project)+".json")
+}
+func CollectADOVariableGroups(project string) string {
+	return adoCollect("variable-groups", adoKey(project)+".json")
+}
+func CollectADOSecureFiles(project string) string {
+	return adoCollect("secure-files", adoKey(project)+".json")
+}
+func CollectADOEnvironments(project string) string {
+	return adoCollect("environments", adoKey(project)+".json")
+}
+func CollectADODeploymentGroups(project string) string {
+	return adoCollect("deployment-groups", adoKey(project)+".json")
+}
+func CollectADOTaskGroups(project string) string {
+	return adoCollect("task-groups", adoKey(project)+".json")
+}
+func CollectADOAgentQueues(project string) string {
+	return adoCollect("agent-queues", adoKey(project)+".json")
+}
+func CollectADOBuildDefs(project string) string {
+	return adoCollect("build-definitions", adoKey(project)+".json")
+}
+func CollectADOPipelines(project string) string {
+	return adoCollect("pipelines", adoKey(project)+".json")
+}
+func CollectADOReleases(project string) string {
+	return adoCollect("releases", adoKey(project)+".json")
+}
+func CollectADOReleaseFull(project string, id int64) string {
+	return adoCollect("release-definition", adoKey(project), fmt.Sprintf("%d.json", id))
+}
+func CollectADOBuildACL(project string) string {
+	return adoCollect("acl-build", adoKey(project)+".json")
+}
+
+// Per-pipeline / per-resource / per-repo (nested under project).
+func CollectADOBuildDefFull(project string, id int64) string {
+	return adoCollect("build-definition", adoKey(project), fmt.Sprintf("%d.json", id))
+}
+func CollectADOPipelinePreview(project string, id int64) string {
+	return adoCollect("pipeline-preview", adoKey(project), fmt.Sprintf("%d.json", id))
+}
+func CollectADOPipelineYAML(project string, id int64, name string) string {
+	return adoCollect("pipeline-yaml", adoKey(project), fmt.Sprintf("%d__%s.json", id, adoKey(name)))
+}
+func CollectADOEnvironmentDetail(project string, envID int64) string {
+	return adoCollect("environment-detail", adoKey(project), fmt.Sprintf("%d.json", envID))
+}
+func CollectADOPipelinePerms(project, rtype, rid string) string {
+	return adoCollect("pipeline-permissions", adoKey(project), adoKey(rtype)+"__"+adoKey(rid)+".json")
+}
+func CollectADOChecks(project, rtype, rid string) string {
+	return adoCollect("checks", adoKey(project), adoKey(rtype)+"__"+adoKey(rid)+".json")
+}
+func CollectADORepoACL(project, repo string) string {
+	return adoCollect("acl-repo", adoKey(project), adoKey(repo)+".json")
+}
+
 func NormalizeJob(repo, workflow, jobID string) string {
 	return path.Join(dirNormalize, "jobs",
 		fmt.Sprintf("%s__%s__%s.json", repo, wfStem(workflow), jobID))


### PR DESCRIPTION
## Summary

Adds the collect phase of the Azure DevOps platform to the internal phased pipeline (collect → normalize → scan → …), mirroring `internal/github`. Collect-only: it produces raw on-disk JSON for a later normalize phase.

The collector walks the organization → projects → repos / pipelines / service connections / variable groups / secure files / environments / agent pools / policies / classic releases, capturing the control-plane state CI/CD security detection needs — resource authorization, approvals & checks, branch/repo policies, effective ACLs, job-authorization scope, service-connection/WIF config, and agent-pool topology.

## What's included

- **New package `internal/ado/`**: scope/locator parsing, PAT auth, a raw-JSON multi-host client (`dev.azure.com`, `vsrm`, `feeds`, `extmgmt`, `vssps`) with `x-ms-continuationtoken` pagination and 429/5xx retry, orchestration, per-surface collectors, and recursive `extends:`/`template:` closure collection.
- **Locator**: `<org>`, `<org>/<project>`, or `<org>/<project>/<repo>` (falls back to `ORG_NAME`); org + project surfaces are always collected regardless of narrowing.
- **CLI**: `trajan ado collect [locator]` with `--concurrency` / `--output-dir`.
- **Engine**: `CollectADO*` on-disk path helpers in `internal/engine/paths.go`.

Fixes LAB-4282
