### PR TITLE
ado: add normalize phase for the internal phased pipeline

### DIFF
--- a/cmd/trajan/ado/normalize.go
+++ b/cmd/trajan/ado/normalize.go
@@ -1,0 +1,30 @@
+package ado
+
+import (
+	"github.com/spf13/cobra"
+
+	adocollect "github.com/praetorian-inc/trajan/internal/ado"
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// newNormalizeCmd wires the ADO normalize phase (structural node/edge records
+// from the collected raw JSON) into the ado command tree.
+func newNormalizeCmd() *cobra.Command {
+	cfg := &engine.Config{}
+	var path string
+	c := &cobra.Command{
+		Use:   "normalize",
+		Short: "Normalize collected Azure DevOps data into structural node/edge records",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runDir, err := engine.ResolveRunDir(cfg, "ado", path)
+			if err != nil {
+				return err
+			}
+			return adocollect.Normalize(cmd.Context(), runDir)
+		},
+	}
+	c.Flags().StringVar(&cfg.OutputDir, "output-dir", "./trajan-out", "run output directory")
+	c.Flags().StringVarP(&path, "path", "p", "", "run directory (default: latest ado run)")
+	return c
+}

--- a/cmd/trajan/ado/root.go
+++ b/cmd/trajan/ado/root.go
@@ -22,6 +22,7 @@ func init() {
 	AdoCmd.AddCommand(attackCmd)
 	AdoCmd.AddCommand(retrieveCmd)
 	AdoCmd.AddCommand(newCollectCmd())
+	AdoCmd.AddCommand(newNormalizeCmd())
 }
 
 func getToken(cmd *cobra.Command) string {

--- a/internal/ado/classify_sink.go
+++ b/internal/ado/classify_sink.go
@@ -1,0 +1,435 @@
+package ado
+
+import (
+	_ "embed"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	yaml "go.yaml.in/yaml/v4"
+)
+
+//go:embed sinks.yaml
+var sinksYAML []byte
+
+type patternEntry struct {
+	Name     string `yaml:"name"`
+	Pattern  string `yaml:"pattern"`
+	compiled *regexp.Regexp
+}
+
+type sinkTable struct {
+	Exec   []patternEntry `yaml:"exec_sinks"`
+	AITask []patternEntry `yaml:"ai_task"`
+	AICLI  []patternEntry `yaml:"ai_cli"`
+}
+
+var loadSinks = sync.OnceValue(func() sinkTable {
+	var t sinkTable
+	if err := yaml.Unmarshal(sinksYAML, &t); err != nil {
+		panic(fmt.Errorf("parse ado sinks.yaml: %w", err))
+	}
+	for _, group := range [][]patternEntry{t.Exec, t.AITask, t.AICLI} {
+		for i := range group {
+			group[i].compiled = regexp.MustCompile(group[i].Pattern)
+		}
+	}
+	return t
+})
+
+// executorTask records, for a shell/executor task, the shell dialect and which
+// inputs are inline-script sinks (macros expand into a command line) vs argument
+// sinks (macros concatenated onto the command line). This is fixed platform
+// surface, so it lives in code rather than the data table.
+type executorTask struct {
+	shell        string
+	scriptInputs []string
+	argInputs    []string
+}
+
+var executorTasks = map[string]executorTask{
+	"CmdLine@2":         {"cmd", []string{"script"}, nil},
+	"Bash@3":            {"bash", []string{"script"}, []string{"arguments"}},
+	"ShellScript@2":     {"bash", nil, []string{"args"}},
+	"PowerShell@2":      {"powershell", []string{"script"}, []string{"arguments"}},
+	"PowerShell@1":      {"powershell", []string{"script", "inlineScript"}, []string{"arguments"}},
+	"PowerShell@0":      {"powershell", []string{"inlineScript"}, []string{"arguments"}},
+	"AzureCLI@2":        {"azurecli", []string{"inlineScript"}, []string{"arguments"}},
+	"AzureCLI@1":        {"azurecli", []string{"inlineScript"}, []string{"arguments"}},
+	"AzurePowerShell@5": {"powershell", []string{"Inline"}, []string{"ScriptArguments"}},
+	"Ssh@0":             {"ssh", []string{"inline", "commands"}, nil},
+	"BatchScript@1":     {"cmd", nil, []string{"arguments"}},
+	"SSH@0":             {"ssh", []string{"inline", "commands"}, nil},
+}
+
+var shorthandShells = map[string]string{
+	"script": "cmd", "bash": "bash", "powershell": "powershell", "pwsh": "powershell",
+}
+
+// Predefined variables populated by the platform from attacker-controlled data
+// (commit messages, branch names, PR fields). A `$(var)` reference to one of
+// these is the cat-02 `predefined_variable` injection / cat-13 untrusted echo
+// source. Keyed lowercase.
+var untrustedPredefined = map[string]string{
+	"build.sourceversionmessage":             "commit_message",
+	"build.sourceversionauthor":              "commit_message",
+	"build.sourcebranch":                     "branch_name",
+	"build.sourcebranchname":                 "branch_name",
+	"build.requestedfor":                     "requestor",
+	"build.requestedforemail":                "requestor",
+	"system.pullrequest.sourcebranch":        "pr_source_branch",
+	"system.pullrequest.targetbranch":        "pr_target_branch",
+	"system.pullrequest.sourcerepositoryuri": "pr_source_repo",
+	"system.pullrequest.sourcecommitid":      "pr_source_commit",
+}
+
+// systemPrefixes mark platform-generated (non-user, non-attacker) variables that
+// are NOT a queue-time injection surface. A macro whose name has one of these
+// prefixes and is not in untrustedPredefined is treated as safe.
+var systemPrefixes = []string{
+	"build.", "system.", "agent.", "pipeline.", "environment.", "release.",
+	"tf_build", "common.", "endpoint.", "resources.",
+}
+
+var (
+	reMacro   = regexp.MustCompile(`\$\(([A-Za-z0-9_.]+)\)`)
+	reParam   = regexp.MustCompile(`\$\{\{\s*parameters\.([A-Za-z0-9_]+)`)
+	reParamIx = regexp.MustCompile(`\$\{\{\s*parameters\[\s*'([^']+)'`)
+	reRuntime = regexp.MustCompile(`\$\[\s*variables\[?\s*'?([A-Za-z0-9_.]+)`)
+	reVsoLit  = regexp.MustCompile(`##vso\[`)
+	reCat     = regexp.MustCompile(`(?i)(^|\s|;|&&|\|)(cat|type|Get-Content|gc)\s+[./\\$]`)
+	reHTTP    = regexp.MustCompile(`(?i)(^|\s|;|&&|\|)(curl|wget|Invoke-WebRequest|Invoke-RestMethod|iwr)\b`)
+)
+
+// macroKind classifies a `$(name)` variable reference. "system" macros are not an
+// injection surface; "predefined_untrusted" carry attacker-controlled data;
+// "user" are pipeline/queue-time variables (the primary cat-02 surface).
+func macroKind(name string) string {
+	lower := strings.ToLower(name)
+	if _, ok := untrustedPredefined[lower]; ok {
+		return "predefined_untrusted"
+	}
+	for _, p := range systemPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return "system"
+		}
+	}
+	return "user"
+}
+
+// macroNames returns the distinct `$(var)` names in a string (order-stable).
+func macroNames(s string) []string {
+	return uniqueSubmatch(reMacro.FindAllStringSubmatch(s, -1))
+}
+
+// paramNames returns the distinct compile-time expansion selectors: `${{ parameters.x }}`,
+// `${{ parameters['x'] }}`, and `$[ variables['x'] ]` runtime expressions.
+func paramNames(s string) []string {
+	seen, out := map[string]bool{}, []string{}
+	for _, re := range []*regexp.Regexp{reParam, reParamIx, reRuntime} {
+		for _, m := range re.FindAllStringSubmatch(s, -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				out = append(out, m[1])
+			}
+		}
+	}
+	return out
+}
+
+func uniqueSubmatch(matches [][]string) []string {
+	seen, out := map[string]bool{}, []string{}
+	for _, m := range matches {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+// classifyExecSink returns the first exec-sink name matching the script body and
+// whether the body executes checked-out code.
+func classifyExecSink(script string) (string, bool) {
+	for _, e := range loadSinks().Exec {
+		if e.compiled.MatchString(script) {
+			return e.Name, true
+		}
+	}
+	return "", false
+}
+
+func matchesAITask(task string) bool {
+	for _, e := range loadSinks().AITask {
+		if e.compiled.MatchString(task) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAICLI(script string) bool {
+	for _, e := range loadSinks().AICLI {
+		if e.compiled.MatchString(script) {
+			return true
+		}
+	}
+	return false
+}
+
+func aiVendor(s string) string {
+	l := strings.ToLower(s)
+	switch {
+	case strings.Contains(l, "claude") || strings.Contains(l, "anthropic"):
+		return "anthropic"
+	case strings.Contains(l, "openai") || strings.Contains(l, "gpt") || strings.Contains(l, "azureopenai"):
+		return "azure_openai"
+	case strings.Contains(l, "copilot"):
+		return "github_copilot"
+	case strings.Contains(l, "gemini"):
+		return "google_gemini"
+	case strings.Contains(l, "bedrock"):
+		return "aws_bedrock"
+	}
+	return "custom_llm"
+}
+
+// aiCapabilities infers the AI task/CLI's agentic reach from its script/inputs.
+func aiCapabilities(text string) []any {
+	l := strings.ToLower(text)
+	var caps []any
+	add := func(c string) { caps = append(caps, c) }
+	if strings.Contains(l, "--allow-tool") || strings.Contains(l, "--tool") || strings.Contains(l, "tools") || strings.Contains(l, "agent") {
+		add("tool_exec")
+	}
+	if strings.Contains(l, "system.accesstoken") {
+		add("id_token")
+	}
+	if strings.Contains(l, "curl") || strings.Contains(l, "wget") || strings.Contains(l, "http") || strings.Contains(l, "egress") {
+		add("egress")
+	}
+	if strings.Contains(l, "commit") || strings.Contains(l, "git push") || strings.Contains(l, "git commit") {
+		add("auto_commit")
+	}
+	if strings.Contains(l, "pull request") || strings.Contains(l, "--pr") || strings.Contains(l, "az repos pr") {
+		add("auto_pr")
+	}
+	if caps == nil {
+		caps = []any{}
+	}
+	return caps
+}
+
+var bareBinaries = []string{
+	"git", "az", "kubectl", "python", "python3", "dotnet", "npm", "node",
+	"terraform", "gpg", "docker", "helm", "aws", "gcloud", "make", "bash",
+}
+
+var bareBinaryRes = sync.OnceValue(func() map[string]*regexp.Regexp {
+	m := map[string]*regexp.Regexp{}
+	for _, bin := range bareBinaries {
+		m[bin] = regexp.MustCompile(`(?m)(^|\s|;|&&|\||\()` + regexp.QuoteMeta(bin) + `\s`)
+	}
+	return m
+})
+
+// bareBinaryCalls returns the recognized binaries a script invokes by bare name
+// (not an absolute/relative path) — the cat-13 prependpath-shadow sink surface.
+func bareBinaryCalls(script string) []string {
+	var out []string
+	res := bareBinaryRes()
+	for _, bin := range bareBinaries {
+		if res[bin].MatchString(script) {
+			out = append(out, bin)
+		}
+	}
+	return out
+}
+
+// tasks that authenticate and write a credential file to the agent workspace —
+// the earlier-writes-secret-file precondition for cat-13 artifact exfiltration.
+var credWritingTasks = map[string]string{
+	"Docker@2":             "~/.docker/config.json",
+	"Docker@1":             "~/.docker/config.json",
+	"AzureCLI@2":           "~/.azure",
+	"AzureCLI@1":           "~/.azure",
+	"npmAuthenticate@0":    "~/.npmrc",
+	"Kubernetes@1":         "~/.kube/config",
+	"KubernetesManifest@1": "~/.kube/config",
+}
+
+var reCondVar = regexp.MustCompile(`variables\[\s*'([^']+)'\s*\]|variables\.([A-Za-z0-9_.]+)`)
+
+// conditionVars returns the variable names a step `condition:` reads — the
+// setvariable control-flip consumer surface (cat-13).
+func conditionVars(cond string) []string {
+	var out []string
+	for _, m := range reCondVar.FindAllStringSubmatch(cond, -1) {
+		if m[1] != "" {
+			out = append(out, m[1])
+		} else if m[2] != "" {
+			out = append(out, m[2])
+		}
+	}
+	return out
+}
+
+// untrustedEcho reports whether a script body prints attacker-controlled data to
+// stdout (the cat-13 logging-injection source), and what kind.
+func untrustedEcho(body string) (string, bool) {
+	for _, name := range macroNames(body) {
+		if src, ok := untrustedPredefined[strings.ToLower(name)]; ok {
+			return src, true
+		}
+	}
+	switch {
+	case reCat.MatchString(body):
+		return "file_content", true
+	case reHTTP.MatchString(body):
+		return "http_response", true
+	case reVsoLit.MatchString(body):
+		return "literal_vso", true
+	}
+	return "", false
+}
+
+func echoMechanism(shell string) string {
+	switch shell {
+	case "powershell":
+		return "PowerShell"
+	case "cmd":
+		return "CmdLine"
+	}
+	return "script"
+}
+
+func splitTaskVersion(task string) (id, version string) {
+	if i := strings.LastIndex(task, "@"); i >= 0 {
+		return task[:i], task[i+1:]
+	}
+	return task, ""
+}
+
+func macroSinkRec(name, location, task string, stepIdx int, settable map[string]bool) map[string]any {
+	return map[string]any{
+		"macro_name": name, "location": location, "task_name": task, "step_index": stepIdx,
+		"is_declared_settable": settable[name], "macro_kind": macroKind(name),
+	}
+}
+
+func paramSinkRec(name, location, keyword, task string, stepIdx int) map[string]any {
+	return map[string]any{
+		"param_name": name, "location": location, "keyword": keyword,
+		"task_name": task, "step_index": stepIdx,
+	}
+}
+
+func taskUsageRec(task string, stepIdx int) map[string]any {
+	id, version := splitTaskVersion(task)
+	rec := map[string]any{"task": task, "task_id": id, "version": version, "step_index": stepIdx}
+	switch {
+	case executorTasks[task].shell != "":
+		rec["is_sink"], rec["sink_form"], rec["sink_kind"] = true, "script", "inline_script"
+	case matchesAITask(task):
+		rec["is_sink"], rec["sink_form"], rec["sink_kind"] = true, "ai_agent", "ai_task"
+	default:
+		rec["is_sink"], rec["sink_form"], rec["sink_kind"] = false, "", ""
+	}
+	return rec
+}
+
+func aiTaskRec(task string, inputs map[string]any, stepIdx int) map[string]any {
+	blob := task
+	for _, k := range sortedKeys(inputs) {
+		blob += " " + yamlStr(inputs[k])
+	}
+	return map[string]any{
+		"task_id": task, "vendor": aiVendor(task), "capabilities": aiCapabilities(blob),
+		"inputs": inputs, "source": "task", "step_index": stepIdx,
+	}
+}
+
+func poolExpr(v any) string {
+	switch p := v.(type) {
+	case string:
+		return p
+	case map[string]any:
+		return yamlStr(p["name"]) + " " + yamlStr(p["vmImage"])
+	}
+	return ""
+}
+
+var compileKeywordInputs = func() map[string]bool {
+	m := map[string]bool{}
+	for _, n := range scInputNames {
+		m[n] = true
+	}
+	return m
+}()
+
+func isCompileKeywordInput(name string) bool { return compileKeywordInputs[name] }
+
+// settableVariablesOf extracts a `variables:` block's `settableVariables:`
+// declaration: nil (absent — all overridable), or the restricting name list
+// ([] = none). Only the mapping form carries this key.
+func settableVariablesOf(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	sv, present := m["settableVariables"]
+	if !present {
+		return nil
+	}
+	list, ok := sv.([]any)
+	if !ok {
+		return []any{}
+	}
+	out := make([]any, 0, len(list))
+	for _, e := range list {
+		out = append(out, yamlStr(e))
+	}
+	return out
+}
+
+// settableVarSet is the set of definition variables flagged allowOverride=true —
+// the queue-time-settable surface when the org/project limit is enforced.
+func settableVarSet(vars map[string]any) map[string]bool {
+	out := map[string]bool{}
+	for name, v := range vars {
+		if entBool(entMap(v)["allowOverride"]) {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func mergeSettable(base map[string]bool, extra any) map[string]bool {
+	out := make(map[string]bool, len(base))
+	for k, v := range base {
+		out[k] = v
+	}
+	if list, ok := extra.([]any); ok {
+		for _, e := range list {
+			if s, _ := e.(string); s != "" {
+				out[s] = true
+			}
+		}
+	}
+	return out
+}
+
+func sortedSet(m map[string]bool) []any {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]any, len(keys))
+	for i, k := range keys {
+		out[i] = k
+	}
+	return out
+}

--- a/internal/ado/classify_sink_test.go
+++ b/internal/ado/classify_sink_test.go
@@ -1,0 +1,212 @@
+package ado
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMacroKind(t *testing.T) {
+	cases := map[string]string{
+		"deployTarget":                    "user",
+		"buildConfig":                     "user",
+		"Build.BuildId":                   "system",
+		"Agent.HomeDirectory":             "system",
+		"System.DefaultWorkingDirectory":  "system",
+		"Build.SourceVersionMessage":      "predefined_untrusted",
+		"System.PullRequest.SourceBranch": "predefined_untrusted",
+	}
+	for name, want := range cases {
+		if got := macroKind(name); got != want {
+			t.Errorf("macroKind(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestMacroNames(t *testing.T) {
+	// distinct names; shell command substitution `$(find ...)` (has spaces) is NOT
+	// an ADO macro and must be excluded.
+	got := macroNames(`P=$(find . -name '*.zip'); echo $(deployTarget) $(deployTarget) $(Build.BuildId)`)
+	want := []string{"deployTarget", "Build.BuildId"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("macroNames = %v, want %v", got, want)
+	}
+}
+
+func TestParamNames(t *testing.T) {
+	got := paramNames(`img:${{ parameters.tag }} $[ variables['containerImage'] ] ${{ parameters.tag }}`)
+	want := []string{"tag", "containerImage"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("paramNames = %v, want %v", got, want)
+	}
+}
+
+func TestClassifyExecSink(t *testing.T) {
+	if _, ok := classifyExecSink("npm ci && npm run build"); !ok {
+		t.Error("npm ci should be an exec sink")
+	}
+	if _, ok := classifyExecSink(`echo "hello world"`); ok {
+		t.Error("a bare echo is not an exec sink")
+	}
+}
+
+func TestUntrustedEcho(t *testing.T) {
+	cases := []struct {
+		body, want string
+		ok         bool
+	}{
+		{`echo "commit: $(Build.SourceVersionMessage)"`, "commit_message", true},
+		{`echo "branch: $(Build.SourceBranchName)"`, "branch_name", true},
+		{`cat ./build-info.txt`, "file_content", true},
+		{`curl https://api.example/x`, "http_response", true},
+		{`echo "safe: $(Build.BuildId)"`, "", false},
+	}
+	for _, c := range cases {
+		got, ok := untrustedEcho(c.body)
+		if ok != c.ok || got != c.want {
+			t.Errorf("untrustedEcho(%q) = (%q,%v), want (%q,%v)", c.body, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestMatchesAI(t *testing.T) {
+	if !matchesAITask("VendorAIReview@2") {
+		t.Error("VendorAIReview@2 should match an AI task")
+	}
+	if matchesAITask("CmdLine@2") {
+		t.Error("CmdLine@2 is not an AI task")
+	}
+	if !matchesAICLI(`claude -p "summarize $BODY" --allow-tool bash`) {
+		t.Error("claude CLI should match ai_cli")
+	}
+	if matchesAICLI("make build") {
+		t.Error("make is not an AI CLI")
+	}
+}
+
+func TestBareBinaryCalls(t *testing.T) {
+	got := bareBinaryCalls("kubectl apply -f ./k8s/\naz account show")
+	want := []string{"az", "kubectl"}
+	// order follows the bareBinaries registry
+	if len(got) != 2 || !contains(got, "kubectl") || !contains(got, "az") {
+		t.Errorf("bareBinaryCalls = %v, want %v (any order)", got, want)
+	}
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// walkSteps mirrors the shape yaml.Unmarshal produces (map[string]any/[]any).
+
+// cat-13 setvariable control-flip (firing-range Bree/296): a banner step echoes
+// the untrusted commit message; a later step's condition consumes the variable.
+func TestWalkSteps_LoggingControlFlip(t *testing.T) {
+	steps := []any{
+		map[string]any{"checkout": "self"},
+		map[string]any{"script": `echo "Building commit: $(Build.SourceVersionMessage)"`},
+		map[string]any{"script": "./deploy.sh", "condition": "eq(variables.deployToProd, 'true')"},
+	}
+	f := walkSteps(steps, nil)
+
+	if len(f.vsoEchoSources) != 1 {
+		t.Fatalf("want 1 vso echo source, got %d", len(f.vsoEchoSources))
+	}
+	echo := f.vsoEchoSources[0].(map[string]any)
+	if echo["untrusted_source"] != "commit_message" || echo["step_index"] != 1 {
+		t.Errorf("echo = %v, want commit_message@1", echo)
+	}
+	if !hasConsumer(f.varConsumers, "deployToProd", 2, "condition") {
+		t.Errorf("want deployToProd condition consumer @2, got %v", f.varConsumers)
+	}
+}
+
+// cat-02 unrestricted macro into a script sink (firing-range Rohan/197).
+func TestWalkSteps_MacroScriptSink(t *testing.T) {
+	steps := []any{
+		map[string]any{"script": "echo $(deployTarget)\n./deploy.sh --env $(deployTarget)"},
+	}
+	f := walkSteps(steps, map[string]bool{"deployTarget": true})
+	if len(f.macroSinks) != 1 { // deduped within the body
+		t.Fatalf("want 1 macro sink, got %d: %v", len(f.macroSinks), f.macroSinks)
+	}
+	ms := f.macroSinks[0].(map[string]any)
+	if ms["macro_name"] != "deployTarget" || ms["location"] != "script" ||
+		ms["macro_kind"] != "user" || ms["is_declared_settable"] != true {
+		t.Errorf("macro sink = %v", ms)
+	}
+}
+
+// cat-02 settable var into task arguments (firing-range Rohan/198): a macro in a
+// Bash@3 `arguments` input is a macro_in_task_input sink; a system var is not.
+func TestWalkSteps_ArgumentsSink(t *testing.T) {
+	steps := []any{
+		map[string]any{"task": "Bash@3", "inputs": map[string]any{
+			"targetType": "filePath", "filePath": "build/run.sh", "arguments": "--config $(buildConfig)",
+		}},
+	}
+	f := walkSteps(steps, nil)
+	if len(f.macroSinks) != 1 {
+		t.Fatalf("want 1 macro sink, got %d", len(f.macroSinks))
+	}
+	ms := f.macroSinks[0].(map[string]any)
+	if ms["location"] != "task_input" || ms["macro_name"] != "buildConfig" || ms["task_name"] != "Bash@3" {
+		t.Errorf("arguments sink = %v", ms)
+	}
+}
+
+// cat-02 freeform parameter into a compile-time keyword (firing-range Rohan/201).
+func TestWalkSteps_ParamCompileKeyword(t *testing.T) {
+	steps := []any{
+		map[string]any{"task": "AzureCLI@2", "inputs": map[string]any{
+			"azureSubscription": "${{ parameters.connection }}", "scriptType": "bash",
+			"scriptLocation": "inlineScript", "inlineScript": "az account show",
+		}},
+	}
+	f := walkSteps(steps, nil)
+	if !hasParamSink(f.paramSinks, "connection", "compile_keyword", "azureSubscription") {
+		t.Errorf("want connection compile_keyword sink on azureSubscription, got %v", f.paramSinks)
+	}
+}
+
+func hasConsumer(list []any, name string, step int, via string) bool {
+	for _, e := range list {
+		m := e.(map[string]any)
+		if m["name"] == name && m["step_index"] == step && m["via"] == via {
+			return true
+		}
+	}
+	return false
+}
+
+func hasParamSink(list []any, name, loc, keyword string) bool {
+	for _, e := range list {
+		m := e.(map[string]any)
+		if m["param_name"] == name && m["location"] == loc && m["keyword"] == keyword {
+			return true
+		}
+	}
+	return false
+}
+
+// collectSteps must gather steps from every deployment lifecycle hook, not just
+// deploy — preDeploy/postRouteTraffic/on.failure steps carry real task facts.
+func TestCollectSteps_DeploymentHooks(t *testing.T) {
+	m := map[string]any{"strategy": map[string]any{"runOnce": map[string]any{
+		"preDeploy":        map[string]any{"steps": []any{map[string]any{"script": "echo pre"}}},
+		"deploy":           map[string]any{"steps": []any{map[string]any{"script": "echo deploy"}}},
+		"routeTraffic":     map[string]any{"steps": []any{map[string]any{"script": "echo route"}}},
+		"postRouteTraffic": map[string]any{"steps": []any{map[string]any{"script": "echo post"}}},
+		"on": map[string]any{
+			"failure": map[string]any{"steps": []any{map[string]any{"script": "echo fail"}}},
+			"success": map[string]any{"steps": []any{map[string]any{"script": "echo ok"}}},
+		},
+	}}}
+	if got := len(collectSteps(m)); got != 6 {
+		t.Errorf("collectSteps gathered %d hook steps, want 6", got)
+	}
+}

--- a/internal/ado/collect.go
+++ b/internal/ado/collect.go
@@ -125,8 +125,26 @@ func collectOneProject(ctx context.Context, cl ADO, cp engine.CurrentPhase, scop
 			return e
 		})
 	}
-	collectList("service-connections", "core", APIVersionSEP, "/"+pe+"/_apis/serviceendpoint/endpoints",
-		engine.CollectADOServiceConnections(project), "service-connections", "endpoint")
+	// includeSharedServiceEndpoints surfaces connections shared INTO this project
+	// (not just owned), so each consuming project's per-connection authorization
+	// and checks get collected — normalize dedups the shared node.
+	softSurface(timer, lbl("service-connections"), func() error {
+		items, status, e := softList(ctx, cl, "core", APIVersionSEP, "/"+pe+"/_apis/serviceendpoint/endpoints",
+			url.Values{"includeSharedServiceEndpoints": []string{"true"}})
+		if e != nil {
+			return e
+		}
+		if e := writeListOrMark(cp, engine.CollectADOServiceConnections(project), "service-connections",
+			"/"+pe+"/_apis/serviceendpoint/endpoints", items, status); e != nil {
+			return e
+		}
+		for _, raw := range items {
+			if id := strField(raw, "id"); id != "" {
+				resources = append(resources, resourceRef{Type: "endpoint", ID: id, Name: strField(raw, "name")})
+			}
+		}
+		return nil
+	})
 	collectList("variable-groups", "core", APIVersion, "/"+pe+"/_apis/distributedtask/variablegroups",
 		engine.CollectADOVariableGroups(project), "variable-groups", "variablegroup")
 	collectList("secure-files", "core", APIVersion, "/"+pe+"/_apis/distributedtask/securefiles",

--- a/internal/ado/correlate.go
+++ b/internal/ado/correlate.go
@@ -1,0 +1,796 @@
+package ado
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// hashKey produces a bounded, collision-safe filename stem for edges whose
+// natural key (ACL token + identity descriptor) can exceed the 255-byte path
+// limit. The readable components stay as fields on the record.
+func hashKey(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(h[:16])
+}
+
+// correlate reads the normalized corpus back as generic maps and derives the
+// structural edges plus the three settings-resolution joins. Derived/attack
+// (taint) edges are a later pass.
+func correlate(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	pipelines, err := loadRecords(prior, "10-normalize/pipelines")
+	if err != nil {
+		return fmt.Errorf("correlate: load pipelines: %w", err)
+	}
+	repos, err := loadRecords(prior, "10-normalize/repos")
+	if err != nil {
+		return fmt.Errorf("correlate: load repos: %w", err)
+	}
+	projectsRec, err := loadRecords(prior, "10-normalize/projects")
+	if err != nil {
+		return fmt.Errorf("correlate: load projects: %w", err)
+	}
+	policies, err := loadRecords(prior, "10-normalize/policies")
+	if err != nil {
+		return fmt.Errorf("correlate: load policies: %w", err)
+	}
+	jobs, err := loadRecords(prior, "10-normalize/jobs")
+	if err != nil {
+		return fmt.Errorf("correlate: load jobs: %w", err)
+	}
+
+	for _, step := range []func() error{
+		func() error { return deriveRunsAs(cp, timer, pipelines, projectsRec) },
+		func() error { return derivePolicyAttribution(cp, timer, policies, repos) },
+		func() error { return deriveBranches(cp, timer, pipelines, policies, repos) },
+		func() error { return deriveEffectiveRoles(ctx, prior, cp, timer, org) },
+		func() error { return deriveMemberOf(prior, cp, timer, org) },
+		func() error { return deriveJobResourceEdges(prior, cp, timer, jobs) },
+	} {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := step(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// clampScope resolves the job-auth scope: effective = "project" when the project
+// enforces (or enforcement is unobserved — fail closed), else the requested scope.
+// Shared by the :Pipeline node (identity_scope) and the RUNS_AS edge.
+func clampScope(requested string, enforced, observed bool) (effective, identityScope, provenance string) {
+	effective = requested
+	if enforced || !observed {
+		effective = "project"
+	}
+	identityScope = "project"
+	if effective == "projectCollection" {
+		identityScope = "collection"
+	}
+	provenance = "observed"
+	if !observed {
+		provenance = "unknown"
+	}
+	return
+}
+
+// deriveRunsAs — JOIN #1: 3-level job-auth clamp. effective = "project" if the
+// project (or org, unknown) enforces enforceJobAuthScope, else the pipeline's
+// requested scope. Emits a runs-as edge per pipeline.
+func deriveRunsAs(cp engine.CurrentPhase, timer *engine.PhaseTimer, pipelines, projectsRec []map[string]any) error {
+	type enf struct{ enforced, observed bool }
+	enforceByProject := map[string]enf{}
+	for _, p := range projectsRec {
+		enforceByProject[mStr(p, "project")] = enf{mBool(p, "limit_job_auth_scope_to_current_project"), mBool(p, "settings_observed")}
+	}
+	for _, pl := range pipelines {
+		project := mStr(pl, "project")
+		requested := mStr(pl, "job_authorization_scope") // "project" | "projectCollection"
+		e := enforceByProject[project]
+		effective, scope, provenance := clampScope(requested, e.enforced, e.observed)
+		rec := map[string]any{
+			"kind":                "RUNS_AS",
+			"pipeline_id":         mInt64(pl, "id"),
+			"project":             project,
+			"requested_scope":     requested,
+			"effective_scope":     effective,
+			"identity_scope":      scope,
+			"enforced_by_project": e.enforced,
+			"enforce_provenance":  provenance,
+			"org_provenance":      "unknown",
+		}
+		key := fmt.Sprintf("%s__%d", project, mInt64(pl, "id"))
+		if err := emit(cp, timer, engine.NormalizeADOEdges("runs-as", key), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// derivePolicyAttribution — JOIN #2: attach each BranchPolicy to repos by scope
+// (repositoryId, null=all in project); materialize the branch from refName; emit
+// BUILD_VALIDATES for build-validation policies.
+func derivePolicyAttribution(cp engine.CurrentPhase, timer *engine.PhaseTimer, policies, repos []map[string]any) error {
+	reposByProject := map[string][]map[string]any{}
+	for _, r := range repos {
+		proj := mStr(r, "project")
+		reposByProject[proj] = append(reposByProject[proj], r)
+	}
+	for _, pol := range policies {
+		project := mStr(pol, "project")
+		for _, sc := range mList(pol, "scope") {
+			scope := entMap(sc)
+			repoID := entStr(scope["repositoryId"]) // "" => project-wide
+			refName := entStr(scope["refName"])
+			targets := reposByProject[project]
+			if repoID != "" {
+				targets = filterReposByID(targets, repoID)
+			}
+			for _, r := range targets {
+				matchKind := entStr(scope["matchKind"])
+				branch := stripRef(refName)
+				branchID := project + "/" + mStr(r, "name") + "@" + branch
+				rec := map[string]any{
+					"kind":    "HAS_POLICY",
+					"project": project,
+					"repo":    mStr(r, "name"),
+					// stripped to match the :Branch node/DEFINED_BY join key.
+					"branch":    branch,
+					"branch_id": branchID,
+					// Prefix => refName is a subtree prefix (protects the whole
+					// subtree), not a concrete branch — load-bearing for attribution.
+					"match_kind":   matchKind,
+					"is_prefix":    matchKind == "Prefix",
+					"policy_type":  mStr(pol, "policy_type"),
+					"config_id":    mInt64(pol, "config_id"),
+					"is_blocking":  mBool(pol, "is_blocking"),
+					"is_enabled":   mBool(pol, "is_enabled"),
+					"project_wide": repoID == "",
+				}
+				// A single config can carry multiple scope[] entries on the same
+				// repo+ref differing only by matchKind, or a project-wide (null repo)
+				// scope alongside a repo-specific one — key on both so neither is lost.
+				scopeDisc := repoID
+				if scopeDisc == "" {
+					scopeDisc = "all"
+				}
+				key := fmt.Sprintf("%s__%s__%d__%s__%s__%s", adoSafe(project), adoSafe(mStr(r, "name")), mInt64(pol, "config_id"), adoSafe(refName), adoSafe(matchKind), adoSafe(scopeDisc))
+				if err := emit(cp, timer, engine.NormalizeADOEdges("has-policy", key), rec); err != nil {
+					return err
+				}
+				if bdID := mInt64(mMap(pol, "settings"), "buildDefinitionId"); bdID != 0 {
+					bv := map[string]any{
+						"kind":                "BUILD_VALIDATES",
+						"project":             project,
+						"repo":                mStr(r, "name"),
+						"branch":              branch,
+						"branch_id":           branchID,
+						"config_id":           mInt64(pol, "config_id"),
+						"build_definition_id": bdID,
+						"is_blocking":         mBool(pol, "is_blocking"),
+					}
+					if err := emit(cp, timer, engine.NormalizeADOEdges("build-validates", key), bv); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func filterReposByID(repos []map[string]any, id string) []map[string]any {
+	var out []map[string]any
+	for _, r := range repos {
+		if mStr(r, "id") == id {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// deriveEffectiveRoles — JOIN #3: decode each ACL's effectiveAllow bitmask into
+// action names (per its security namespace) and expand group descriptors to
+// leaf members via graph memberships. Emits a HAS_ROLE edge per ACE.
+func deriveEffectiveRoles(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer, org string) error {
+	nsActions := loadNamespaceActions(prior, org)
+	memberships := loadMemberships(prior, org)
+	idIndex := aceIdentityIndex(prior, org)
+	repoIdx, scIdx, projIdx, err := roleTokenIndexes(prior)
+	if err != nil {
+		return err
+	}
+
+	sources := []struct {
+		dir string
+		ns  string
+	}{
+		{"00-collect/acl-repo", gitNS},
+		{"00-collect/acl-build", buildNS},
+		{"00-collect/acl-endpoint", endpointNS},
+	}
+	for _, src := range sources {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		files, err := prior.IterJSON(src.dir)
+		if err != nil {
+			return fmt.Errorf("correlate: load %s: %w", src.dir, err)
+		}
+		actions := nsActions[src.ns]
+		for _, f := range files {
+			data := entDataOf(f.Data)
+			for _, raw := range entListOrEmpty(data["value"]) {
+				acl := entMap(raw)
+				token := entStr(acl["token"])
+				for desc, aceRaw := range entObj(acl, "acesDictionary") {
+					ace := entMap(aceRaw)
+					eff := effectiveAllowMask(ace)
+					// ACL descriptors are legacy identity descriptors; bridge to the
+					// graph subject descriptor so the principal node + members resolve.
+					graphDesc := aceGraphDescriptor(desc, idIndex)
+					resKind, resID := resolveRoleToken(token, repoIdx, scIdx, projIdx)
+					rec := map[string]any{
+						"kind":              "HAS_ROLE",
+						"descriptor":        desc,
+						"graph_descriptor":  graphDesc,
+						"token":             token,
+						"namespace":         src.ns,
+						"resource_kind":     resKind,
+						"resource_id":       resID,
+						"resource_resolved": resID != "",
+						"allowed_actions":   decodeActions(eff, actions),
+						"effective_allow":   eff,
+						"expanded_members":  expandMembers(graphDesc, memberships),
+					}
+					key := hashKey(src.ns, token, desc)
+					if err := emit(cp, timer, engine.NormalizeADOEdges("has-role", key), rec); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// roleTokenIndexes builds the lookups that resolve a HAS_ROLE ACL token to the
+// node it grants on: repos by GUID, service connections by id, projects by GUID.
+func roleTokenIndexes(prior engine.PriorPhase) (repoIdx, scIdx, projIdx map[string]string, err error) {
+	repoIdx, scIdx, projIdx = map[string]string{}, map[string]string{}, map[string]string{}
+	repos, err := loadRecords(prior, "10-normalize/repos")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("correlate: load repos: %w", err)
+	}
+	for _, r := range repos {
+		repoIdx[mStr(r, "id")] = mStr(r, "_id")
+	}
+	scs, err := loadRecords(prior, "10-normalize/service-connections")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("correlate: load service-connections: %w", err)
+	}
+	for _, s := range scs {
+		scIdx[mStr(s, "id")] = mStr(s, "_id")
+	}
+	projs, err := loadRecords(prior, "10-normalize/projects")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("correlate: load projects: %w", err)
+	}
+	for _, p := range projs {
+		projIdx[mStr(p, "id")] = mStr(p, "_id")
+	}
+	return repoIdx, scIdx, projIdx, nil
+}
+
+// resolveRoleToken maps a security-namespace ACL token to the emitted node _id it
+// scopes: "repoV2/<projGuid>/<repoGuid>" -> Repository, "endpoints/<projGuid>/<id>"
+// -> ServiceConnection, a bare "<projGuid>" -> Project. Unresolvable (collection
+// root, deleted resource) returns "".
+func resolveRoleToken(token string, repoIdx, scIdx, projIdx map[string]string) (kind, nodeID string) {
+	parts := strings.Split(token, "/")
+	switch {
+	case len(parts) >= 3 && parts[0] == "repoV2":
+		return "Repository", repoIdx[parts[2]]
+	case len(parts) >= 3 && parts[0] == "endpoints":
+		return "ServiceConnection", scIdx[parts[2]]
+	case len(parts) == 1 && parts[0] != "":
+		if id := projIdx[parts[0]]; id != "" {
+			return "Project", id
+		}
+	}
+	return "", ""
+}
+
+// effectiveAllowMask selects an ACE's effective permission bits. Only fall back
+// to the local allow when effectiveAllow is ABSENT — a present effectiveAllow of
+// 0 is a real deny, not an unknown.
+func effectiveAllowMask(ace map[string]any) int64 {
+	if e := entGetIn(ace, "extendedInfo", "effectiveAllow"); e != nil {
+		return entInt64(e)
+	}
+	return entInt64(ace["allow"])
+}
+
+// aceIdentityIndex maps an ACL ACE identity (the token after ";") to the graph
+// subject descriptor that carries it, for both forms that resolve to an emitted
+// principal node:
+//   - group SIDs (S-1-…), base64-encoded in the vssgp./aadgp. group descriptor;
+//   - service identities (<org>:Build:<guid>), base64-encoded in the svc. user
+//     descriptor a Microsoft.TeamFoundation.ServiceIdentity ACE references.
+//
+// Built-in server SIDs the Graph API does not enumerate resolve to "" and stay
+// unexpanded (the raw descriptor is still kept on the HAS_ROLE record).
+func aceIdentityIndex(prior engine.PriorPhase, org string) map[string]string {
+	graph := entLoadData(prior, engine.CollectADOGraph(org))
+	idx := map[string]string{}
+	for _, raw := range entListOrEmpty(graph["groups"]) {
+		desc := entStr(entMap(raw)["descriptor"])
+		if sid := decodeGraphSID(desc); sid != "" {
+			idx[sid] = desc
+		}
+	}
+	for _, raw := range entListOrEmpty(graph["users"]) {
+		u := entMap(raw)
+		desc := entStr(u["descriptor"])
+		if desc == "" {
+			continue
+		}
+		if inner := decodeSubjectDescriptor(desc); inner != "" {
+			idx[inner] = desc
+		}
+		// A direct AAD-user ACE is a ClaimsIdentity keyed by UPN/mail, not a SID —
+		// index those (lowercased) so the user's HAS_ROLE resolves to its node.
+		for _, k := range []string{entStr(u["principalName"]), entStr(u["mailAddress"]), entStr(u["domain"]) + "\\" + entStr(u["principalName"])} {
+			if k != "" && k != "\\" {
+				idx[strings.ToLower(k)] = desc
+			}
+		}
+	}
+	return idx
+}
+
+func decodeGraphSID(desc string) string {
+	for _, p := range []string{"vssgp.", "aadgp."} {
+		if !strings.HasPrefix(desc, p) {
+			continue
+		}
+		b := desc[len(p):]
+		for _, enc := range []*base64.Encoding{base64.RawStdEncoding, base64.RawURLEncoding} {
+			if dec, err := enc.DecodeString(b); err == nil {
+				if s := string(dec); strings.HasPrefix(s, "S-1-") {
+					return s
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// decodeSubjectDescriptor returns the identity string a graph user descriptor
+// (<prefix>.<base64>) encodes — a svc. build-service descriptor decodes to
+// "<org>:Build:<guid>", exactly the id a ServiceIdentity ACE references.
+func decodeSubjectDescriptor(desc string) string {
+	i := strings.IndexByte(desc, '.')
+	if i < 0 {
+		return ""
+	}
+	b := desc[i+1:]
+	for _, enc := range []*base64.Encoding{base64.RawURLEncoding, base64.RawStdEncoding} {
+		if dec, err := enc.DecodeString(b); err == nil {
+			return string(dec)
+		}
+	}
+	return ""
+}
+
+// aceGraphDescriptor translates an ACL ACE identity descriptor to the graph
+// descriptor of the principal it names (group SID or service identity), or ""
+// when the identity is not present in the collected graph.
+func aceGraphDescriptor(aceDesc string, idIndex map[string]string) string {
+	i := strings.Index(aceDesc, ";")
+	if i < 0 {
+		return ""
+	}
+	id := aceDesc[i+1:]
+	if d, ok := idIndex[id]; ok { // exact: SID or <org>:Build:<guid>
+		return d
+	}
+	return idIndex[strings.ToLower(id)] // case-insensitive: ClaimsIdentity UPN/mail
+}
+
+func loadNamespaceActions(prior engine.PriorPhase, org string) map[string]map[int64]string {
+	out := map[string]map[int64]string{}
+	for _, raw := range entLoadList(prior, engine.CollectADOSecurityNS(org)) {
+		ns := entMap(raw)
+		id := entStr(ns["namespaceId"])
+		if id == "" {
+			continue
+		}
+		bits := map[int64]string{}
+		for _, a := range entListOrEmpty(ns["actions"]) {
+			am := entMap(a)
+			bits[entInt64(am["bit"])] = entStr(am["name"])
+		}
+		out[id] = bits
+	}
+	return out
+}
+
+func decodeActions(mask int64, actions map[int64]string) []any {
+	var names []string
+	for bit, name := range actions {
+		if mask&bit != 0 {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names) // deterministic output (map iteration is randomized)
+	out := make([]any, len(names))
+	for i, n := range names {
+		out[i] = n
+	}
+	return out
+}
+
+func loadMemberships(prior engine.PriorPhase, org string) map[string][]string {
+	graph := entLoadData(prior, engine.CollectADOGraph(org))
+	out := map[string][]string{}
+	for container, raw := range entObj(graph, "memberships") {
+		for _, m := range entListOrEmpty(raw) {
+			if md := entStr(entMap(m)["memberDescriptor"]); md != "" {
+				out[container] = append(out[container], md)
+			}
+		}
+	}
+	return out
+}
+
+// expandMembers walks memberships (direction=down) to the leaf descriptors under
+// a group, with cycle detection. A non-group (leaf) descriptor returns itself.
+func expandMembers(desc string, memberships map[string][]string) []any {
+	seen := map[string]bool{}
+	var leaves []string
+	var walk func(d string)
+	walk = func(d string) {
+		if seen[d] {
+			return
+		}
+		seen[d] = true
+		children, ok := memberships[d]
+		if !ok || len(children) == 0 {
+			if d != desc {
+				leaves = append(leaves, d)
+			}
+			return
+		}
+		for _, c := range children {
+			walk(c)
+		}
+	}
+	walk(desc)
+	slices.Sort(leaves) // deterministic output
+	out := make([]any, len(leaves))
+	for i, l := range leaves {
+		out[i] = l
+	}
+	return out
+}
+
+// deriveJobResourceEdges resolves the job-level YAML references (variable-group
+// names, service-connection names) to their concrete resource ids.
+func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer, jobs []map[string]any) error {
+	type vgRef struct {
+		id    int64
+		owner string
+	}
+	type scRef struct{ id, owner string }
+	vgByProjectName := map[string]map[string]vgRef{}
+	scByProjectName := map[string]map[string]scRef{}
+	vgs, err := loadRecords(prior, "10-normalize/variable-groups")
+	if err != nil {
+		return fmt.Errorf("correlate: load variable-groups: %w", err)
+	}
+	// A shared resource is visible (and referable by name) in every project it is
+	// shared into, so register its name under all of them, resolving to the single
+	// canonical (owner-keyed) node — carrying owner_project so the edge binds to
+	// the node _id "owner/id" rather than the consuming project.
+	for _, g := range vgs {
+		for _, proj := range visibleProjects(g) {
+			if vgByProjectName[proj] == nil {
+				vgByProjectName[proj] = map[string]vgRef{}
+			}
+			vgByProjectName[proj][mStr(g, "name")] = vgRef{mInt64(g, "id"), mStr(g, "owner_project")}
+		}
+	}
+	scs, err := loadRecords(prior, "10-normalize/service-connections")
+	if err != nil {
+		return fmt.Errorf("correlate: load service-connections: %w", err)
+	}
+	for _, s := range scs {
+		for _, proj := range visibleProjects(s) {
+			if scByProjectName[proj] == nil {
+				scByProjectName[proj] = map[string]scRef{}
+			}
+			scByProjectName[proj][mStr(s, "name")] = scRef{mStr(s, "id"), mStr(s, "owner_project")}
+		}
+	}
+	envByProjectName := map[string]map[string]int64{}
+	envs, err := loadRecords(prior, "10-normalize/environments")
+	if err != nil {
+		return fmt.Errorf("correlate: load environments: %w", err)
+	}
+	for _, e := range envs {
+		proj := mStr(e, "project")
+		if envByProjectName[proj] == nil {
+			envByProjectName[proj] = map[string]int64{}
+		}
+		envByProjectName[proj][mStr(e, "name")] = mInt64(e, "id")
+	}
+	poolByProjectName := map[string]map[string]int64{}
+	pools, err := loadRecords(prior, "10-normalize/project-agent-pools")
+	if err != nil {
+		return fmt.Errorf("correlate: load project-agent-pools: %w", err)
+	}
+	for _, p := range pools {
+		proj := mStr(p, "project")
+		if poolByProjectName[proj] == nil {
+			poolByProjectName[proj] = map[string]int64{}
+		}
+		poolByProjectName[proj][mStr(p, "name")] = mInt64(p, "id")
+	}
+
+	// CONSUMES_GROUP is emitted at the level a group is DECLARED (schema: a
+	// pipeline-level group reaches every job; a stage-level group every job in the
+	// stage). The Pipeline/Stage/Job nodes each carry only their own declarations.
+	emitConsumesGroup := func(level, project string, pipelineID int64, stage, job, name string) error {
+		ref := vgByProjectName[project][name]
+		rec := map[string]any{
+			"kind": "CONSUMES_GROUP", "project": project, "pipeline_id": pipelineID,
+			"level": level, "stage": stage, "job": job, "group_name": name,
+			"variable_group_id": ref.id, "owner_project": ref.owner, "resolved": ref.id != 0,
+		}
+		key := fmt.Sprintf("%s__%d__%s__%s__%s__%s", adoSafe(project), pipelineID, level, adoSafe(stage), adoSafe(job), adoSafe(name))
+		return emit(cp, timer, engine.NormalizeADOEdges("consumes-group", key), rec)
+	}
+	pipelineRecs, err := loadRecords(prior, "10-normalize/pipelines")
+	if err != nil {
+		return fmt.Errorf("correlate: load pipelines: %w", err)
+	}
+	for _, pl := range pipelineRecs {
+		for _, g := range mList(pl, "variable_groups") {
+			if name, _ := g.(string); name != "" {
+				if err := emitConsumesGroup("pipeline", mStr(pl, "project"), mInt64(pl, "id"), "", "", name); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	stageRecs, err := loadRecords(prior, "10-normalize/stages")
+	if err != nil {
+		return fmt.Errorf("correlate: load stages: %w", err)
+	}
+	for _, st := range stageRecs {
+		for _, g := range mList(st, "variable_groups") {
+			if name, _ := g.(string); name != "" {
+				if err := emitConsumesGroup("stage", mStr(st, "project"), mInt64(st, "pipeline_id"), mStr(st, "stage"), "", name); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	for _, j := range jobs {
+		project := mStr(j, "project")
+		jobKey := fmt.Sprintf("%s__%d__%s__%s", adoSafe(project), mInt64(j, "pipeline_id"), adoSafe(mStr(j, "stage")), adoSafe(mStr(j, "job")))
+		for _, g := range mList(j, "variable_groups") {
+			if name, _ := g.(string); name != "" {
+				if err := emitConsumesGroup("job", project, mInt64(j, "pipeline_id"), mStr(j, "stage"), mStr(j, "job"), name); err != nil {
+					return err
+				}
+			}
+		}
+		for _, u := range mList(j, "service_connection_usages") {
+			um := entMap(u)
+			name := entStr(um["connection_name"])
+			ref := scByProjectName[project][name]
+			rec := map[string]any{
+				"kind":                  "USES_CONNECTION",
+				"project":               project,
+				"pipeline_id":           mInt64(j, "pipeline_id"),
+				"job":                   mStr(j, "job"),
+				"connection_name":       name,
+				"service_connection_id": ref.id,
+				"owner_project":         ref.owner,
+				"task":                  entStr(um["task"]),
+				"input_name":            entStr(um["input_name"]),
+				"resolved":              ref.id != "",
+			}
+			if err := emit(cp, timer, engine.NormalizeADOEdges("uses-connection", jobKey+"__"+adoSafe(name)), rec); err != nil {
+				return err
+			}
+		}
+		if env := mStr(j, "targets_environment"); env != "" {
+			// A deployment target may be resource-scoped ("env.resource"): prefer an
+			// exact environment match, else split on the first "." and resolve the
+			// environment prefix, keeping the resource separately.
+			envName, resource := env, ""
+			envID := envByProjectName[project][env]
+			if envID == 0 {
+				if n, r, ok := strings.Cut(env, "."); ok {
+					if id := envByProjectName[project][n]; id != 0 {
+						envName, resource, envID = n, r, id
+					}
+				}
+			}
+			rec := map[string]any{
+				"kind": "TARGETS", "project": project, "pipeline_id": mInt64(j, "pipeline_id"),
+				"job": mStr(j, "job"), "environment": envName, "resource": strOrNull(resource),
+				"environment_ref": env, "environment_id": envID, "resolved": envID != 0,
+			}
+			if err := emit(cp, timer, engine.NormalizeADOEdges("targets", jobKey+"__"+adoSafe(env)), rec); err != nil {
+				return err
+			}
+		}
+		if pool := mMap(j, "pool"); poolRef(pool) != "" {
+			name := mStr(pool, "name")
+			vmImage := mStr(pool, "vm_image")
+			poolID := poolByProjectName[project][name]
+			rec := map[string]any{
+				"kind": "RUNS_ON", "project": project, "pipeline_id": mInt64(j, "pipeline_id"),
+				"job": mStr(j, "job"), "pool_name": name, "vm_image": vmImage,
+				"demands": listOrEmpty(pool, "demands"),
+				// vmImage with no named pool is a Microsoft-hosted image (no node).
+				"is_hosted":             name == "" && vmImage != "",
+				"project_agent_pool_id": poolID,
+				"resolved":              poolID != 0,
+			}
+			if err := emit(cp, timer, engine.NormalizeADOEdges("runs-on", jobKey), rec); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// deriveBranches materializes :Branch nodes and DEFINED_BY edges. A branch is
+// referenced two ways: as a YAML pipeline's entry point (Pipeline -> Branch,
+// carrying the yaml_path) and as a branch-policy scope's protected ref. Nodes are
+// deduped by id; the pipeline pass runs first so a branch that is a repo default
+// keeps is_default=true.
+func deriveBranches(cp engine.CurrentPhase, timer *engine.PhaseTimer, pipelines, policies, repos []map[string]any) error {
+	branches := map[string]map[string]any{}
+	add := func(project, repo, repoID, branch string, isDefault, isPrefix bool) {
+		id := project + "/" + repo + "@" + branch
+		if _, ok := branches[id]; ok {
+			return
+		}
+		branches[id] = map[string]any{
+			"_id": id, "kind": "Branch", "project": project, "repo": repo,
+			"repo_id": repoID, "name": branch, "is_default": isDefault, "is_prefix": isPrefix,
+		}
+	}
+
+	for _, pl := range pipelines {
+		if mStr(pl, "settings_source_type") != "yaml" {
+			continue
+		}
+		repo := mMap(pl, "repository")
+		if !strings.EqualFold(mStr(repo, "type"), "TfsGit") {
+			continue
+		}
+		repoName := mStr(repo, "name")
+		if repoName == "" {
+			continue
+		}
+		project := mStr(pl, "project")
+		branch := stripRef(mStr(repo, "default_branch"))
+		if branch == "" {
+			branch = "main"
+		}
+		add(project, repoName, mStr(repo, "id"), branch, true, false)
+		edge := map[string]any{
+			"kind": "DEFINED_BY", "project": project, "pipeline_id": mInt64(pl, "id"),
+			"repo": repoName, "branch": branch, "yaml_path": mStr(pl, "yaml_path"),
+			"branch_id": project + "/" + repoName + "@" + branch,
+		}
+		if err := emit(cp, timer, engine.NormalizeADOEdges("defined-by", fmt.Sprintf("%s__%d", adoSafe(project), mInt64(pl, "id"))), edge); err != nil {
+			return err
+		}
+	}
+
+	reposByProject := map[string][]map[string]any{}
+	for _, r := range repos {
+		reposByProject[mStr(r, "project")] = append(reposByProject[mStr(r, "project")], r)
+	}
+	for _, pol := range policies {
+		project := mStr(pol, "project")
+		for _, sc := range mList(pol, "scope") {
+			scope := entMap(sc)
+			ref := stripRef(entStr(scope["refName"]))
+			if ref == "" {
+				continue
+			}
+			repoID := entStr(scope["repositoryId"])
+			isPrefix := entStr(scope["matchKind"]) == "Prefix"
+			targets := reposByProject[project]
+			if repoID != "" {
+				targets = filterReposByID(targets, repoID)
+			}
+			for _, r := range targets {
+				add(project, mStr(r, "name"), mStr(r, "id"), ref, ref == stripRef(mStr(r, "default_branch")), isPrefix)
+			}
+		}
+	}
+
+	ids := make([]string, 0, len(branches))
+	for id := range branches {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	for _, id := range ids {
+		b := branches[id]
+		if err := emit(cp, timer, engine.NormalizeADOBranch(mStr(b, "project"), mStr(b, "repo"), mStr(b, "name")), b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// visibleProjects lists every project a (possibly shared) resource can be
+// referenced from: its owner plus everyone it is shared into.
+func visibleProjects(rec map[string]any) []string {
+	set := map[string]bool{}
+	if o := mStr(rec, "owner_project"); o != "" {
+		set[o] = true
+	}
+	for _, p := range mList(rec, "shared_into") {
+		if s, ok := p.(string); ok {
+			set[s] = true
+		}
+	}
+	for _, p := range mList(rec, "visible_in_projects") {
+		if s, ok := p.(string); ok {
+			set[s] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	return out
+}
+
+func poolRef(pool map[string]any) string {
+	if n := mStr(pool, "name"); n != "" {
+		return n
+	}
+	return mStr(pool, "vm_image")
+}
+
+func listOrEmpty(m map[string]any, key string) []any {
+	if v, ok := mGet(m, key).([]any); ok {
+		return v
+	}
+	return []any{}
+}
+
+// deriveMemberOf emits a MEMBER_OF edge per direct group membership (graph
+// memberships, direction=down), so nested-group traversal has explicit edges.
+func deriveMemberOf(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer, org string) error {
+	for group, members := range loadMemberships(prior, org) {
+		for _, member := range members {
+			rec := map[string]any{"kind": "MEMBER_OF", "member": member, "group": group, "is_direct": true}
+			if err := emit(cp, timer, engine.NormalizeADOEdges("member-of", hashKey(member, group)), rec); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/ado/correlate.go
+++ b/internal/ado/correlate.go
@@ -52,6 +52,8 @@ func correlate(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPh
 		func() error { return deriveEffectiveRoles(ctx, prior, cp, timer, org) },
 		func() error { return deriveMemberOf(prior, cp, timer, org) },
 		func() error { return deriveJobResourceEdges(prior, cp, timer, jobs) },
+		func() error { return deriveTaintEdges(prior, cp, timer, jobs, pipelines) },
+		func() error { return deriveBranchAccessEdges(prior, cp, timer) },
 	} {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -668,7 +670,15 @@ func deriveBranches(cp engine.CurrentPhase, timer *engine.PhaseTimer, pipelines,
 	branches := map[string]map[string]any{}
 	add := func(project, repo, repoID, branch string, isDefault, isPrefix bool) {
 		id := project + "/" + repo + "@" + branch
-		if _, ok := branches[id]; ok {
+		if b, ok := branches[id]; ok {
+			// a branch reached by more than one reference (pipeline default + policy
+			// scope, or several policies) keeps every flag that any reference set.
+			if isDefault {
+				b["is_default"] = true
+			}
+			if isPrefix {
+				b["is_prefix"] = true
+			}
 			return
 		}
 		branches[id] = map[string]any{

--- a/internal/ado/correlate_policy.go
+++ b/internal/ado/correlate_policy.go
@@ -1,0 +1,263 @@
+package ado
+
+import (
+	"fmt"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// Normalized policy_type display names (the collected policy type friendly names).
+const (
+	minReviewersType    = "Minimum number of reviewers"
+	buildValidationType = "Build"
+)
+
+// Git-namespace ACL action names (see the Git Repositories security namespace).
+const (
+	actContribute       = "GenericContribute"
+	actEditPolicies     = "EditPolicies"
+	actBypassPush       = "PolicyExempt"            // Bypass policies when pushing
+	actBypassPRComplete = "PullRequestBypassPolicy" // Bypass policies when completing PRs
+)
+
+// deriveBranchAccessEdges emits the cat-06 permission edges — CAN_PUSH_TO
+// (unreviewed write, schema §5), CAN_MERGE_VIA_PR (its gated complement), and
+// CAN_BYPASS (an explicit Git-namespace bypass grant, fanned out per governed
+// BranchPolicy). Sources are the repo's Contribute/bypass grants; the
+// HAS_POLICY/BranchPolicy premises are kept, not replaced.
+func deriveBranchAccessEdges(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer) error {
+	branches, err := loadRecords(prior, "10-normalize/branches")
+	if err != nil {
+		return fmt.Errorf("correlate: load branches: %w", err)
+	}
+	policies, err := loadRecords(prior, "10-normalize/policies")
+	if err != nil {
+		return fmt.Errorf("correlate: load policies: %w", err)
+	}
+	polByConfig := map[int64]map[string]any{}
+	for _, p := range policies {
+		polByConfig[mInt64(p, "config_id")] = p
+	}
+	hasPolicy, err := loadRecords(prior, "10-normalize/edges/has-policy")
+	if err != nil {
+		return fmt.Errorf("correlate: load has-policy: %w", err)
+	}
+	policiesByBranch := map[string][]map[string]any{}
+	for _, e := range hasPolicy {
+		policiesByBranch[mStr(e, "branch_id")] = append(policiesByBranch[mStr(e, "branch_id")], e)
+	}
+	repoGrants := loadRepoGrants(prior)
+	repoIDByName := map[string]string{} // "project/repo" -> repo node _id
+	if repos, err := loadRecords(prior, "10-normalize/repos"); err == nil {
+		for _, r := range repos {
+			repoIDByName[mStr(r, "project")+"/"+mStr(r, "name")] = mStr(r, "_id")
+		}
+	}
+
+	for _, b := range branches {
+		branchID := mStr(b, "_id")
+		// branch.repo_id is the repo GUID; HAS_ROLE resource_id is the repo node _id
+		// ("org/project/repo"), so resolve via the name index to join the two.
+		repoID := repoIDByName[mStr(b, "project")+"/"+mStr(b, "repo")]
+		gov := governingPolicies(policiesByBranch[branchID], polByConfig)
+		branchVia := branchWeaknesses(gov)
+		contributors := repoGrants.with(repoID, actContribute)
+
+		for _, g := range contributors {
+			via := append([]string{}, branchVia...)
+			if repoGrants.grantHas(g, repoID, actBypassPush) {
+				via = append(via, "bypass_policies")
+			}
+			if repoGrants.grantHas(g, repoID, actEditPolicies) {
+				via = append(via, "edit_policies")
+			}
+			if len(via) > 0 {
+				if err := emitBranchEdge(cp, timer, "can-push-to", "CAN_PUSH_TO", b, g, via, gov); err != nil {
+					return err
+				}
+			}
+			// the gated complement: a blocking review policy exists, so the same
+			// contributor can still land code through a PR (trivially if self-approval).
+			if gov.blockingMinReviewers != nil {
+				mergeVia := []string{"reviewed_pr"}
+				if entBool(mMap(gov.blockingMinReviewers, "settings")["creator_vote_counts"]) {
+					mergeVia = []string{"self_approve"}
+				}
+				if err := emitBranchEdge(cp, timer, "can-merge-via-pr", "CAN_MERGE_VIA_PR", b, g, mergeVia, gov); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return deriveCanBypass(cp, timer, hasPolicy, polByConfig, repoIDByName, repoGrants)
+}
+
+type govPolicies struct {
+	blockingMinReviewers map[string]any
+	buildValidations     []map[string]any
+	anyBlocking          bool
+}
+
+func governingPolicies(edges []map[string]any, polByConfig map[int64]map[string]any) govPolicies {
+	var g govPolicies
+	for _, e := range edges {
+		if !mBool(e, "is_enabled") {
+			continue
+		}
+		pol := polByConfig[mInt64(e, "config_id")]
+		switch mStr(e, "policy_type") {
+		case minReviewersType:
+			if mBool(e, "is_blocking") {
+				g.anyBlocking = true
+				if g.blockingMinReviewers == nil {
+					g.blockingMinReviewers = pol
+				}
+			}
+		case buildValidationType:
+			g.buildValidations = append(g.buildValidations, e)
+			if mBool(e, "is_blocking") {
+				g.anyBlocking = true
+			}
+		default:
+			if mBool(e, "is_blocking") {
+				g.anyBlocking = true
+			}
+		}
+	}
+	return g
+}
+
+// branchWeaknesses returns the branch-scoped CAN_PUSH_TO via variants (independent
+// of the principal) — the ways an unreviewed push lands despite the policies.
+func branchWeaknesses(g govPolicies) []string {
+	var via []string
+	if !g.anyBlocking {
+		return []string{"no_policy"}
+	}
+	if mr := g.blockingMinReviewers; mr != nil {
+		s := mMap(mr, "settings")
+		if mInt64(s, "minimum_approver_count") == 0 {
+			via = append(via, "weak_review")
+		}
+		if entBool(s["creator_vote_counts"]) {
+			via = append(via, "self_approve")
+		}
+		if !entBool(s["reset_on_source_push"]) {
+			via = append(via, "stale_approval")
+		}
+	}
+	for _, bv := range g.buildValidations {
+		if !mBool(bv, "is_blocking") || !mBool(bv, "is_enabled") {
+			via = append(via, "optional_build_validation")
+			break
+		}
+	}
+	return via
+}
+
+func emitBranchEdge(cp engine.CurrentPhase, timer *engine.PhaseTimer, kind, edgeKind string, b, grant map[string]any, via []string, gov govPolicies) error {
+	desc := mStr(grant, "descriptor")
+	rec := map[string]any{
+		"kind": edgeKind, "project": mStr(b, "project"), "repo": mStr(b, "repo"),
+		"branch": mStr(b, "name"), "branch_id": mStr(b, "_id"),
+		"principal": desc, "members": listOrEmpty(grant, "members"),
+		"via": via[0], "all_via": toAnyStrings(via),
+		"has_blocking_policy": gov.anyBlocking, "target": mStr(b, "_id"),
+	}
+	return emit(cp, timer, engine.NormalizeADOEdges(kind, hashKey(edgeKind, desc, mStr(b, "_id"))), rec)
+}
+
+// deriveCanBypass emits one CAN_BYPASS edge per (bypass-holding principal,
+// governed BranchPolicy) — the intentional per-policy fan-out (schema §5).
+func deriveCanBypass(cp engine.CurrentPhase, timer *engine.PhaseTimer, hasPolicy []map[string]any, polByConfig map[int64]map[string]any, repoIDByName map[string]string, repoGrants repoGrantIndex) error {
+	seen := map[string]bool{}
+	for _, e := range hasPolicy {
+		repoID := repoIDByName[mStr(e, "project")+"/"+mStr(e, "repo")]
+		if repoID == "" {
+			continue
+		}
+		pol := polByConfig[mInt64(e, "config_id")]
+		polID := mStr(pol, "_id")
+		if polID == "" {
+			continue
+		}
+		for _, mode := range []struct{ action, name string }{
+			{actBypassPush, "push"}, {actBypassPRComplete, "pull_request"},
+		} {
+			for _, g := range repoGrants.with(repoID, mode.action) {
+				desc := mStr(g, "descriptor")
+				key := hashKey(desc, polID, mode.name)
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				rec := map[string]any{
+					"kind": "CAN_BYPASS", "project": mStr(e, "project"), "repo": mStr(e, "repo"),
+					"principal": desc, "members": listOrEmpty(g, "members"),
+					"branch_policy_id": polID, "config_id": mInt64(e, "config_id"),
+					"policy_type": mStr(e, "policy_type"), "bypass_mode": mode.name, "target": polID,
+				}
+				if err := emit(cp, timer, engine.NormalizeADOEdges("can-bypass", key), rec); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ---- repo-scoped grant index (Git-namespace ACLs per repository) ----------
+
+type repoGrantIndex struct {
+	byRepoAction map[string]map[string][]map[string]any
+}
+
+func loadRepoGrants(prior engine.PriorPhase) repoGrantIndex {
+	idx := repoGrantIndex{byRepoAction: map[string]map[string][]map[string]any{}}
+	roles, err := loadRecords(prior, "10-normalize/edges/has-role")
+	if err != nil {
+		return idx
+	}
+	for _, role := range roles {
+		if mStr(role, "namespace") != gitNS || mStr(role, "resource_kind") != "Repository" {
+			continue
+		}
+		repoID := mStr(role, "resource_id")
+		grant := map[string]any{"descriptor": mStr(role, "graph_descriptor"), "members": listOrEmpty(role, "expanded_members")}
+		if grant["descriptor"] == "" {
+			continue
+		}
+		if idx.byRepoAction[repoID] == nil {
+			idx.byRepoAction[repoID] = map[string][]map[string]any{}
+		}
+		for _, a := range mList(role, "allowed_actions") {
+			if action, _ := a.(string); action != "" {
+				idx.byRepoAction[repoID][action] = append(idx.byRepoAction[repoID][action], grant)
+			}
+		}
+	}
+	return idx
+}
+
+func (r repoGrantIndex) with(repoID, action string) []map[string]any {
+	return r.byRepoAction[repoID][action]
+}
+
+func (r repoGrantIndex) grantHas(grant map[string]any, repoID, action string) bool {
+	desc := mStr(grant, "descriptor")
+	for _, g := range r.byRepoAction[repoID][action] {
+		if mStr(g, "descriptor") == desc {
+			return true
+		}
+	}
+	return false
+}
+
+func toAnyStrings(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/internal/ado/correlate_policy_test.go
+++ b/internal/ado/correlate_policy_test.go
@@ -1,0 +1,88 @@
+package ado
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func mr(minCount int, creatorVotes, resetOnPush bool) map[string]any {
+	return map[string]any{"settings": map[string]any{
+		"minimum_approver_count": float64(minCount),
+		"creator_vote_counts":    creatorVotes,
+		"reset_on_source_push":   resetOnPush,
+	}}
+}
+
+func TestBranchWeaknesses(t *testing.T) {
+	cases := []struct {
+		name string
+		gov  govPolicies
+		want []string
+	}{
+		{"no blocking policy at all", govPolicies{}, []string{"no_policy"}},
+		{
+			"weak review (0 approvers) + stale (no reset)",
+			govPolicies{anyBlocking: true, blockingMinReviewers: mr(0, false, false)},
+			[]string{"weak_review", "stale_approval"},
+		},
+		{
+			"self-approval allowed",
+			govPolicies{anyBlocking: true, blockingMinReviewers: mr(2, true, true)},
+			[]string{"self_approve"},
+		},
+		{
+			"strong review (2 approvers, reset on push, no self-approve) => no unreviewed push",
+			govPolicies{anyBlocking: true, blockingMinReviewers: mr(2, false, true)},
+			nil,
+		},
+		{
+			"optional (non-blocking) build validation",
+			govPolicies{
+				anyBlocking:      true,
+				buildValidations: []map[string]any{{"is_blocking": false, "is_enabled": true}},
+			},
+			[]string{"optional_build_validation"},
+		},
+	}
+	for _, c := range cases {
+		got := branchWeaknesses(c.gov)
+		sort.Strings(got)
+		want := append([]string(nil), c.want...)
+		sort.Strings(want)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("%s: branchWeaknesses = %v, want %v", c.name, got, want)
+		}
+	}
+}
+
+// A blocking build-validation with a strong reviewer policy leaves no unreviewed
+// path (CAN_PUSH_TO must be empty) — the blocking gate holds.
+func TestGoverningPolicies_BlockingHolds(t *testing.T) {
+	edges := []map[string]any{
+		{"policy_type": minReviewersType, "is_blocking": true, "is_enabled": true, "config_id": float64(1)},
+		{"policy_type": buildValidationType, "is_blocking": true, "is_enabled": true, "config_id": float64(2)},
+	}
+	polByConfig := map[int64]map[string]any{1: mr(2, false, true)}
+	gov := governingPolicies(edges, polByConfig)
+	if !gov.anyBlocking || gov.blockingMinReviewers == nil {
+		t.Fatalf("expected a blocking minReviewers gate, got %+v", gov)
+	}
+	if via := branchWeaknesses(gov); len(via) != 0 {
+		t.Errorf("strong blocking gate should yield no via, got %v", via)
+	}
+}
+
+// A disabled policy does not govern (must be ignored).
+func TestGoverningPolicies_DisabledIgnored(t *testing.T) {
+	edges := []map[string]any{
+		{"policy_type": minReviewersType, "is_blocking": true, "is_enabled": false, "config_id": float64(1)},
+	}
+	gov := governingPolicies(edges, map[int64]map[string]any{1: mr(2, false, true)})
+	if gov.anyBlocking {
+		t.Error("a disabled policy must not count as a blocking gate")
+	}
+	if via := branchWeaknesses(gov); !reflect.DeepEqual(via, []string{"no_policy"}) {
+		t.Errorf("disabled-only branch should be no_policy, got %v", via)
+	}
+}

--- a/internal/ado/correlate_taint.go
+++ b/internal/ado/correlate_taint.go
@@ -1,0 +1,518 @@
+package ado
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// deriveTaintEdges is the derived/attack-edge half of normalize (schema §5). It
+// reads back the structural corpus the earlier joins wrote and emits the taint
+// edges: READS (secret reach), QUEUE_TIME_INJECTION (cat-02),
+// LOGGING_COMMAND_INJECTION (cat-13), AGENT_INJECTION (cat-12 injection half),
+// and PIPELINE_POISONING (cat-01 injection half). The step-level sinks/sources
+// these key on are already collapsed onto each :Job by walkSteps.
+func deriveTaintEdges(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer, jobs, pipelines []map[string]any) error {
+	pipeMeta := indexPipelines(pipelines)
+	grants := loadGrants(prior)
+
+	readsByJob, err := deriveReads(prior, cp, timer, jobs)
+	if err != nil {
+		return err
+	}
+	for _, j := range jobs {
+		meta := pipeMeta[pipeKey(mStr(j, "project"), mInt64(j, "pipeline_id"))]
+		if err := deriveQueueTimeInjection(cp, timer, j, meta, grants); err != nil {
+			return err
+		}
+		if err := deriveLoggingInjection(cp, timer, j, meta, grants); err != nil {
+			return err
+		}
+		if err := deriveAgentInjection(cp, timer, j, meta, grants); err != nil {
+			return err
+		}
+		if err := derivePipelinePoisoning(cp, timer, j, meta, grants, readsByJob[jobKeyOf(j)]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type pipeInfo struct {
+	identityScope   string
+	enforceSettable bool
+	enableSanitize  bool
+	settableVars    any  // nil=all overridable, []=none, list=restricted
+	ciTrigger       any  // nil=implicit, "none"=off, else filter
+	buildValidated  bool // a BUILD_VALIDATES policy targets this pipeline
+	freeformParams  map[string]bool
+	allowlistParams map[string]bool
+	name            string
+}
+
+func pipeKey(project string, id int64) string { return fmt.Sprintf("%s/%d", project, id) }
+
+func indexPipelines(pipelines []map[string]any) map[string]pipeInfo {
+	out := map[string]pipeInfo{}
+	for _, p := range pipelines {
+		info := pipeInfo{
+			identityScope:   mStr(p, "identity_scope"),
+			enforceSettable: mBool(p, "enforce_settable_var"),
+			enableSanitize:  mBool(p, "enable_shell_tasks_args_sanitizing"),
+			settableVars:    mGet(p, "settable_variables"),
+			ciTrigger:       mGet(p, "ci_trigger"),
+			name:            mStr(p, "name"),
+			freeformParams:  map[string]bool{},
+			allowlistParams: map[string]bool{},
+		}
+		for _, raw := range mList(p, "parameters") {
+			pm := entMap(raw)
+			name := entStr(pm["name"])
+			if entBool(pm["is_freeform"]) {
+				info.freeformParams[name] = true
+			}
+			if entBool(pm["has_values_allowlist"]) {
+				info.allowlistParams[name] = true
+			}
+		}
+		out[pipeKey(mStr(p, "project"), mInt64(p, "id"))] = info
+	}
+	return out
+}
+
+// ---- READS (Job -> SecretVariable) ---------------------------------------
+
+func deriveReads(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer, jobs []map[string]any) (map[string]bool, error) {
+	readsByJob := map[string]bool{}
+	secretsByGroup := map[int64][]map[string]any{}
+	secrets, err := loadRecords(prior, "10-normalize/secret-variables")
+	if err != nil {
+		return nil, fmt.Errorf("correlate: load secret-variables: %w", err)
+	}
+	for _, s := range secrets {
+		gid := mInt64(s, "group_id")
+		secretsByGroup[gid] = append(secretsByGroup[gid], s)
+	}
+	vgGate := map[int64]map[string]any{}
+	vgs, err := loadRecords(prior, "10-normalize/variable-groups")
+	if err != nil {
+		return nil, fmt.Errorf("correlate: load variable-groups: %w", err)
+	}
+	for _, g := range vgs {
+		vgGate[mInt64(g, "id")] = g
+	}
+	cg, err := loadRecords(prior, "10-normalize/edges/consumes-group")
+	if err != nil {
+		return nil, fmt.Errorf("correlate: load consumes-group: %w", err)
+	}
+
+	for _, j := range jobs {
+		project, pid := mStr(j, "project"), mInt64(j, "pipeline_id")
+		stage, job := mStr(j, "stage"), mStr(j, "job")
+		seen := map[int64]bool{}
+		for _, e := range cg {
+			if mStr(e, "project") != project || mInt64(e, "pipeline_id") != pid {
+				continue
+			}
+			// a pipeline-level group reaches every job; a stage-level group every job
+			// in the stage; a job-level group only its own job (schema §5 READS).
+			reaches := false
+			switch mStr(e, "level") {
+			case "pipeline":
+				reaches = true
+			case "stage":
+				reaches = mStr(e, "stage") == stage
+			case "job":
+				reaches = mStr(e, "stage") == stage && mStr(e, "job") == job
+			}
+			if !reaches {
+				continue
+			}
+			gid := mInt64(e, "variable_group_id")
+			if gid == 0 || seen[gid] {
+				continue
+			}
+			seen[gid] = true
+			strength, state, confidence := vgGateState(vgGate[gid])
+			if len(secretsByGroup[gid]) > 0 {
+				readsByJob[jobKeyOf(j)] = true
+			}
+			for _, s := range secretsByGroup[gid] {
+				rec := map[string]any{
+					"kind": "READS", "project": project, "pipeline_id": pid, "stage": stage, "job": job,
+					"variable_group_id": gid, "secret_name": mStr(s, "name"), "secret_id": mStr(s, "_id"),
+					"via_level": mStr(e, "level"), "gate_strength": strength, "gate_state": state, "confidence": confidence,
+				}
+				key := fmt.Sprintf("%s__%d__%s__%s__%d__%s", adoSafe(project), pid, adoSafe(stage), adoSafe(job), gid, adoSafe(mStr(s, "name")))
+				if err := emit(cp, timer, engine.NormalizeADOEdges("reads", key), rec); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return readsByJob, nil
+}
+
+func vgGateState(vg map[string]any) (strength, state, confidence string) {
+	if vg != nil && len(mList(vg, "checks")) > 0 {
+		return "strong", "real", "low"
+	}
+	return "none", "absent", "high"
+}
+
+// ---- QUEUE_TIME_INJECTION (source -> Job) --------------------------------
+
+func deriveQueueTimeInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j map[string]any, meta pipeInfo, grants grantIndex) error {
+	project := mStr(j, "project")
+	sources := grants.principalsWith(project, buildNSKey, "QueueBuilds")
+	target := jobID(j)
+
+	blocksAllMacros := meta.enforceSettable && isEmptyList(meta.settableVars)
+
+	emitEdge := func(sinkType, name, via, location, confidence string, ms map[string]any) error {
+		rec := map[string]any{
+			"kind": "QUEUE_TIME_INJECTION", "technique": "queue_time_injection",
+			"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+			"source": "queue_build_principal", "source_permission": "QueueBuilds", "source_principals": sources,
+			"sink_type": sinkType, "macro_name": name, "sink_location": location, "via": via,
+			"enforce_settable_var": meta.enforceSettable, "enable_args_validation": meta.enableSanitize,
+			"is_declared_settable": entBool(ms["is_declared_settable"]), "settable_variables": meta.settableVars,
+			"identity_scope": meta.identityScope, "confidence": confidence,
+			"target": target, "context": "azure_repos",
+		}
+		key := fmt.Sprintf("%s__%s__%s", jobKeyOf(j), adoSafe(via), adoSafe(name))
+		return emit(cp, timer, engine.NormalizeADOEdges("queue-time-injection", key), rec)
+	}
+
+	for _, raw := range mList(j, "macro_sinks") {
+		ms := entMap(raw)
+		kind, loc, name := entStr(ms["macro_kind"]), entStr(ms["location"]), entStr(ms["macro_name"])
+		if kind == "predefined_untrusted" {
+			st := "macro_in_script"
+			if loc == "task_input" {
+				st = "macro_in_task_input"
+			}
+			if err := emitEdge(st, name, "predefined_variable", loc, "high", ms); err != nil {
+				return err
+			}
+			continue
+		}
+		if blocksAllMacros { // settableVariables:[] with the limit on blocks every macro (deterministic)
+			continue
+		}
+		switch loc {
+		case "script":
+			conf := "high"
+			if meta.enforceSettable && !entBool(ms["is_declared_settable"]) {
+				conf = "medium"
+			}
+			if err := emitEdge("macro_in_script", name, "unrestricted_macro", loc, conf, ms); err != nil {
+				return err
+			}
+		case "task_input":
+			conf := "high"
+			if meta.enableSanitize {
+				conf = "low" // shell-args validation hardens the arguments sink
+			}
+			if err := emitEdge("macro_in_task_input", name, "settable_var_arguments", loc, conf, ms); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, raw := range mList(j, "parameter_sinks") {
+		ps := entMap(raw)
+		name, loc := entStr(ps["param_name"]), entStr(ps["location"])
+		if meta.allowlistParams[name] {
+			continue // values: allowlist is a deterministic sanitizer
+		}
+		switch loc {
+		case "script":
+			if err := emitEdge("parameter_in_script", name, "freeform_parameter", "script", "high", ps); err != nil {
+				return err
+			}
+		case "compile_keyword":
+			if err := emitEdge("parameter_in_compile_keyword", name, "input_target_redirect", entStr(ps["keyword"]), "high", ps); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ---- LOGGING_COMMAND_INJECTION (source -> Job) ---------------------------
+
+func deriveLoggingInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j map[string]any, meta pipeInfo, grants grantIndex) error {
+	echoes := mList(j, "vso_echo_sources")
+	if len(echoes) == 0 {
+		return nil
+	}
+	project := mStr(j, "project")
+	sources := grants.principalsWith(project, gitNSKey, "GenericContribute", "PullRequestContribute")
+
+	emitEdge := func(cmdType, via, effect, source string, echoStep int, consumer map[string]any, confidence string) error {
+		rec := map[string]any{
+			"kind": "LOGGING_COMMAND_INJECTION", "technique": "logging_command_injection",
+			"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+			"command_type": cmdType, "untrusted_source": source, "echo_step": echoStep,
+			"via": via, "effect": effect, "consumer_step": consumer["step_index"],
+			"target_resource": consumer["resource"], "source_principals": sources,
+			"identity_scope": meta.identityScope, "confidence": confidence,
+			"target": jobID(j), "context": "azure_repos",
+		}
+		key := fmt.Sprintf("%s__%s__%d__%v", jobKeyOf(j), adoSafe(via), echoStep, consumer["step_index"])
+		return emit(cp, timer, engine.NormalizeADOEdges("logging-command-injection", key), rec)
+	}
+
+	scUsages := mList(j, "service_connection_usages")
+	bareBins := mList(j, "bare_binary_calls")
+	varCons := mList(j, "variable_consumers")
+	credWrites := mList(j, "cred_writes")
+
+	for _, raw := range echoes {
+		echo := entMap(raw)
+		e := int(entInt64(echo["step_index"]))
+		src := entStr(echo["untrusted_source"])
+		conf := loggingConfidence(src)
+
+		for _, u := range scUsages { // setendpoint: connection used after the echo
+			um := entMap(u)
+			if int(entInt64(um["step_index"])) > e {
+				if err := emitEdge("setendpoint", "setendpoint_redirect", "connection_url_redirect", src, e,
+					map[string]any{"step_index": um["step_index"], "resource": entStr(um["connection_name"])}, conf); err != nil {
+					return err
+				}
+			}
+		}
+		for _, b := range bareBins { // prependpath: bare binary invoked after the echo
+			bm := entMap(b)
+			if int(entInt64(bm["step_index"])) > e {
+				if err := emitEdge("prependpath", "prependpath_shadow", "path_binary_shadow", src, e,
+					map[string]any{"step_index": bm["step_index"], "resource": entStr(bm["bin"])}, conf); err != nil {
+					return err
+				}
+			}
+		}
+		for _, v := range varCons { // setvariable: variable read after the echo
+			vm := entMap(v)
+			if int(entInt64(vm["step_index"])) > e {
+				if err := emitEdge("setvariable", "setvariable_control_flip", "variable_control_flip", src, e,
+					map[string]any{"step_index": vm["step_index"], "resource": entStr(vm["name"])}, conf); err != nil {
+					return err
+				}
+			}
+		}
+		for _, c := range credWrites { // artifact.upload: a secret file written before the echo
+			cm := entMap(c)
+			if int(entInt64(cm["step_index"])) < e {
+				if err := emitEdge("artifact.upload", "artifact_upload_exfil", "file_exfiltration", src, e,
+					map[string]any{"step_index": cm["step_index"], "resource": entStr(cm["file"])}, conf); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func loggingConfidence(src string) string {
+	switch src {
+	case "literal_vso", "variable_value":
+		return "medium"
+	}
+	return "high"
+}
+
+// ---- AGENT_INJECTION (source -> Job) -------------------------------------
+
+func deriveAgentInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j map[string]any, meta pipeInfo, grants grantIndex) error {
+	ai := mList(j, "ai_task_sinks")
+	if len(ai) == 0 {
+		return nil
+	}
+	project := mStr(j, "project")
+	sources := grants.principalsWith(project, gitNSKey, "GenericContribute", "PullRequestContribute")
+
+	for i, raw := range ai {
+		sink := entMap(raw)
+		caps := mList(sink, "capabilities")
+		conf := "medium"
+		if slices.ContainsFunc(caps, func(c any) bool { s, _ := c.(string); return s == "tool_exec" || s == "egress" }) {
+			conf = "high"
+		}
+		via := "direct"
+		if hasCap(caps, "tool_exec") {
+			via = "generate_then_execute"
+		}
+		rec := map[string]any{
+			"kind": "AGENT_INJECTION", "technique": "prompt_injection",
+			"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+			"via": via, "source_kind": "pr_description", "vendor": entStr(sink["vendor"]),
+			"capabilities": caps, "gate_state": "absent", "source_principals": sources,
+			"identity_scope": meta.identityScope, "confidence": conf,
+			"target": jobID(j), "context": "azure_repos",
+		}
+		key := fmt.Sprintf("%s__%d", jobKeyOf(j), i)
+		if err := emit(cp, timer, engine.NormalizeADOEdges("agent-injection", key), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---- PIPELINE_POISONING (source -> Job) ----------------------------------
+
+func derivePipelinePoisoning(cp engine.CurrentPhase, timer *engine.PhaseTimer, j map[string]any, meta pipeInfo, grants grantIndex, reads bool) error {
+	// Necessary conjuncts (schema §5): an execution trigger runs the repo's YAML,
+	// and the pipeline has an authorized blast radius worth stealing — a secret
+	// reach (READS), a service connection, the collection-scoped access token, or
+	// a deployment target. A resource-less `echo build` pipeline is not a finding.
+	trigger, via := poisonTrigger(meta)
+	if trigger == "" {
+		return nil
+	}
+	blastRadius := reads || len(mList(j, "service_connection_usages")) > 0 ||
+		mBool(j, "exposes_system_access_token") || meta.identityScope == "collection" ||
+		mStr(j, "targets_environment") != ""
+	if !blastRadius {
+		return nil
+	}
+	project := mStr(j, "project")
+	sources := grants.principalsWith(project, gitNSKey, "GenericContribute", "PullRequestContribute")
+
+	sinkKind := "checkout"
+	if mBool(j, "executes_checked_out_code") {
+		sinkKind = "script"
+	}
+	confidence := "medium"
+	if via == "build_validation" {
+		confidence = "high" // runs before any reviewer approves
+	}
+	rec := map[string]any{
+		"kind": "PIPELINE_POISONING", "technique": "pipeline_poisoning",
+		"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+		"trigger": trigger, "via": via, "sink_kind": sinkKind, "sink_form": "script",
+		"exposes_system_access_token": mBool(j, "exposes_system_access_token"),
+		"identity_scope":              meta.identityScope, "source_principals": sources,
+		"gate_state": "absent", "confidence": confidence,
+		"target": jobID(j), "context": "azure_repos",
+	}
+	return emit(cp, timer, engine.NormalizeADOEdges("pipeline-poisoning", jobKeyOf(j)), rec)
+}
+
+// poisonTrigger resolves the strongest execution trigger a Contributor can drive.
+func poisonTrigger(meta pipeInfo) (trigger, via string) {
+	switch {
+	case meta.buildValidated:
+		return "build_validation", "build_validation"
+	case meta.ciTrigger != nil && meta.ciTrigger != "none":
+		return "ci_push", "ci_trigger"
+	default:
+		// no CI trigger declared: a Contributor still pushes modified YAML to a
+		// branch and queues a build against it (schema §5 via: branch_queue).
+		return "manual_queue", "branch_queue"
+	}
+}
+
+// ---- source-principal resolution -----------------------------------------
+
+const (
+	gitNSKey      = "git"
+	buildNSKey    = "build"
+	endpointNSKey = "endpoint"
+)
+
+type grantIndex struct {
+	byProjectAction map[string]map[string][]map[string]any
+}
+
+// loadGrants indexes HAS_ROLE edges by (project, namespace-tagged action) -> the
+// principal grants (descriptor + expanded leaf members) — the source side of the
+// injection edges (who holds Queue builds / Contribute).
+func loadGrants(prior engine.PriorPhase) grantIndex {
+	idx := grantIndex{byProjectAction: map[string]map[string][]map[string]any{}}
+	roles, err := loadRecords(prior, "10-normalize/edges/has-role")
+	if err != nil {
+		return idx
+	}
+	projByID := map[string]string{}
+	if projs, err := loadRecords(prior, "10-normalize/projects"); err == nil {
+		for _, p := range projs {
+			projByID[mStr(p, "_id")] = mStr(p, "project")
+		}
+	}
+	repoProj := map[string]string{}
+	if repos, err := loadRecords(prior, "10-normalize/repos"); err == nil {
+		for _, r := range repos {
+			repoProj[mStr(r, "_id")] = mStr(r, "project")
+		}
+	}
+	nsTag := map[string]string{gitNS: gitNSKey, buildNS: buildNSKey, endpointNS: endpointNSKey}
+	for _, role := range roles {
+		project := ""
+		switch mStr(role, "resource_kind") {
+		case "Project":
+			project = projByID[mStr(role, "resource_id")]
+		case "Repository":
+			project = repoProj[mStr(role, "resource_id")]
+		}
+		if project == "" {
+			continue
+		}
+		nsk := nsTag[mStr(role, "namespace")]
+		grant := map[string]any{"descriptor": mStr(role, "graph_descriptor"), "members": listOrEmpty(role, "expanded_members")}
+		for _, a := range mList(role, "allowed_actions") {
+			action, _ := a.(string)
+			if action == "" {
+				continue
+			}
+			tagged := nsk + ":" + action
+			if idx.byProjectAction[project] == nil {
+				idx.byProjectAction[project] = map[string][]map[string]any{}
+			}
+			idx.byProjectAction[project][tagged] = append(idx.byProjectAction[project][tagged], grant)
+		}
+	}
+	return idx
+}
+
+func (g grantIndex) principalsWith(project, ns string, actions ...string) []any {
+	byAction := g.byProjectAction[project]
+	seen := map[string]bool{}
+	out := []any{}
+	for _, action := range actions {
+		for _, grant := range byAction[ns+":"+action] {
+			d, _ := grant["descriptor"].(string)
+			if d == "" || seen[d] {
+				continue
+			}
+			seen[d] = true
+			out = append(out, grant)
+		}
+	}
+	return out
+}
+
+// ---- small helpers -------------------------------------------------------
+
+func jobID(j map[string]any) string { return mStr(j, "_id") }
+
+func jobKeyOf(j map[string]any) string {
+	return fmt.Sprintf("%s__%d__%s__%s", adoSafe(mStr(j, "project")), mInt64(j, "pipeline_id"),
+		adoSafe(mStr(j, "stage")), adoSafe(mStr(j, "job")))
+}
+
+func isEmptyList(v any) bool {
+	l, ok := v.([]any)
+	return ok && len(l) == 0
+}
+
+func hasCap(caps []any, want string) bool {
+	for _, c := range caps {
+		if s, _ := c.(string); s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ado/facts_ado.go
+++ b/internal/ado/facts_ado.go
@@ -1,0 +1,172 @@
+package ado
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// Normalize-side helpers, ported from the GitHub stack (platform-agnostic): safe
+// navigation over the collected {_meta,data} envelopes, and reading the
+// normalized corpus back as generic maps for the correlate pass.
+
+// entLoadData returns the "data" object of a collected envelope, or nil for a
+// missing file / null data (so callers skip the surface).
+func entLoadData(prior engine.PriorPhase, rel string) map[string]any {
+	var env map[string]any
+	if err := engine.ReadJSON(prior.Abs(rel), &env); err != nil {
+		return nil
+	}
+	return entMap(env["data"])
+}
+
+// entLoadList returns the "data" of a list-surface envelope as []any (the ADO
+// list endpoints store the value array directly under data).
+func entLoadList(prior engine.PriorPhase, rel string) []any {
+	var env map[string]any
+	if err := engine.ReadJSON(prior.Abs(rel), &env); err != nil {
+		return nil
+	}
+	return entList(env["data"])
+}
+
+// entDataOf returns the "data" object of a collected envelope (nil for a
+// non-object body such as a bare list surface — callers reading those use
+// entLoadList instead).
+func entDataOf(b []byte) map[string]any {
+	var env map[string]any
+	if err := json.Unmarshal(b, &env); err != nil {
+		return nil
+	}
+	return entMap(env["data"])
+}
+
+func entMap(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
+}
+
+func entList(v any) []any {
+	l, _ := v.([]any)
+	return l
+}
+
+// entListOrEmpty never returns nil so a list field serializes as [] not null.
+func entListOrEmpty(v any) []any {
+	if l, ok := v.([]any); ok {
+		return l
+	}
+	return []any{}
+}
+
+// entObj never returns nil so chained indexing is safe.
+func entObj(m map[string]any, key string) map[string]any {
+	if o := entMap(m[key]); o != nil {
+		return o
+	}
+	return map[string]any{}
+}
+
+func entGetIn(m map[string]any, keys ...string) any {
+	var cur any = m
+	for _, k := range keys {
+		cm := entMap(cur)
+		if cm == nil {
+			return nil
+		}
+		cur = cm[k]
+	}
+	return cur
+}
+
+func entStr(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func entBool(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func entInt64(v any) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case int:
+		return int64(x)
+	case int64:
+		return x
+	case string:
+		if n, err := strconv.ParseInt(x, 10, 64); err == nil {
+			return n
+		}
+	case json.Number:
+		if n, err := x.Int64(); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// ---- correlate read-side (normalized corpus as maps) ----
+
+func loadRecords(prior engine.PriorPhase, dir string) ([]map[string]any, error) {
+	files, err := prior.IterJSON(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, 0, len(files))
+	for _, f := range files {
+		var rec map[string]any
+		if err := json.Unmarshal(f.Data, &rec); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+func mGet(m map[string]any, key string) any {
+	if m == nil {
+		return nil
+	}
+	return m[key]
+}
+
+func mStr(m map[string]any, key string) string {
+	s, _ := mGet(m, key).(string)
+	return s
+}
+
+func mBool(m map[string]any, key string) bool {
+	b, _ := mGet(m, key).(bool)
+	return b
+}
+
+func mMap(m map[string]any, key string) map[string]any {
+	v, _ := mGet(m, key).(map[string]any)
+	return v
+}
+
+func mList(m map[string]any, key string) []any {
+	v, _ := mGet(m, key).([]any)
+	return v
+}
+
+func mInt64(m map[string]any, key string) int64 {
+	return entInt64(mGet(m, key))
+}
+
+type provenance struct {
+	File string `json:"file"`
+}
+
+func prov(files ...string) []provenance {
+	out := make([]provenance, 0, len(files))
+	for _, f := range files {
+		out = append(out, provenance{File: f})
+	}
+	return out
+}

--- a/internal/ado/normalize.go
+++ b/internal/ado/normalize.go
@@ -1,0 +1,85 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+type projectMeta struct {
+	ID   string
+	Name string
+}
+
+// Normalize turns the raw collected JSON (00-collect) into structural node/edge
+// records (10-normalize) per the ADO security-graph ontology. This is the
+// structural pass: nodes, collected edges, and the three settings-resolution
+// joins. Derived/attack (taint) edges are a later pass.
+func Normalize(ctx context.Context, runDir string) error {
+	state, err := engine.LoadState(runDir)
+	if err != nil {
+		return err
+	}
+	if err := state.CheckPhase(engine.PhaseNormalize); err != nil {
+		return err
+	}
+	for _, d := range state.StaleDirs(engine.PhaseNormalize) {
+		if err := os.RemoveAll(filepath.Join(runDir, d)); err != nil {
+			return err
+		}
+	}
+	// Clear this phase's own output so a re-run against shrunk input leaves no
+	// orphan records for correlate to read back.
+	if err := os.RemoveAll(filepath.Join(runDir, "10-normalize")); err != nil {
+		return err
+	}
+	org := state.Org
+	if org == "" {
+		return fmt.Errorf("org not set in %s; run collect first", engine.RunMeta())
+	}
+
+	timer := engine.StartPhaseTimer(engine.PhaseNormalize, "normalize")
+	prior := engine.PriorPhase{RunDir: runDir}
+	cp := engine.CurrentPhase{RunDir: runDir}
+
+	normErr := normalizeEntities(ctx, prior, cp, org, timer)
+	if normErr == nil {
+		normErr = normalizePipelines(ctx, prior, cp, timer)
+	}
+	if normErr == nil {
+		normErr = correlate(ctx, prior, cp, org, timer)
+	}
+
+	rec := timer.Stop(normErr)
+	state.RecordPhase(rec)
+	if err := state.Save(runDir); err != nil {
+		return err
+	}
+	return normErr
+}
+
+// emit writes one normalized record and counts it. Normalize is sequential, so
+// no locking is needed on the timer.
+func emit(cp engine.CurrentPhase, timer *engine.PhaseTimer, rel string, rec any) error {
+	if err := cp.Write(rel, rec); err != nil {
+		return err
+	}
+	timer.OutputFiles++
+	return nil
+}
+
+// projects reads the collected project roster (id + true name; per-project
+// surface files are keyed by the sanitized name).
+func projects(prior engine.PriorPhase, org string) []projectMeta {
+	var out []projectMeta
+	for _, raw := range entLoadList(prior, engine.CollectADOProjects(org)) {
+		m := entMap(raw)
+		if id, name := entStr(m["id"]), entStr(m["name"]); id != "" && name != "" {
+			out = append(out, projectMeta{ID: id, Name: name})
+		}
+	}
+	return out
+}

--- a/internal/ado/normalize_contract_test.go
+++ b/internal/ado/normalize_contract_test.go
@@ -1,0 +1,168 @@
+package ado
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// clampScope is fail-closed: an unobserved enforce flag clamps to project, and an
+// observed non-enforcing project passes the requested collection scope through.
+func TestClampScope(t *testing.T) {
+	cases := []struct {
+		requested                    string
+		enforced, observed           bool
+		wantEff, wantScope, wantProv string
+	}{
+		{"projectCollection", false, true, "projectCollection", "collection", "observed"},
+		{"projectCollection", true, true, "project", "project", "observed"},
+		{"projectCollection", false, false, "project", "project", "unknown"}, // fail closed
+		{"project", false, true, "project", "project", "observed"},
+	}
+	for _, c := range cases {
+		eff, scope, prov := clampScope(c.requested, c.enforced, c.observed)
+		if eff != c.wantEff || scope != c.wantScope || prov != c.wantProv {
+			t.Errorf("clampScope(%q,%v,%v) = %q/%q/%q, want %q/%q/%q",
+				c.requested, c.enforced, c.observed, eff, scope, prov, c.wantEff, c.wantScope, c.wantProv)
+		}
+	}
+}
+
+// resolveRoleToken maps ACL namespace tokens to the emitted node they scope.
+func TestResolveRoleToken(t *testing.T) {
+	repoIdx := map[string]string{"repo-guid": "org/P/myrepo"}
+	scIdx := map[string]string{"conn-1": "Owner/conn-1"}
+	projIdx := map[string]string{"proj-guid": "org/P"}
+	cases := []struct{ token, wantKind, wantID string }{
+		{"repoV2/proj-guid/repo-guid", "Repository", "org/P/myrepo"},
+		{"endpoints/proj-guid/conn-1", "ServiceConnection", "Owner/conn-1"},
+		{"proj-guid", "Project", "org/P"},
+		{"repoV2/proj-guid/unknown-repo", "Repository", ""}, // repo not indexed -> unresolved
+		{"$PROJECT:vstfs:///unknown", "", ""},               // not a recognized shape
+	}
+	for _, c := range cases {
+		k, id := resolveRoleToken(c.token, repoIdx, scIdx, projIdx)
+		if k != c.wantKind || id != c.wantID {
+			t.Errorf("resolveRoleToken(%q) = %q/%q, want %q/%q", c.token, k, id, c.wantKind, c.wantID)
+		}
+	}
+}
+
+// policySettings projects raw camelCase branch-policy settings to schema snake_case.
+func TestPolicySettings(t *testing.T) {
+	got := policySettings(map[string]any{
+		"creatorVoteCounts": true, "minimumApproverCount": float64(2),
+		"blockLastPusherVote": true, "buildDefinitionId": float64(9), "manualQueueOnly": true,
+	})
+	if got["creator_vote_counts"] != true || got["block_last_pusher_vote"] != true || got["manual_queue_only"] != true {
+		t.Errorf("bool mapping wrong: %v", got)
+	}
+	if got["minimum_approver_count"] != int64(2) || got["build_definition_id"] != int64(9) {
+		t.Errorf("int mapping wrong: %v", got)
+	}
+	if _, ok := got["creatorVoteCounts"]; ok {
+		t.Error("raw camelCase key leaked into output")
+	}
+}
+
+// CONSUMES_GROUP is emitted at each declaration level (pipeline/stage/job) with the
+// level property and the group's owner_project (so a shared group binds to owner/id).
+func TestConsumesGroupLevels(t *testing.T) {
+	dir := t.TempDir()
+	cp, prior := engineCP(dir), engine.PriorPhase{RunDir: dir}
+	write := func(rel string, rec any) {
+		if err := engine.WriteJSON(filepath.Join(dir, rel), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(engine.NormalizeADOVariableGroup("Owner", 7), map[string]any{
+		"_id": "Owner/7", "kind": "VariableGroup", "id": float64(7), "name": "prod-secrets",
+		"owner_project": "Owner", "visible_in_projects": []any{"Owner"},
+	})
+	write(engine.NormalizeADOPipeline("Owner", 1), map[string]any{
+		"project": "Owner", "id": float64(1), "variable_groups": []any{"prod-secrets"},
+	})
+	write(engine.NormalizeADOStage("Owner", 1, "deploy"), map[string]any{
+		"project": "Owner", "pipeline_id": float64(1), "stage": "deploy", "variable_groups": []any{"prod-secrets"},
+	})
+	jobs := []map[string]any{
+		{"project": "Owner", "pipeline_id": float64(1), "stage": "deploy", "job": "ship", "variable_groups": []any{"prod-secrets"}},
+	}
+	if err := deriveJobResourceEdges(prior, cp, normTimer(), jobs); err != nil {
+		t.Fatal(err)
+	}
+	byLevel := map[string]map[string]any{}
+	for _, f := range mustGlob(t, dir, "10-normalize/edges/consumes-group/*.json") {
+		var e map[string]any
+		if err := engine.ReadJSON(f, &e); err != nil {
+			t.Fatal(err)
+		}
+		byLevel[e["level"].(string)] = e
+	}
+	for _, lvl := range []string{"pipeline", "stage", "job"} {
+		e, ok := byLevel[lvl]
+		if !ok {
+			t.Fatalf("missing CONSUMES_GROUP at level %s", lvl)
+		}
+		if e["owner_project"] != "Owner" || e["resolved"] != true || int64(e["variable_group_id"].(float64)) != 7 {
+			t.Errorf("level %s edge wrong: %v", lvl, e)
+		}
+	}
+}
+
+// resolveTemplateSources resolves a resources.repositories alias to its source
+// repo, flagging cross-project and unpinned (default-branch) sources — the cat-08
+// poisoned-template surface that was previously an opaque alias string.
+func TestResolveTemplateSources(t *testing.T) {
+	root := map[string]any{
+		"resources": map[string]any{
+			"repositories": []any{
+				map[string]any{"repository": "templates", "type": "git", "name": "BuildTemplates"},                                         // same project, unpinned
+				map[string]any{"repository": "shared", "type": "git", "name": "PlatformProject/SharedTemplates", "ref": "refs/heads/main"}, // cross-project, pinned
+			},
+		},
+	}
+	list, byAlias := resolveTemplateSources(root, "MyProject")
+	if len(list) != 2 {
+		t.Fatalf("want 2 sources, got %d", len(list))
+	}
+	same := byAlias["templates"]
+	if same["repository"] != "BuildTemplates" || same["source_project"] != "MyProject" || same["is_cross_project"] != false || same["ref_pinned"] != false {
+		t.Errorf("same-project source wrong: %v", same)
+	}
+	cross := byAlias["shared"]
+	if cross["repository"] != "SharedTemplates" || cross["source_project"] != "PlatformProject" || cross["is_cross_project"] != true || cross["ref_pinned"] != true {
+		t.Errorf("cross-project source wrong: %v", cross)
+	}
+}
+
+// normalizeParameters flags a queue-time-settable string/number/object param with
+// no values allowlist as freeform — the cat-02 injection surface.
+func TestNormalizeParameters(t *testing.T) {
+	got := normalizeParameters([]any{
+		map[string]any{"name": "tag", "type": "string"},                                 // freeform
+		map[string]any{"name": "env", "type": "string", "values": []any{"dev", "prod"}}, // allowlisted
+		map[string]any{"name": "extraSteps", "type": "stepList"},                        // not injectable text
+		map[string]any{"name": "count", "type": "number"},                               // freeform
+	})
+	want := map[string]bool{"tag": true, "env": false, "extraSteps": false, "count": true}
+	if len(got) != 4 {
+		t.Fatalf("want 4 params, got %d", len(got))
+	}
+	for _, raw := range got {
+		p := raw.(map[string]any)
+		if p["is_freeform"] != want[p["name"].(string)] {
+			t.Errorf("%s is_freeform = %v, want %v", p["name"], p["is_freeform"], want[p["name"].(string)])
+		}
+	}
+}
+
+func mustGlob(t *testing.T, dir, pat string) []string {
+	t.Helper()
+	fs, err := filepath.Glob(filepath.Join(dir, pat))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fs
+}

--- a/internal/ado/normalize_entities.go
+++ b/internal/ado/normalize_entities.go
@@ -1,0 +1,824 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// normalizeEntities emits one structural record per node from the API-JSON
+// surfaces. Resource-scoped properties (checks, pipeline authorization, secrets)
+// fold onto their owning node. Per-item failures are recorded and skipped.
+func normalizeEntities(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	projs := projects(prior, org)
+
+	if err := normalizeOrg(prior, cp, org, projs, timer); err != nil {
+		return err
+	}
+	if err := normalizePrincipals(prior, cp, org, timer); err != nil {
+		return err
+	}
+	if err := normalizeAgentPools(prior, cp, timer); err != nil {
+		return err
+	}
+	if err := normalizeFeeds(prior, cp, org, timer); err != nil {
+		return err
+	}
+	if err := normalizeExtensions(prior, cp, org, timer); err != nil {
+		return err
+	}
+	if err := normalizeServiceHooks(prior, cp, org, timer); err != nil {
+		return err
+	}
+	// Service connections and variable groups are deduped across projects (a
+	// shared resource appears in every project it is shared into), so they run
+	// org-level, not per-project.
+	if err := normalizeServiceConnectionsShared(prior, cp, org, projs, timer); err != nil {
+		return err
+	}
+	if err := normalizeVariableGroupsShared(prior, cp, org, projs, timer); err != nil {
+		return err
+	}
+	for _, p := range projs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		for _, fn := range []func(engine.PriorPhase, engine.CurrentPhase, string, projectMeta, *engine.PhaseTimer) error{
+			normalizeProject, normalizeRepos, normalizeEnvironments, normalizePolicies, normalizeAgentQueues, normalizeSecureFiles,
+		} {
+			if err := fn(prior, cp, org, p, timer); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// generalSettings returns a project's effective build/pipeline settings object.
+func generalSettings(prior engine.PriorPhase, project string) map[string]any {
+	return entLoadData(prior, engine.CollectADOGeneralSettings(project))
+}
+
+// orgInheritedSettings are the general-settings keys (schema names) that resolve
+// down from the org. Only these gate org_settings_uniform; the remaining
+// settingsView keys are project-scoped posture.
+var orgInheritedSettings = []string{
+	"limit_job_auth_scope_to_current_project", "limit_job_auth_scope_for_releases",
+	"limit_job_auth_scope_to_referenced_repos", "enforce_settable_var",
+	"disable_classic_pipeline_creation", "disable_classic_build_pipeline_creation",
+	"disable_classic_release_creation", "disable_implied_yaml_ci_trigger",
+}
+
+// settingsView projects the load-bearing general-settings booleans under the
+// schema_reference property names (the values are effective/server-clamped). These
+// are spread FLAT onto :Organization and :Project per the schema. settings_observed
+// is false when the surface soft-failed, so an absent flag is not read as false.
+func settingsView(gs map[string]any) map[string]any {
+	observed := gs != nil
+	if _, un := gs["_unobserved"]; un {
+		observed = false
+	}
+	return map[string]any{
+		"limit_job_auth_scope_to_current_project":  entBool(gs["enforceJobAuthScope"]),
+		"limit_job_auth_scope_for_releases":        entBool(gs["enforceJobAuthScopeForReleases"]),
+		"limit_job_auth_scope_to_referenced_repos": entBool(gs["enforceReferencedRepoScopedToken"]),
+		"enforce_settable_var":                     entBool(gs["enforceSettableVar"]),
+		"disable_classic_pipeline_creation":        entBool(gs["disableClassicPipelineCreation"]),
+		"disable_classic_build_pipeline_creation":  entBool(gs["disableClassicBuildPipelineCreation"]),
+		"disable_classic_release_creation":         entBool(gs["disableClassicReleasePipelineCreation"]),
+		"disable_implied_yaml_ci_trigger":          entBool(gs["disableImpliedYAMLCiTrigger"]),
+		"enable_shell_tasks_args_sanitizing":       entBool(gs["enableShellTasksArgsSanitizing"]),
+		"fork_protection_enabled":                  entBool(gs["forkProtectionEnabled"]),
+		"builds_enabled_for_forks":                 entBool(gs["buildsEnabledForForks"]),
+		"settings_observed":                        observed,
+	}
+}
+
+// mergeFlat spreads src's keys onto dst (dst wins on conflict is not expected;
+// settings keys are disjoint from the node's own keys).
+func mergeFlat(dst, src map[string]any) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+func normalizeOrg(prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	// No org-level generalsettings endpoint exists (404): the org enforce flags
+	// are only observable as the per-project effective values. Present a sample
+	// project's view, but only assert it as the org baseline when ALL projects
+	// agree — an override on any project would otherwise be reported as the org's.
+	var sample map[string]any
+	var sampleProject string
+	uniform := true
+	if len(projs) > 0 {
+		sample = settingsView(generalSettings(prior, projs[0].Name))
+		sampleProject = projs[0].Name
+		for _, p := range projs[1:] {
+			v := settingsView(generalSettings(prior, p.Name))
+			for _, k := range orgInheritedSettings {
+				if v[k] != sample[k] {
+					uniform = false
+					break
+				}
+			}
+			if !uniform {
+				break
+			}
+		}
+	}
+	conn := entLoadData(prior, engine.CollectADOConnectionData(org))
+	rec := map[string]any{
+		"_id":                  org,
+		"kind":                 "Organization",
+		"org":                  org,
+		"sample_project":       sampleProject,
+		"org_settings_uniform": uniform, // if true, the flat settings are the org baseline
+		"org_provenance":       "unknown",
+		"projects_count":       len(projs),
+		"authenticated_user":   entObj(conn, "authenticatedUser"),
+		"_provenance":          prov(engine.CollectADOProjects(org), engine.CollectADOConnectionData(org)),
+	}
+	// The org has no generalsettings endpoint; attach the enforce/disable booleans
+	// flat from the (uniform) per-project effective values per schema §2.
+	mergeFlat(rec, orDefaultMap(sample))
+	return emit(cp, timer, engine.NormalizeADOOrg(org), rec)
+}
+
+func normalizeProject(prior engine.PriorPhase, cp engine.CurrentPhase, org string, p projectMeta, timer *engine.PhaseTimer) error {
+	detail := entLoadData(prior, engine.CollectADOProject(p.Name))
+	gs := generalSettings(prior, p.Name)
+	rec := map[string]any{
+		"_id":              org + "/" + p.Name,
+		"kind":             "Project",
+		"org":              org,
+		"project":          p.Name,
+		"id":               p.ID,
+		"visibility":       entStr(detail["visibility"]),
+		"process_template": entStr(entGetIn(detail, "capabilities", "processTemplate", "templateName")),
+		"_provenance":      prov(engine.CollectADOProject(p.Name), engine.CollectADOGeneralSettings(p.Name)),
+	}
+	// Schema §2: the job-auth/classic/fork settings sit flat on :Project (they
+	// override the org). deriveRunsAs reads limit_job_auth_scope_to_current_project.
+	mergeFlat(rec, settingsView(gs))
+	return emit(cp, timer, engine.NormalizeADOProject(p.Name), rec)
+}
+
+func normalizeRepos(prior engine.PriorPhase, cp engine.CurrentPhase, org string, p projectMeta, timer *engine.PhaseTimer) error {
+	for _, raw := range entLoadList(prior, engine.CollectADORepos(p.Name)) {
+		r := entMap(raw)
+		name := entStr(r["name"])
+		if name == "" {
+			continue
+		}
+		rec := map[string]any{
+			"_id":            org + "/" + p.Name + "/" + name,
+			"kind":           "Repository",
+			"project":        p.Name,
+			"id":             entStr(r["id"]),
+			"name":           name,
+			"default_branch": entStr(r["defaultBranch"]),
+			"is_disabled":    entBool(r["isDisabled"]),
+			"size":           entInt64(r["size"]),
+			// attributed by the policy-by-scope join (correlate)
+			"build_validation_policies": []any{},
+			"_provenance":               prov(engine.CollectADORepos(p.Name)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADORepo(p.Name, name), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// foldChecks projects the collected check configs onto a resource node.
+func foldChecks(prior engine.PriorPhase, project, rtype, id string) []any {
+	out := []any{}
+	for _, raw := range entLoadList(prior, engine.CollectADOChecks(project, rtype, id)) {
+		c := entMap(raw)
+		out = append(out, map[string]any{
+			"type_id":     entStr(entGetIn(c, "type", "id")),
+			"type_name":   entStr(entGetIn(c, "type", "name")),
+			"settings":    c["settings"],
+			"is_disabled": entBool(c["isDisabled"]),
+		})
+	}
+	return out
+}
+
+// foldAuthorization projects the pipeline-permissions object. A soft-failed
+// surface (collector wrote {_unobserved:status}) must NOT collapse to
+// all_pipelines:false — "unknown" is not "not granted". A present-but-absent
+// allPipelines key genuinely means no blanket grant.
+func foldAuthorization(prior engine.PriorPhase, project, rtype, id string) map[string]any {
+	d := entLoadData(prior, engine.CollectADOPipelinePerms(project, rtype, id))
+	if st, ok := d["_unobserved"]; ok {
+		return map[string]any{"observed": false, "unobserved_status": st, "all_pipelines": nil, "pipelines": []any{}, "authorized_pipelines": []any{}}
+	}
+	pipelines := entListOrEmpty(d["pipelines"])
+	authorized := []any{}
+	for _, raw := range pipelines {
+		p := entMap(raw)
+		if entBool(p["authorized"]) {
+			authorized = append(authorized, entInt64(p["id"]))
+		}
+	}
+	return map[string]any{
+		"observed":             true,
+		"all_pipelines":        entBool(entObj(d, "allPipelines")["authorized"]),
+		"pipelines":            pipelines,
+		"authorized_pipelines": authorized,
+	}
+}
+
+// resAgg accumulates one shared resource (service connection or variable group)
+// across every project it is visible in, so it collapses to a single owner-keyed
+// node with per-project authorization (which legitimately differs per consuming
+// project) retained. The static record is built from the owner's copy, not
+// whichever project happened to iterate first.
+type resAgg struct {
+	owner   string
+	seen    map[string]bool
+	perProj map[string]any
+	copies  map[string]map[string]any
+	order   []string // project collection order, for a deterministic owner-absent fallback
+}
+
+func newResAgg(owner string) *resAgg {
+	return &resAgg{owner: owner, seen: map[string]bool{}, perProj: map[string]any{}, copies: map[string]map[string]any{}}
+}
+
+// sourceCopy returns the owner's raw copy (the authoritative one) and the project
+// it came from, falling back deterministically to the first-collected copy when
+// the owner project was not itself collected.
+func (a *resAgg) sourceCopy() (map[string]any, string) {
+	if c := a.copies[a.owner]; c != nil {
+		return c, a.owner
+	}
+	for _, p := range a.order {
+		if c := a.copies[p]; c != nil {
+			return c, p
+		}
+	}
+	return map[string]any{}, a.owner
+}
+
+func normalizeServiceConnectionsShared(prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	byID := map[string]*resAgg{}
+	var order []string
+	for _, p := range projs {
+		for _, raw := range entLoadList(prior, engine.CollectADOServiceConnections(p.Name)) {
+			e := entMap(raw)
+			id := entStr(e["id"])
+			if id == "" {
+				continue
+			}
+			a := byID[id]
+			if a == nil {
+				a = newResAgg(ownerFromRefs(e["serviceEndpointProjectReferences"], p.Name))
+				byID[id] = a
+				order = append(order, id)
+			}
+			a.seen[p.Name] = true
+			a.order = append(a.order, p.Name)
+			a.copies[p.Name] = e
+			a.perProj[p.Name] = map[string]any{
+				"checks":               foldChecks(prior, p.Name, "endpoint", id),
+				"pipeline_permissions": foldAuthorization(prior, p.Name, "endpoint", id),
+			}
+		}
+	}
+	for _, id := range order {
+		a := byID[id]
+		src, srcProj := a.sourceCopy()
+		rec := serviceConnectionRec(src)
+		rec["_id"] = a.owner + "/" + id
+		rec["project"] = a.owner
+		rec["owner_project"] = a.owner
+		rec["owner_collected"] = a.copies[a.owner] != nil
+		rec["visible_in_projects"] = sortedStrSet(a.seen)
+		rec["shared_into"] = sharedInto(rec["project_references"], a.owner)
+		rec["per_project_authorization"] = a.perProj
+		auth := ownerAuth(a.perProj, a.owner, a.seen)
+		rec["checks"] = auth["checks"]
+		rec["pipeline_permissions"] = auth["pipeline_permissions"]
+		rec["_provenance"] = prov(engine.CollectADOServiceConnections(srcProj))
+		if err := emitWIFCredential(cp, timer, src, id, a.owner); err != nil {
+			return err
+		}
+		if err := emit(cp, timer, engine.NormalizeADOServiceConnection(a.owner, id), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func serviceConnectionRec(e map[string]any) map[string]any {
+	auth := entObj(e, "authorization")
+	params := entObj(auth, "parameters")
+	data := entObj(e, "data")
+	scheme := entStr(auth["scheme"])
+	return map[string]any{
+		"kind":                 "ServiceConnection",
+		"id":                   entStr(e["id"]),
+		"name":                 entStr(e["name"]),
+		"type":                 entStr(e["type"]),
+		"auth_scheme":          scheme,
+		"url":                  entStr(e["url"]),
+		"is_shared":            entBool(e["isShared"]),
+		"is_ready":             entBool(e["isReady"]),
+		"owner":                entStr(e["owner"]),
+		"scope":                entStr(data["scopeLevel"]),
+		"scope_level":          entStr(data["scopeLevel"]),
+		"creation_mode":        entStr(data["creationMode"]),
+		"subscription_id":      entStr(data["subscriptionId"]),
+		"subscription_name":    entStr(data["subscriptionName"]),
+		"tenant_id":            entStr(params["tenantid"]),
+		"service_principal_id": entStr(params["serviceprincipalid"]),
+		"project_references":   entListOrEmpty(e["serviceEndpointProjectReferences"]),
+		"is_wif":               scheme == "WorkloadIdentityFederation",
+	}
+}
+
+// emitWIFCredential emits a bare :WIFCredential + FEDERATES_TO once per WIF
+// connection (subject/issuer are server-generated, absent for manual).
+func emitWIFCredential(cp engine.CurrentPhase, timer *engine.PhaseTimer, e map[string]any, id, owner string) error {
+	params := entObj(entObj(e, "authorization"), "parameters")
+	if entStr(entObj(e, "authorization")["scheme"]) != "WorkloadIdentityFederation" {
+		return nil
+	}
+	spn := entStr(params["serviceprincipalid"])
+	subject := entStr(params["workloadIdentityFederationSubject"])
+	key := spn
+	if key == "" {
+		key = subject
+	}
+	wif := map[string]any{
+		"_id": id + "/" + key, "kind": "WIFCredential", "connection_id": id, "project": owner,
+		"app_registration_id": spn, "subject": strOrNull(subject),
+		"issuer":      strOrNull(entStr(params["workloadIdentityFederationIssuer"])),
+		"issuer_type": entStr(params["workloadIdentityFederationIssuerType"]),
+		"tenant_id":   entStr(params["tenantid"]),
+	}
+	if err := emit(cp, timer, engine.NormalizeADOWIFCredential(id, key), wif); err != nil {
+		return err
+	}
+	fed := map[string]any{"kind": "FEDERATES_TO", "project": owner, "connection_id": id,
+		"wif_credential_id": id + "/" + key, "app_registration_id": spn,
+		"subject": strOrNull(subject),
+		"issuer":  strOrNull(entStr(params["workloadIdentityFederationIssuer"]))}
+	return emit(cp, timer, engine.NormalizeADOEdges("federates-to", adoSafe(id)), fed)
+}
+
+func normalizeVariableGroupsShared(prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	byID := map[int64]*resAgg{}
+	var order []int64
+	for _, p := range projs {
+		for _, raw := range entLoadList(prior, engine.CollectADOVariableGroups(p.Name)) {
+			g := entMap(raw)
+			gid := entInt64(g["id"])
+			if gid == 0 {
+				continue
+			}
+			a := byID[gid]
+			if a == nil {
+				a = newResAgg(ownerFromRefs(g["variableGroupProjectReferences"], p.Name))
+				byID[gid] = a
+				order = append(order, gid)
+			}
+			a.seen[p.Name] = true
+			a.order = append(a.order, p.Name)
+			a.copies[p.Name] = g
+			idStr := fmt.Sprintf("%d", gid)
+			a.perProj[p.Name] = map[string]any{
+				"checks":               foldChecks(prior, p.Name, "variablegroup", idStr),
+				"pipeline_permissions": foldAuthorization(prior, p.Name, "variablegroup", idStr),
+			}
+		}
+	}
+	for _, gid := range order {
+		a := byID[gid]
+		src, srcProj := a.sourceCopy()
+		rec := variableGroupRec(src)
+		rec["_id"] = a.owner + "/" + fmt.Sprintf("%d", gid)
+		rec["project"] = a.owner
+		rec["owner_project"] = a.owner
+		rec["owner_collected"] = a.copies[a.owner] != nil
+		rec["visible_in_projects"] = sortedStrSet(a.seen)
+		rec["shared_into"] = sharedInto(rec["project_references"], a.owner)
+		rec["per_project_authorization"] = a.perProj
+		auth := ownerAuth(a.perProj, a.owner, a.seen)
+		rec["checks"] = auth["checks"]
+		rec["pipeline_permissions"] = auth["pipeline_permissions"]
+		rec["_provenance"] = prov(engine.CollectADOVariableGroups(srcProj))
+		if err := emitSecretVariables(cp, timer, src, gid, a.owner); err != nil {
+			return err
+		}
+		if err := emit(cp, timer, engine.NormalizeADOVariableGroup(a.owner, gid), rec); err != nil {
+			return err
+		}
+		if err := emitKeyVaultLink(cp, timer, rec, a.owner, gid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitKeyVaultLink materializes a :KeyVault node + LINKS_TO edge for an
+// AzureKeyVault-backed variable group (schema §; empty in estates with no KV VG).
+func emitKeyVaultLink(cp engine.CurrentPhase, timer *engine.PhaseTimer, rec map[string]any, owner string, gid int64) error {
+	if !mBool(rec, "is_linked_to_keyvault") {
+		return nil
+	}
+	vault := mStr(rec, "keyvault_name")
+	if vault == "" {
+		return nil
+	}
+	kv := map[string]any{
+		"_id": owner + "/" + vault, "kind": "KeyVault", "project": owner, "name": vault,
+		"service_connection_id": mStr(rec, "keyvault_service_connection_id"),
+	}
+	if err := emit(cp, timer, engine.NormalizeADOKeyVault(owner, vault), kv); err != nil {
+		return err
+	}
+	link := map[string]any{
+		"kind": "LINKS_TO", "project": owner, "variable_group_id": gid,
+		"keyvault_name": vault, "keyvault_id": owner + "/" + vault,
+		"service_connection_id": mStr(rec, "keyvault_service_connection_id"),
+	}
+	return emit(cp, timer, engine.NormalizeADOEdges("links-to", fmt.Sprintf("%s__%d", adoSafe(owner), gid)), link)
+}
+
+func variableGroupRec(g map[string]any) map[string]any {
+	vars := entObj(g, "variables")
+	secretNames := []any{}
+	varList := []any{}
+	for _, name := range sortedKeys(vars) {
+		isSecret := entBool(entObj(vars, name)["isSecret"])
+		varList = append(varList, map[string]any{"name": name, "is_secret": isSecret})
+		if isSecret {
+			secretNames = append(secretNames, name)
+		}
+	}
+	pd := entObj(g, "providerData")
+	return map[string]any{
+		"kind":                           "VariableGroup",
+		"id":                             entInt64(g["id"]),
+		"name":                           entStr(g["name"]),
+		"type":                           entStr(g["type"]),
+		"is_linked_to_keyvault":          entStr(g["type"]) == "AzureKeyVault",
+		"keyvault_name":                  entStr(pd["vault"]),
+		"keyvault_service_connection_id": entStr(pd["serviceEndpointId"]),
+		"variables":                      varList,
+		"secret_variable_names":          secretNames,
+		"project_references":             entListOrEmpty(g["variableGroupProjectReferences"]),
+	}
+}
+
+func emitSecretVariables(cp engine.CurrentPhase, timer *engine.PhaseTimer, g map[string]any, gid int64, owner string) error {
+	vars := entObj(g, "variables")
+	for _, name := range sortedKeys(vars) {
+		if !entBool(entObj(vars, name)["isSecret"]) {
+			continue
+		}
+		sv := map[string]any{
+			"_id": fmt.Sprintf("%d/%s", gid, name), "kind": "SecretVariable",
+			"group_id": gid, "project": owner, "name": name, "is_secret": true,
+		}
+		if err := emit(cp, timer, engine.NormalizeADOSecretVariable(gid, name), sv); err != nil {
+			return err
+		}
+		def := map[string]any{"kind": "DEFINES", "group_id": gid, "secret_name": name, "project": owner}
+		if err := emit(cp, timer, engine.NormalizeADOEdges("defines", fmt.Sprintf("%d__%s", gid, adoSafe(name))), def); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ownerFromRefs picks the owning project of a (possibly shared) resource: the
+// first project reference (ADO lists the owner first), else the collecting one.
+func ownerFromRefs(refs any, fallback string) string {
+	list, _ := refs.([]any)
+	if len(list) > 0 {
+		if n := entStr(entGetIn(entMap(list[0]), "projectReference", "name")); n != "" {
+			return n
+		}
+	}
+	return fallback
+}
+
+func sharedInto(refs any, owner string) []any {
+	out := []any{}
+	seen := map[string]bool{owner: true}
+	list, _ := refs.([]any)
+	for _, r := range list {
+		if n := entStr(entGetIn(entMap(r), "projectReference", "name")); n != "" && !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func sortedStrSet(m map[string]bool) []any {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]any, len(keys))
+	for i, k := range keys {
+		out[i] = k
+	}
+	return out
+}
+
+// ownerAuth returns the owner project's authorization/checks (the primary), or
+// any collected project's deterministically if the owner wasn't collected.
+func ownerAuth(perProj map[string]any, owner string, seen map[string]bool) map[string]any {
+	if a, ok := perProj[owner].(map[string]any); ok {
+		return a
+	}
+	for _, p := range sortedStrSet(seen) {
+		if a, ok := perProj[p.(string)].(map[string]any); ok {
+			return a
+		}
+	}
+	return map[string]any{"checks": []any{}, "pipeline_permissions": map[string]any{}}
+}
+
+// normalizeAgentQueues emits a :ProjectAgentPool per agent queue, folding its
+// checks + pipeline-authorization (queue resource type) and a REFERENCES_POOL
+// edge to the org-level pool.
+func normalizeAgentQueues(prior engine.PriorPhase, cp engine.CurrentPhase, org string, p projectMeta, timer *engine.PhaseTimer) error {
+	for _, raw := range entLoadList(prior, engine.CollectADOAgentQueues(p.Name)) {
+		q := entMap(raw)
+		qid := entInt64(q["id"])
+		if qid == 0 {
+			continue
+		}
+		idStr := fmt.Sprintf("%d", qid)
+		pool := entObj(q, "pool")
+		orgPool := entInt64(pool["id"])
+		rec := map[string]any{
+			"_id":                  fmt.Sprintf("%s/%d", p.Name, qid),
+			"kind":                 "ProjectAgentPool",
+			"project":              p.Name,
+			"id":                   qid,
+			"name":                 entStr(q["name"]),
+			"pool_id":              orgPool,
+			"is_hosted":            entBool(pool["isHosted"]),
+			"pool_type":            entStr(pool["poolType"]),
+			"checks":               foldChecks(prior, p.Name, "queue", idStr),
+			"pipeline_permissions": foldAuthorization(prior, p.Name, "queue", idStr),
+			"_provenance":          prov(engine.CollectADOAgentQueues(p.Name)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOProjectAgentPool(p.Name, qid), rec); err != nil {
+			return err
+		}
+		if orgPool != 0 {
+			ref := map[string]any{"kind": "REFERENCES_POOL", "project": p.Name, "queue_id": qid, "org_pool_id": orgPool}
+			if err := emit(cp, timer, engine.NormalizeADOEdges("references-pool", fmt.Sprintf("%s__%d", adoSafe(p.Name), qid)), ref); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeEnvironments(prior engine.PriorPhase, cp engine.CurrentPhase, org string, p projectMeta, timer *engine.PhaseTimer) error {
+	for _, raw := range entLoadList(prior, engine.CollectADOEnvironments(p.Name)) {
+		e := entMap(raw)
+		envID := entInt64(e["id"])
+		name := entStr(e["name"])
+		if name == "" {
+			continue
+		}
+		idStr := fmt.Sprintf("%d", envID)
+		detail := entLoadData(prior, engine.CollectADOEnvironmentDetail(p.Name, envID))
+		rec := map[string]any{
+			"_id":                  p.Name + "/" + name,
+			"kind":                 "Environment",
+			"project":              p.Name,
+			"id":                   envID,
+			"name":                 name,
+			"description":          entStr(e["description"]),
+			"resources":            entListOrEmpty(detail["resources"]),
+			"created_on":           entStr(detail["createdOn"]),
+			"created_by":           entStr(entGetIn(detail, "createdBy", "displayName")),
+			"last_modified_on":     entStr(detail["lastModifiedOn"]),
+			"checks":               foldChecks(prior, p.Name, "environment", idStr),
+			"pipeline_permissions": foldAuthorization(prior, p.Name, "environment", idStr),
+			"_provenance":          prov(engine.CollectADOEnvironments(p.Name)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOEnvironment(p.Name, name), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// policySettings maps raw REST camelCase branch-policy settings to the schema's
+// snake_case property names (reviewer + build-validation fields as a union; absent
+// keys serialize as zero-values, harmless to the rule that reads the other subtype).
+func policySettings(s map[string]any) map[string]any {
+	return map[string]any{
+		"minimum_approver_count":          entInt64(s["minimumApproverCount"]),
+		"creator_vote_counts":             entBool(s["creatorVoteCounts"]),
+		"allow_downvotes":                 entBool(s["allowDownvotes"]),
+		"reset_on_source_push":            entBool(s["resetOnSourcePush"]),
+		"reset_rejections_on_source_push": entBool(s["resetRejectionsOnSourcePush"]),
+		"block_last_pusher_vote":          entBool(s["blockLastPusherVote"]),
+		"require_vote_on_last_iteration":  entBool(s["requireVoteOnLastIteration"]),
+		"build_definition_id":             entInt64(s["buildDefinitionId"]),
+		"display_name":                    entStr(s["displayName"]),
+		"manual_queue_only":               entBool(s["manualQueueOnly"]),
+		"queue_on_source_update_only":     entBool(s["queueOnSourceUpdateOnly"]),
+		"valid_duration":                  entInt64(s["validDuration"]),
+		"filename_patterns":               entListOrEmpty(s["filenamePatterns"]),
+		"scope":                           entListOrEmpty(s["scope"]),
+	}
+}
+
+// policyTypeNames resolves policy type GUID -> display name from policy-types.
+func policyTypeNames(prior engine.PriorPhase, project string) map[string]string {
+	out := map[string]string{}
+	for _, raw := range entLoadList(prior, engine.CollectADOPolicyTypes(project)) {
+		t := entMap(raw)
+		if id, name := entStr(t["id"]), entStr(t["displayName"]); id != "" {
+			out[id] = name
+		}
+	}
+	return out
+}
+
+// normalizePolicies emits one BranchPolicy record per policy configuration
+// (scope[] preserved); repo/branch attribution is the policy-by-scope join.
+func normalizePolicies(prior engine.PriorPhase, cp engine.CurrentPhase, org string, p projectMeta, timer *engine.PhaseTimer) error {
+	types := policyTypeNames(prior, p.Name)
+	for _, raw := range entLoadList(prior, engine.CollectADOPolicies(p.Name)) {
+		c := entMap(raw)
+		cfgID := entInt64(c["id"])
+		typeID := entStr(entGetIn(c, "type", "id"))
+		typeName := types[typeID]
+		if typeName == "" {
+			typeName = entStr(entGetIn(c, "type", "displayName"))
+		}
+		rec := map[string]any{
+			"_id":         fmt.Sprintf("%s/%d", p.Name, cfgID),
+			"kind":        "BranchPolicy",
+			"project":     p.Name,
+			"config_id":   cfgID,
+			"policy_type": typeName,
+			"type_id":     typeID,
+			"is_enabled":  entBool(c["isEnabled"]),
+			"is_blocking": entBool(c["isBlocking"]),
+			"is_deleted":  entBool(c["isDeleted"]),
+			"scope":       entListOrEmpty(entGetIn(entObj(c, "settings"), "scope")),
+			"settings":    policySettings(entObj(c, "settings")),
+			"_provenance": prov(engine.CollectADOPolicies(p.Name)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOPolicy(p.Name, fmt.Sprintf("cfg-%d", cfgID), typeName), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeAgentPools(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer) error {
+	files, err := prior.IterJSON("00-collect/pools")
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		pool := entDataOf(f.Data)
+		id := entInt64(pool["id"])
+		if id == 0 {
+			continue
+		}
+		agents := []any{}
+		for _, raw := range entLoadList(prior, engine.CollectADOPoolAgents(id)) {
+			a := entMap(raw)
+			agents = append(agents, map[string]any{
+				"id":                  entInt64(a["id"]),
+				"name":                entStr(a["name"]),
+				"enabled":             entBool(a["enabled"]),
+				"status":              entStr(a["status"]),
+				"os_description":      entStr(a["osDescription"]),
+				"version":             entStr(a["version"]),
+				"system_capabilities": entObj(a, "systemCapabilities"),
+			})
+		}
+		elastic := entLoadData(prior, engine.CollectADOElasticPool(id))
+		rec := map[string]any{
+			"_id":            fmt.Sprintf("%d", id),
+			"kind":           "OrgAgentPool",
+			"id":             id,
+			"name":           entStr(pool["name"]),
+			"is_hosted":      entBool(pool["isHosted"]),
+			"pool_type":      entStr(pool["poolType"]),
+			"auto_provision": entBool(pool["autoProvision"]),
+			"auto_update":    entBool(pool["autoUpdate"]),
+			"size":           entInt64(pool["size"]),
+			"agents":         agents,
+			"elastic":        orDefaultMap(elastic),
+			"is_elastic":     elastic != nil,
+			"_provenance":    prov(engine.CollectADOPool(id)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOAgentPool(id), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func normalizeFeeds(prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	for _, raw := range entLoadList(prior, engine.CollectADOFeeds(org)) {
+		bundle := entMap(raw)
+		feed := entObj(bundle, "feed")
+		fid := entStr(feed["id"])
+		if fid == "" {
+			continue
+		}
+		rec := map[string]any{
+			"_id":              "org/" + fid,
+			"kind":             "ArtifactsFeed",
+			"scope":            "org",
+			"id":               fid,
+			"name":             entStr(feed["name"]),
+			"upstream_enabled": entBool(feed["upstreamEnabled"]),
+			"upstream_sources": entListOrEmpty(feed["upstreamSources"]),
+			"views":            entListOrEmpty(bundle["views"]),
+			"permissions":      entListOrEmpty(bundle["permissions"]),
+			"_provenance":      prov(engine.CollectADOFeeds(org)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOFeed("org", fid), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizePrincipals emits User / SecurityGroup / BuildServiceIdentity records
+// from the graph bundle. Build Service identities are users with domain "Build".
+func normalizePrincipals(prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	graph := entLoadData(prior, engine.CollectADOGraph(org))
+	if graph == nil {
+		return nil
+	}
+	for _, raw := range entListOrEmpty(graph["users"]) {
+		u := entMap(raw)
+		desc := entStr(u["descriptor"])
+		if desc == "" {
+			continue
+		}
+		if entStr(u["domain"]) == "Build" {
+			rec := principalRecord("BuildServiceIdentity", org, u)
+			if err := emit(cp, timer, engine.NormalizeADOPrincipal("build-service", desc), rec); err != nil {
+				return err
+			}
+			continue
+		}
+		rec := principalRecord("User", org, u)
+		if err := emit(cp, timer, engine.NormalizeADOPrincipal("users", desc), rec); err != nil {
+			return err
+		}
+	}
+	for _, raw := range entListOrEmpty(graph["groups"]) {
+		g := entMap(raw)
+		desc := entStr(g["descriptor"])
+		if desc == "" {
+			continue
+		}
+		rec := principalRecord("SecurityGroup", org, g)
+		if err := emit(cp, timer, engine.NormalizeADOPrincipal("groups", desc), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func principalRecord(kind, org string, m map[string]any) map[string]any {
+	return map[string]any{
+		"_id":            entStr(m["descriptor"]),
+		"kind":           kind,
+		"org":            org,
+		"descriptor":     entStr(m["descriptor"]),
+		"principal_name": entStr(m["principalName"]),
+		"display_name":   entStr(m["displayName"]),
+		"mail_address":   entStr(m["mailAddress"]),
+		"origin":         entStr(m["origin"]),
+		"origin_id":      entStr(m["originId"]),
+		"domain":         entStr(m["domain"]),
+		"subject_kind":   entStr(m["subjectKind"]),
+	}
+}
+
+func orDefaultMap(m map[string]any) map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	return m
+}

--- a/internal/ado/normalize_extra.go
+++ b/internal/ado/normalize_extra.go
@@ -1,0 +1,119 @@
+package ado
+
+import (
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// pipelineDecoratorContribution is the contribution type an extension declares to
+// inject steps into every pipeline run — the org-wide code-injection surface.
+const pipelineDecoratorContribution = "ms.azure-pipelines.pipeline-decorator"
+
+// normalizeExtensions emits an :Extension node per installed extension and, when
+// an extension contributes a pipeline decorator, a :PipelineDecorator node + an
+// INSTALLS edge (schema §; cat-07/03, cat-12/04).
+func normalizeExtensions(prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	// The installedextensions surface stores the raw {count,value} envelope.
+	data := entLoadData(prior, engine.CollectADOExtensions(org))
+	for _, raw := range entListOrEmpty(data["value"]) {
+		e := entMap(raw)
+		pub, ext := entStr(e["publisherId"]), entStr(e["extensionId"])
+		if pub == "" || ext == "" {
+			continue
+		}
+		id := pub + "." + ext
+		flags := entStr(entGetIn(e, "installState", "flags"))
+		var decorator bool
+		contribs := []any{}
+		for _, c := range entListOrEmpty(e["contributions"]) {
+			ctype := entStr(entMap(c)["type"])
+			contribs = append(contribs, map[string]any{"id": entStr(entMap(c)["id"]), "type": ctype})
+			if ctype == pipelineDecoratorContribution {
+				decorator = true
+			}
+		}
+		rec := map[string]any{
+			"_id": id, "kind": "Extension", "org": org,
+			"publisher_id": pub, "publisher_name": entStr(e["publisherName"]),
+			"extension_id": ext, "extension_name": entStr(e["extensionName"]),
+			"version":                             entStr(e["version"]),
+			"scopes":                              entListOrEmpty(e["scopes"]),
+			"is_builtin":                          strings.Contains(flags, "builtIn"),
+			"is_trusted":                          strings.Contains(flags, "trusted"),
+			"auto_update":                         strings.Contains(flags, "autoUpdate"),
+			"org_installed":                       true,
+			"has_pipeline_decorator_contribution": decorator,
+			"contributions":                       contribs,
+			"_provenance":                         prov(engine.CollectADOExtensions(org)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOExtension(id), rec); err != nil {
+			return err
+		}
+		if decorator {
+			deco := map[string]any{
+				"_id": id + "/decorator", "kind": "PipelineDecorator", "org": org,
+				"extension_id": id, "publisher_id": pub, "scopes": entListOrEmpty(e["scopes"]),
+			}
+			if err := emit(cp, timer, engine.NormalizeADOEdges("installs", adoSafe(id)), map[string]any{
+				"kind": "INSTALLS", "org": org, "extension_id": id, "decorator_id": id + "/decorator",
+			}); err != nil {
+				return err
+			}
+			if err := emit(cp, timer, engine.NormalizeADOExtension(id+"__decorator"), deco); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// normalizeSecureFiles emits a :SecureFile node per collected secure file with its
+// folded checks + pipeline permissions (schema §; cat-03/05). Empty in estates
+// with no secure files.
+func normalizeSecureFiles(prior engine.PriorPhase, cp engine.CurrentPhase, org string, p projectMeta, timer *engine.PhaseTimer) error {
+	for _, raw := range entLoadList(prior, engine.CollectADOSecureFiles(p.Name)) {
+		f := entMap(raw)
+		id := entStr(f["id"])
+		if id == "" {
+			continue
+		}
+		rec := map[string]any{
+			"_id": p.Name + "/" + id, "kind": "SecureFile", "project": p.Name,
+			"id": id, "name": entStr(f["name"]),
+			"checks":               foldChecks(prior, p.Name, "securefile", id),
+			"pipeline_permissions": foldAuthorization(prior, p.Name, "securefile", id),
+			"_provenance":          prov(engine.CollectADOSecureFiles(p.Name)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOSecureFile(p.Name, id), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeServiceHooks emits a :ServiceHookSubscription node per subscription
+// (schema §; cat-07/10). Empty in estates with no hooks.
+func normalizeServiceHooks(prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	for _, raw := range entLoadList(prior, engine.CollectADOServiceHooks(org)) {
+		s := entMap(raw)
+		id := entStr(s["id"])
+		if id == "" {
+			continue
+		}
+		cons := entObj(s, "consumerInputs")
+		rec := map[string]any{
+			"_id": id, "kind": "ServiceHookSubscription", "org": org,
+			"id": id, "consumer_id": entStr(s["consumerId"]), "consumer_action_id": entStr(s["consumerActionId"]),
+			"event_type": entStr(s["eventType"]), "publisher_id": entStr(s["publisherId"]),
+			"status":      entStr(s["status"]),
+			"url":         entStr(cons["url"]),
+			"project":     entStr(entGetIn(s, "publisherInputs", "projectId")),
+			"_provenance": prov(engine.CollectADOServiceHooks(org)),
+		}
+		if err := emit(cp, timer, engine.NormalizeADOServiceHook(id), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/ado/normalize_pipeline.go
+++ b/internal/ado/normalize_pipeline.go
@@ -1,0 +1,545 @@
+package ado
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// scInputNames is the registry of task-input keys whose value is a service
+// connection reference (a structural USES_CONNECTION signal).
+var scInputNames = []string{
+	"azureSubscription", "connectedServiceName", "connectedServiceNameARM", "ConnectedServiceName",
+	"connectedServiceNameAzureRM", "azureSubscriptionEndpoint", "azureResourceManagerConnection",
+	"containerRegistry", "dockerRegistryServiceConnection", "azureContainerRegistry",
+	"kubernetesServiceConnection", "awsCredentials", "serviceConnection", "externalEndpoint", "externalEndpoints",
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// normalizePipelines builds a Pipeline node per build definition and, for YAML
+// pipelines, parses the entry YAML into Stage/Job records carrying the
+// structural facts (service-connection usages, checkout, task refs, variable
+// groups, environment targets, pool). Taint facts (macro/echo/script/ai sinks)
+// are a later pass.
+func normalizePipelines(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer) error {
+	files, err := prior.IterJSON("00-collect/build-definition")
+	if err != nil {
+		return err
+	}
+	settingsCache := map[string]map[string]any{}
+	for _, f := range files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		def := entDataOf(f.Data)
+		if def == nil {
+			continue
+		}
+		project := entStr(entGetIn(def, "project", "name"))
+		id := entInt64(def["id"])
+		if project == "" || id == 0 {
+			timer.Errors = append(timer.Errors, fmt.Sprintf("pipeline %s: missing project/id", f.Rel))
+			continue
+		}
+		process := entObj(def, "process")
+		processType := entInt64(process["type"]) // 2=YAML, 1=classic/designer
+		repo := entObj(def, "repository")
+
+		gs, ok := settingsCache[project]
+		if !ok {
+			gs = settingsView(generalSettings(prior, project))
+			settingsCache[project] = gs
+		}
+		requested := entStr(def["jobAuthorizationScope"])
+		effective, identityScope, provenance := clampScope(requested, mBool(gs, "limit_job_auth_scope_to_current_project"), mBool(gs, "settings_observed"))
+		// Project the project-effective posture flags a pipeline-subject rule needs
+		// directly onto the node so it is reachable without a project join (cat-02).
+		enableShellSanitize := mBool(gs, "enable_shell_tasks_args_sanitizing")
+		enforceSettableVar := mBool(gs, "enforce_settable_var")
+
+		pipe := map[string]any{
+			"_id":                     fmt.Sprintf("%s/%d", project, id),
+			"kind":                    "Pipeline",
+			"project":                 project,
+			"id":                      id,
+			"name":                    entStr(def["name"]),
+			"yaml_path":               entStr(process["yamlFilename"]),
+			"settings_source_type":    sourceType(processType),
+			"queue_status":            entStr(def["queueStatus"]),
+			"job_authorization_scope": requested,
+			// schema §: the resolved Build Service identity scope lives on the node
+			"effective_scope":    effective,
+			"identity_scope":     identityScope,
+			"enforce_provenance": provenance,
+			"repository": map[string]any{
+				"id":             entStr(repo["id"]),
+				"name":           entStr(repo["name"]),
+				"type":           entStr(repo["type"]),
+				"default_branch": entStr(repo["defaultBranch"]),
+			},
+			"triggers":    entListOrEmpty(def["triggers"]),
+			"variables":   normalizePipelineVars(entObj(def, "variables")),
+			"_provenance": prov(engine.CollectADOBuildDefFull(project, id)),
+		}
+
+		facts := pipelineYAMLFacts{}
+		if processType == 2 && strings.EqualFold(entStr(repo["type"]), "TfsGit") {
+			content := entryYAML(prior, project, id, repo, entStr(process["yamlFilename"]))
+			if content != "" {
+				facts, err = parsePipelineYAML(cp, timer, project, id, content)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		pipe["extends_template"] = strOrNull(facts.extendsTemplate)
+		pipe["extends_source"] = facts.extendsSource // resolved template source repo/ref (nil if none)
+		pipe["template_sources"] = entListOrEmpty(facts.templateSources)
+		pipe["variable_groups"] = toAnyList(facts.variableGroups) // pipeline-level declarations
+		pipe["parameters"] = entListOrEmpty(facts.parameters)     // runtime params (freeform = cat-02 surface)
+		pipe["ci_trigger"] = facts.ciTrigger                      // nil=implicit, "none"=disabled, else filter
+		pipe["pr_trigger"] = facts.prTrigger
+		pipe["enable_shell_tasks_args_sanitizing"] = enableShellSanitize
+		pipe["enforce_settable_var"] = enforceSettableVar
+
+		if err := emit(cp, timer, engine.NormalizeADOPipeline(project, id), pipe); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sourceType(t int64) string {
+	if t == 1 {
+		return "designer"
+	}
+	return "yaml"
+}
+
+func strOrNull(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// normalizePipelineVars projects definition variables; allowOverride absent =>
+// false (ADO omits it when false).
+func normalizePipelineVars(vars map[string]any) []any {
+	out := []any{}
+	for _, name := range sortedKeys(vars) {
+		vm := entMap(vars[name])
+		out = append(out, map[string]any{
+			"name":           name,
+			"is_secret":      entBool(vm["isSecret"]),
+			"allow_override": entBool(vm["allowOverride"]),
+		})
+	}
+	return out
+}
+
+// entryYAML reconstructs the entry-YAML filename the collector wrote (repoID@
+// branch__yamlFilename) and returns its content, or "" if absent.
+func entryYAML(prior engine.PriorPhase, project string, id int64, repo map[string]any, yamlFilename string) string {
+	repoID := entStr(repo["id"])
+	branch := stripRef(entStr(repo["defaultBranch"]))
+	if branch == "" {
+		branch = "main"
+	}
+	name := fmt.Sprintf("%s@%s__%s", repoID, branch, yamlFilename)
+	d := entLoadData(prior, engine.CollectADOPipelineYAML(project, id, name))
+	return entStr(d["content"])
+}
+
+// pipelineYAMLFacts are the root-level facts a caller stamps onto the :Pipeline
+// node: the extends-template reference, the pipeline-level variable groups, and
+// the CI/PR trigger declarations (nil = absent/implicit; "none" = explicitly off).
+type pipelineYAMLFacts struct {
+	extendsTemplate string
+	extendsSource   map[string]any // resolved source repo/ref of the extends template
+	templateSources []any          // all resources.repositories, resolved (cat-08 surface)
+	variableGroups  []string
+	parameters      []any // runtime parameters (queue-time settable; freeform = injectable)
+	ciTrigger       any
+	prTrigger       any
+}
+
+// normalizeParameters projects the YAML root `parameters:` declarations. A
+// string/number/object parameter with no `values:` allowlist is freeform — the
+// queue-time-settable injection surface (cat-02).
+func normalizeParameters(v any) []any {
+	out := []any{}
+	list, ok := v.([]any)
+	if !ok {
+		return out
+	}
+	for _, raw := range list {
+		pm, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := yamlStr(pm["name"])
+		if name == "" {
+			continue
+		}
+		ptype := yamlStr(pm["type"])
+		if ptype == "" {
+			ptype = "string" // ADO defaults an untyped parameter to string
+		}
+		values, _ := pm["values"].([]any)
+		hasAllowlist := len(values) > 0
+		freeform := !hasAllowlist && (ptype == "string" || ptype == "object" || ptype == "number")
+		out = append(out, map[string]any{
+			"name":                 name,
+			"type":                 ptype,
+			"default":              pm["default"],
+			"values":               entListOrEmpty(pm["values"]),
+			"has_values_allowlist": hasAllowlist,
+			"is_freeform":          freeform,
+		})
+	}
+	return out
+}
+
+// resolveTemplateSources parses resources.repositories into resolved external
+// template-source refs, flagging cross-project and default-branch (unpinned)
+// sources — the writable/poisoned-template surface (cat-08). An empty ref means
+// the source floats on its default branch (mutable).
+func resolveTemplateSources(root map[string]any, pipelineProject string) (list []any, byAlias map[string]map[string]any) {
+	list, byAlias = []any{}, map[string]map[string]any{}
+	repos, ok := entGetIn(root, "resources", "repositories").([]any)
+	if !ok {
+		return list, byAlias
+	}
+	for _, raw := range repos {
+		rm, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		alias := yamlStr(rm["repository"])
+		name := yamlStr(rm["name"])
+		ref := yamlStr(rm["ref"])
+		rtype := yamlStr(rm["type"])
+		srcProject, repoName := splitRepoName(name, pipelineProject)
+		entry := map[string]any{
+			"alias": alias, "name": name, "type": rtype,
+			"source_project": srcProject, "repository": repoName,
+			"ref": ref, "ref_pinned": ref != "",
+			"is_cross_project": rtype == "git" && srcProject != "" && srcProject != pipelineProject,
+			"endpoint":         yamlStr(rm["endpoint"]),
+		}
+		list = append(list, entry)
+		if alias != "" {
+			byAlias[alias] = entry
+		}
+	}
+	return list, byAlias
+}
+
+// splitRepoName splits an Azure Repos "Project/Repo" name into its parts; a bare
+// "Repo" is same-project (the pipeline's project).
+func splitRepoName(name, dfltProject string) (project, repo string) {
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		return name[:i], name[i+1:]
+	}
+	return dfltProject, name
+}
+
+// parsePipelineYAML walks the entry pipeline, emits Stage/Job nodes + the
+// TRIGGERS_ON_COMPLETION edges, and returns the root-level facts. Variable groups
+// are NOT merged down levels — each of Pipeline/Stage/Job carries only what it
+// declares, so the CONSUMES_GROUP level (schema) is recoverable.
+func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, content string) (pipelineYAMLFacts, error) {
+	var root map[string]any
+	if err := yaml.Unmarshal([]byte(content), &root); err != nil {
+		timer.Errors = append(timer.Errors, fmt.Sprintf("pipeline %s/%d: yaml parse: %v", project, pipelineID, err))
+		return pipelineYAMLFacts{}, nil // a bad YAML doc is per-item non-fatal
+	}
+	facts := pipelineYAMLFacts{
+		variableGroups: variableGroups(root["variables"]),
+		parameters:     normalizeParameters(root["parameters"]),
+		ciTrigger:      root["trigger"],
+		prTrigger:      root["pr"],
+	}
+	if err := emitPipelineResources(cp, timer, project, pipelineID, root); err != nil {
+		return facts, err
+	}
+	pipelinePool := root["pool"]
+
+	tsList, tsByAlias := resolveTemplateSources(root, project)
+	facts.templateSources = tsList
+	switch ext := root["extends"].(type) {
+	case map[string]any:
+		facts.extendsTemplate = yamlStr(ext["template"]) // jobs live in the template (deferred pass)
+	case string:
+		facts.extendsTemplate = ext
+	}
+	if facts.extendsTemplate != "" {
+		if alias := splitTemplateRef(facts.extendsTemplate).alias; alias != "" {
+			facts.extendsSource = tsByAlias[alias]
+		}
+	}
+	if root["extends"] != nil {
+		return facts, nil // jobs live in the template (deferred pass)
+	}
+
+	if stages, ok := root["stages"].([]any); ok {
+		for i, s := range stages {
+			sm, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			stageName := firstStr(sm, "stage", fmt.Sprintf("stage_%d", i))
+			if err := emitStageJobs(cp, timer, project, pipelineID, stageName, sm, pipelinePool); err != nil {
+				return facts, err
+			}
+		}
+		return facts, nil
+	}
+	// implicit single stage: root plays pipeline+stage+job. The pipeline-level
+	// groups are stamped on the Pipeline node by the caller; the Stage/Job here
+	// carry only their own (here: none extra), so no level is double-counted.
+	return facts, emitStageJobs(cp, timer, project, pipelineID, "__default", root, pipelinePool)
+}
+
+// emitPipelineResources emits a TRIGGERS_ON_COMPLETION edge per resources.pipelines
+// entry (a pipeline-completion trigger — the trigger-laundering surface, cat-11).
+func emitPipelineResources(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, root map[string]any) error {
+	pipes, ok := entGetIn(root, "resources", "pipelines").([]any)
+	if !ok {
+		return nil
+	}
+	for i, raw := range pipes {
+		rm, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		alias := yamlStr(rm["pipeline"])
+		rec := map[string]any{
+			"kind": "TRIGGERS_ON_COMPLETION", "project": project, "pipeline_id": pipelineID,
+			"alias": alias, "source_pipeline": yamlStr(rm["source"]), "source_project": yamlStr(rm["project"]),
+			"trigger": rm["trigger"], "branches": rm["branches"], "tags": rm["tags"], "stages": rm["stages"],
+		}
+		key := fmt.Sprintf("%s__%d__%s", adoSafe(project), pipelineID, adoSafe(firstStr(rm, "pipeline", fmt.Sprintf("res_%d", i))))
+		if err := emit(cp, timer, engine.NormalizeADOEdges("triggers-on-completion", key), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage string, m map[string]any, inheritedPool any) error {
+	stagePool := m["pool"]
+	if stagePool == nil {
+		stagePool = inheritedPool
+	}
+
+	stageRec := map[string]any{
+		"_id":             fmt.Sprintf("%d/%s", pipelineID, stage),
+		"kind":            "Stage",
+		"project":         project,
+		"pipeline_id":     pipelineID,
+		"stage":           stage,
+		"condition":       yamlStr(m["condition"]),
+		"depends_on":      stringsOf(m["dependsOn"]),
+		"variable_groups": toAnyList(variableGroups(m["variables"])), // stage-level declarations only
+		"environment":     strOrNull(yamlStr(m["environment"])),      // stage-level env (deployment stages carry it on jobs)
+		"_provenance":     prov(engine.CollectADOBuildDefFull(project, pipelineID)),
+	}
+	if err := emit(cp, timer, engine.NormalizeADOStage(project, pipelineID, stage), stageRec); err != nil {
+		return err
+	}
+
+	jobs, ok := m["jobs"].([]any)
+	if !ok {
+		return emitJob(cp, timer, project, pipelineID, stage, "__default", m, stagePool)
+	}
+	for i, j := range jobs {
+		jm, ok := j.(map[string]any)
+		if !ok {
+			continue
+		}
+		jobName := firstStr(jm, "job", firstStr(jm, "deployment", fmt.Sprintf("job_%d", i)))
+		if err := emitJob(cp, timer, project, pipelineID, stage, jobName, jm, stagePool); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func emitJob(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage, job string, m map[string]any, inheritedPool any) error {
+	steps := collectSteps(m)
+	scUsages, checkouts, taskRefs := walkSteps(steps)
+	jobPool := m["pool"]
+	if jobPool == nil {
+		jobPool = inheritedPool
+	}
+
+	rec := map[string]any{
+		"_id":                       fmt.Sprintf("%d/%s/%s", pipelineID, stage, job),
+		"kind":                      "Job",
+		"project":                   project,
+		"pipeline_id":               pipelineID,
+		"stage":                     stage,
+		"job":                       job,
+		"is_deployment":             m["deployment"] != nil,
+		"condition":                 yamlStr(m["condition"]),
+		"depends_on":                stringsOf(m["dependsOn"]),
+		"pool":                      normalizePool(jobPool),
+		"variable_groups":           toAnyList(variableGroups(m["variables"])), // job-level declarations only
+		"targets_environment":       strOrNull(jobEnvironment(m)),
+		"service_connection_usages": scUsages,
+		"checkout_steps":            checkouts,
+		"task_usages":               taskRefs,
+		"_provenance":               prov(engine.CollectADOBuildDefFull(project, pipelineID)),
+	}
+	return emit(cp, timer, engine.NormalizeADOJob(project, pipelineID, stage, job), rec)
+}
+
+// collectSteps returns the step list from a job/deployment strategy.
+func collectSteps(m map[string]any) []any {
+	if s, ok := m["steps"].([]any); ok {
+		return s
+	}
+	// deployment jobs nest steps under strategy.runOnce/rolling.deploy.steps
+	strat := entMap(m["strategy"])
+	for _, kind := range []string{"runOnce", "rolling", "canary"} {
+		phase := entMap(strat[kind])
+		if dep := entMap(phase["deploy"]); dep != nil {
+			if s, ok := dep["steps"].([]any); ok {
+				return s
+			}
+		}
+	}
+	return nil
+}
+
+func walkSteps(steps []any) (scUsages, checkouts, taskRefs []any) {
+	scUsages, checkouts, taskRefs = []any{}, []any{}, []any{}
+	for i, s := range steps {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ck, ok := sm["checkout"]; ok {
+			checkouts = append(checkouts, map[string]any{
+				"repository":          yamlStr(ck),
+				"clean":               sm["clean"],
+				"fetch_depth":         sm["fetchDepth"],
+				"persist_credentials": sm["persistCredentials"],
+				"submodules":          sm["submodules"],
+				"step_index":          i,
+			})
+			continue
+		}
+		task := yamlStr(sm["task"])
+		if task == "" {
+			continue
+		}
+		inputs := entMap(sm["inputs"])
+		taskRefs = append(taskRefs, map[string]any{"task": task, "step_index": i})
+		for _, inputName := range scInputNames {
+			if conn := yamlStr(inputs[inputName]); conn != "" {
+				scUsages = append(scUsages, map[string]any{
+					"task":            task,
+					"input_name":      inputName,
+					"connection_name": conn,
+					"step_index":      i,
+				})
+			}
+		}
+	}
+	return
+}
+
+func normalizePool(v any) map[string]any {
+	switch p := v.(type) {
+	case string:
+		return map[string]any{"name": p}
+	case map[string]any:
+		return map[string]any{
+			"name":     yamlStr(p["name"]),
+			"vm_image": yamlStr(p["vmImage"]),
+			"demands":  entListOrEmpty(p["demands"]),
+		}
+	}
+	return map[string]any{}
+}
+
+// variableGroups returns the names in a `variables:` block's `- group:` entries.
+func variableGroups(v any) []string {
+	var out []string
+	list, ok := v.([]any)
+	if !ok {
+		return out
+	}
+	for _, e := range list {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if g := yamlStr(em["group"]); g != "" {
+			out = append(out, g)
+		}
+	}
+	return out
+}
+
+func jobEnvironment(m map[string]any) string {
+	switch e := m["environment"].(type) {
+	case string:
+		return e
+	case map[string]any:
+		return yamlStr(e["name"])
+	}
+	return ""
+}
+
+// ---- small YAML helpers ----
+
+func yamlStr(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func firstStr(m map[string]any, key, dflt string) string {
+	if s := yamlStr(m[key]); s != "" {
+		return s
+	}
+	return dflt
+}
+
+func stringsOf(v any) []any {
+	switch x := v.(type) {
+	case string:
+		return []any{x}
+	case []any:
+		return x
+	}
+	return []any{}
+}
+
+func toAnyList(ss []string) []any {
+	out := make([]any, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, s)
+	}
+	return out
+}
+
+func adoSafe(s string) string {
+	return strings.NewReplacer("/", "-", " ", "-").Replace(s)
+}

--- a/internal/ado/normalize_pipeline.go
+++ b/internal/ado/normalize_pipeline.go
@@ -3,6 +3,7 @@ package ado
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -95,11 +96,12 @@ func normalizePipelines(ctx context.Context, prior engine.PriorPhase, cp engine.
 			"_provenance": prov(engine.CollectADOBuildDefFull(project, id)),
 		}
 
+		settable := settableVarSet(entObj(def, "variables"))
 		facts := pipelineYAMLFacts{}
 		if processType == 2 && strings.EqualFold(entStr(repo["type"]), "TfsGit") {
 			content := entryYAML(prior, project, id, repo, entStr(process["yamlFilename"]))
 			if content != "" {
-				facts, err = parsePipelineYAML(cp, timer, project, id, content)
+				facts, err = parsePipelineYAML(cp, timer, project, id, content, settable)
 				if err != nil {
 					return err
 				}
@@ -114,6 +116,11 @@ func normalizePipelines(ctx context.Context, prior engine.PriorPhase, cp engine.
 		pipe["pr_trigger"] = facts.prTrigger
 		pipe["enable_shell_tasks_args_sanitizing"] = enableShellSanitize
 		pipe["enforce_settable_var"] = enforceSettableVar
+		// settable_variables: the YAML `settableVariables:` restriction (nil = all
+		// vars overridable; [] = none). The per-definition allowOverride names are
+		// the settable surface when the org/project limit is enforced (cat-02 gate).
+		pipe["settable_variables"] = facts.settableVariables
+		pipe["definition_settable_variables"] = sortedSet(settable)
 
 		if err := emit(cp, timer, engine.NormalizeADOPipeline(project, id), pipe); err != nil {
 			return err
@@ -168,13 +175,14 @@ func entryYAML(prior engine.PriorPhase, project string, id int64, repo map[strin
 // node: the extends-template reference, the pipeline-level variable groups, and
 // the CI/PR trigger declarations (nil = absent/implicit; "none" = explicitly off).
 type pipelineYAMLFacts struct {
-	extendsTemplate string
-	extendsSource   map[string]any // resolved source repo/ref of the extends template
-	templateSources []any          // all resources.repositories, resolved (cat-08 surface)
-	variableGroups  []string
-	parameters      []any // runtime parameters (queue-time settable; freeform = injectable)
-	ciTrigger       any
-	prTrigger       any
+	extendsTemplate   string
+	extendsSource     map[string]any // resolved source repo/ref of the extends template
+	templateSources   []any          // all resources.repositories, resolved (cat-08 surface)
+	variableGroups    []string
+	parameters        []any // runtime parameters (queue-time settable; freeform = injectable)
+	ciTrigger         any
+	prTrigger         any
+	settableVariables any // YAML root `settableVariables:` (nil = all overridable, [] = none)
 }
 
 // normalizeParameters projects the YAML root `parameters:` declarations. A
@@ -262,17 +270,18 @@ func splitRepoName(name, dfltProject string) (project, repo string) {
 // TRIGGERS_ON_COMPLETION edges, and returns the root-level facts. Variable groups
 // are NOT merged down levels — each of Pipeline/Stage/Job carries only what it
 // declares, so the CONSUMES_GROUP level (schema) is recoverable.
-func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, content string) (pipelineYAMLFacts, error) {
+func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, content string, settable map[string]bool) (pipelineYAMLFacts, error) {
 	var root map[string]any
 	if err := yaml.Unmarshal([]byte(content), &root); err != nil {
 		timer.Errors = append(timer.Errors, fmt.Sprintf("pipeline %s/%d: yaml parse: %v", project, pipelineID, err))
 		return pipelineYAMLFacts{}, nil // a bad YAML doc is per-item non-fatal
 	}
 	facts := pipelineYAMLFacts{
-		variableGroups: variableGroups(root["variables"]),
-		parameters:     normalizeParameters(root["parameters"]),
-		ciTrigger:      root["trigger"],
-		prTrigger:      root["pr"],
+		variableGroups:    variableGroups(root["variables"]),
+		parameters:        normalizeParameters(root["parameters"]),
+		ciTrigger:         root["trigger"],
+		prTrigger:         root["pr"],
+		settableVariables: settableVariablesOf(root["variables"]),
 	}
 	if err := emitPipelineResources(cp, timer, project, pipelineID, root); err != nil {
 		return facts, err
@@ -302,17 +311,22 @@ func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project
 			if !ok {
 				continue
 			}
+			if sm["template"] != nil && sm["stage"] == nil {
+				continue // stage-template reference — expanded in the deferred template pass
+			}
 			stageName := firstStr(sm, "stage", fmt.Sprintf("stage_%d", i))
-			if err := emitStageJobs(cp, timer, project, pipelineID, stageName, sm, pipelinePool); err != nil {
+			if err := emitStageJobs(cp, timer, project, pipelineID, stageName, sm, pipelinePool, settable); err != nil {
 				return facts, err
 			}
 		}
 		return facts, nil
 	}
 	// implicit single stage: root plays pipeline+stage+job. The pipeline-level
-	// groups are stamped on the Pipeline node by the caller; the Stage/Job here
-	// carry only their own (here: none extra), so no level is double-counted.
-	return facts, emitStageJobs(cp, timer, project, pipelineID, "__default", root, pipelinePool)
+	// variable groups are already stamped on the Pipeline node by the caller, so
+	// strip them from the map before it stands in for the Stage/Job — otherwise the
+	// same declaration is counted at every level (duplicate CONSUMES_GROUP edges).
+	delete(root, "variables")
+	return facts, emitStageJobs(cp, timer, project, pipelineID, "__default", root, pipelinePool, settable)
 }
 
 // emitPipelineResources emits a TRIGGERS_ON_COMPLETION edge per resources.pipelines
@@ -341,7 +355,7 @@ func emitPipelineResources(cp engine.CurrentPhase, timer *engine.PhaseTimer, pro
 	return nil
 }
 
-func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage string, m map[string]any, inheritedPool any) error {
+func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage string, m map[string]any, inheritedPool any, settable map[string]bool) error {
 	stagePool := m["pool"]
 	if stagePool == nil {
 		stagePool = inheritedPool
@@ -365,84 +379,158 @@ func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project str
 
 	jobs, ok := m["jobs"].([]any)
 	if !ok {
-		return emitJob(cp, timer, project, pipelineID, stage, "__default", m, stagePool)
+		return emitJob(cp, timer, project, pipelineID, stage, "__default", m, stagePool, settable)
 	}
 	for i, j := range jobs {
 		jm, ok := j.(map[string]any)
 		if !ok {
 			continue
 		}
+		if jm["template"] != nil && jm["job"] == nil && jm["deployment"] == nil {
+			continue // job-template reference — expanded in the deferred template pass
+		}
 		jobName := firstStr(jm, "job", firstStr(jm, "deployment", fmt.Sprintf("job_%d", i)))
-		if err := emitJob(cp, timer, project, pipelineID, stage, jobName, jm, stagePool); err != nil {
+		if err := emitJob(cp, timer, project, pipelineID, stage, jobName, jm, stagePool, settable); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func emitJob(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage, job string, m map[string]any, inheritedPool any) error {
-	steps := collectSteps(m)
-	scUsages, checkouts, taskRefs := walkSteps(steps)
+func emitJob(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage, job string, m map[string]any, inheritedPool any, settable map[string]bool) error {
 	jobPool := m["pool"]
 	if jobPool == nil {
 		jobPool = inheritedPool
 	}
+	// a per-job YAML settableVariables list adds to the queue-time-settable surface
+	// used for is_declared_settable annotation on macro sinks.
+	if extra := settableVariablesOf(m["variables"]); extra != nil {
+		settable = mergeSettable(settable, extra)
+	}
+
+	f := walkSteps(collectSteps(m), settable)
+	// compile-time keyword sinks: a runtime parameter / runtime-expression selecting
+	// pool or container steers the execution target/identity (cat-02 redirect).
+	scanCompileKeyword(&f, "pool", poolExpr(jobPool), -1, "")
+	scanCompileKeyword(&f, "container", yamlStr(m["container"]), -1, "")
 
 	rec := map[string]any{
-		"_id":                       fmt.Sprintf("%d/%s/%s", pipelineID, stage, job),
-		"kind":                      "Job",
-		"project":                   project,
-		"pipeline_id":               pipelineID,
-		"stage":                     stage,
-		"job":                       job,
-		"is_deployment":             m["deployment"] != nil,
-		"condition":                 yamlStr(m["condition"]),
-		"depends_on":                stringsOf(m["dependsOn"]),
-		"pool":                      normalizePool(jobPool),
-		"variable_groups":           toAnyList(variableGroups(m["variables"])), // job-level declarations only
-		"targets_environment":       strOrNull(jobEnvironment(m)),
-		"service_connection_usages": scUsages,
-		"checkout_steps":            checkouts,
-		"task_usages":               taskRefs,
-		"_provenance":               prov(engine.CollectADOBuildDefFull(project, pipelineID)),
+		"_id":                         fmt.Sprintf("%d/%s/%s", pipelineID, stage, job),
+		"kind":                        "Job",
+		"project":                     project,
+		"pipeline_id":                 pipelineID,
+		"stage":                       stage,
+		"job":                         job,
+		"is_deployment":               m["deployment"] != nil,
+		"condition":                   yamlStr(m["condition"]),
+		"depends_on":                  stringsOf(m["dependsOn"]),
+		"pool":                        normalizePool(jobPool),
+		"variable_groups":             toAnyList(variableGroups(m["variables"])), // job-level declarations only
+		"targets_environment":         strOrNull(jobEnvironment(m)),
+		"service_connection_usages":   f.scUsages,
+		"checkout_steps":              f.checkouts,
+		"task_usages":                 f.taskUsages,
+		"script_bodies":               f.scriptBodies,
+		"macro_sinks":                 f.macroSinks,
+		"parameter_sinks":             f.paramSinks,
+		"vso_echo_sources":            f.vsoEchoSources,
+		"ai_task_sinks":               f.aiTaskSinks,
+		"variable_consumers":          f.varConsumers,
+		"bare_binary_calls":           f.bareBinaries,
+		"cred_writes":                 f.credWrites,
+		"exec_sinks":                  f.execSinks,
+		"executes_checked_out_code":   f.executesCheckedOutCode,
+		"exposes_system_access_token": f.referencesAccessToken,
+		"_provenance":                 prov(engine.CollectADOBuildDefFull(project, pipelineID)),
 	}
 	return emit(cp, timer, engine.NormalizeADOJob(project, pipelineID, stage, job), rec)
 }
 
-// collectSteps returns the step list from a job/deployment strategy.
+// collectSteps returns the step list from a job/deployment strategy. Deployment
+// jobs nest steps under every lifecycle hook (not just deploy) — preDeploy/
+// routeTraffic/postRouteTraffic and on.failure/on.success can each consume a
+// service connection or run a task, so all hooks are gathered in execution order.
 func collectSteps(m map[string]any) []any {
 	if s, ok := m["steps"].([]any); ok {
 		return s
 	}
-	// deployment jobs nest steps under strategy.runOnce/rolling.deploy.steps
+	var out []any
 	strat := entMap(m["strategy"])
 	for _, kind := range []string{"runOnce", "rolling", "canary"} {
 		phase := entMap(strat[kind])
-		if dep := entMap(phase["deploy"]); dep != nil {
-			if s, ok := dep["steps"].([]any); ok {
-				return s
+		for _, hook := range []string{"preDeploy", "deploy", "routeTraffic", "postRouteTraffic"} {
+			if s, ok := entMap(phase[hook])["steps"].([]any); ok {
+				out = append(out, s...)
+			}
+		}
+		on := entMap(phase["on"])
+		for _, hook := range []string{"failure", "success"} {
+			if s, ok := entMap(on[hook])["steps"].([]any); ok {
+				out = append(out, s...)
 			}
 		}
 	}
-	return nil
+	return out
 }
 
-func walkSteps(steps []any) (scUsages, checkouts, taskRefs []any) {
-	scUsages, checkouts, taskRefs = []any{}, []any{}, []any{}
+// jobFacts collects the security-relevant step facts collapsed onto a :Job — the
+// structural usages plus the taint-pass sinks/sources the derived attack edges
+// (correlate) key on. All slices stay non-nil so empties serialize as [].
+type jobFacts struct {
+	scUsages               []any
+	checkouts              []any
+	taskUsages             []any
+	scriptBodies           []any
+	macroSinks             []any
+	paramSinks             []any
+	vsoEchoSources         []any
+	aiTaskSinks            []any
+	varConsumers           []any
+	bareBinaries           []any
+	credWrites             []any
+	execSinks              []any
+	executesCheckedOutCode bool
+	referencesAccessToken  bool
+}
+
+func newJobFacts() jobFacts {
+	return jobFacts{
+		scUsages: []any{}, checkouts: []any{}, taskUsages: []any{}, scriptBodies: []any{},
+		macroSinks: []any{}, paramSinks: []any{}, vsoEchoSources: []any{}, aiTaskSinks: []any{},
+		varConsumers: []any{}, bareBinaries: []any{}, credWrites: []any{}, execSinks: []any{},
+	}
+}
+
+func walkSteps(steps []any, settable map[string]bool) jobFacts {
+	f := newJobFacts()
 	for i, s := range steps {
 		sm, ok := s.(map[string]any)
 		if !ok {
 			continue
 		}
 		if ck, ok := sm["checkout"]; ok {
-			checkouts = append(checkouts, map[string]any{
-				"repository":          yamlStr(ck),
-				"clean":               sm["clean"],
-				"fetch_depth":         sm["fetchDepth"],
-				"persist_credentials": sm["persistCredentials"],
-				"submodules":          sm["submodules"],
-				"step_index":          i,
+			f.checkouts = append(f.checkouts, map[string]any{
+				"repository": yamlStr(ck), "clean": sm["clean"], "fetch_depth": sm["fetchDepth"],
+				"persist_credentials": sm["persistCredentials"], "submodules": sm["submodules"], "step_index": i,
 			})
+			scanCompileKeyword(&f, "checkout", yamlStr(ck), i, "")
+			continue
+		}
+		if cond := yamlStr(sm["condition"]); cond != "" {
+			for _, name := range conditionVars(cond) {
+				f.varConsumers = append(f.varConsumers, map[string]any{"name": name, "step_index": i, "via": "condition"})
+			}
+		}
+		f.scanEnv(entMap(sm["env"]))
+
+		matched := false
+		for _, key := range []string{"script", "bash", "powershell", "pwsh"} {
+			if body := yamlStr(sm[key]); body != "" {
+				f.scanScriptBody(shorthandShells[key], body, i, "", settable)
+				matched = true
+			}
+		}
+		if matched {
 			continue
 		}
 		task := yamlStr(sm["task"])
@@ -450,19 +538,129 @@ func walkSteps(steps []any) (scUsages, checkouts, taskRefs []any) {
 			continue
 		}
 		inputs := entMap(sm["inputs"])
-		taskRefs = append(taskRefs, map[string]any{"task": task, "step_index": i})
+		f.taskUsages = append(f.taskUsages, taskUsageRec(task, i))
 		for _, inputName := range scInputNames {
 			if conn := yamlStr(inputs[inputName]); conn != "" {
-				scUsages = append(scUsages, map[string]any{
-					"task":            task,
-					"input_name":      inputName,
-					"connection_name": conn,
-					"step_index":      i,
+				f.scUsages = append(f.scUsages, map[string]any{
+					"task": task, "input_name": inputName, "connection_name": conn, "step_index": i,
 				})
 			}
 		}
+		if file, ok := credWritingTasks[task]; ok {
+			f.credWrites = append(f.credWrites, map[string]any{"task": task, "step_index": i, "file": file})
+		}
+		if matchesAITask(task) {
+			f.aiTaskSinks = append(f.aiTaskSinks, aiTaskRec(task, inputs, i))
+		}
+		et, isExecutor := executorTasks[task]
+		if isExecutor {
+			for _, in := range et.scriptInputs {
+				if body := yamlStr(inputs[in]); body != "" {
+					f.scanScriptBody(et.shell, body, i, task, settable)
+				}
+			}
+			for _, in := range et.argInputs {
+				if arg := yamlStr(inputs[in]); arg != "" {
+					f.scanArgs(arg, i, task, settable)
+				}
+			}
+		}
+		for _, in := range sortedKeys(inputs) {
+			if isExecutor && (slices.Contains(et.scriptInputs, in) || slices.Contains(et.argInputs, in)) {
+				continue
+			}
+			if val := yamlStr(inputs[in]); val != "" {
+				f.scanTaskInput(val, in, i, task, settable)
+			}
+		}
 	}
-	return
+	return f
+}
+
+func (f *jobFacts) scanScriptBody(shell, body string, stepIdx int, task string, settable map[string]bool) {
+	f.scriptBodies = append(f.scriptBodies, map[string]any{"content": body, "shell": shell, "step_index": stepIdx})
+	for _, name := range macroNames(body) {
+		if macroKind(name) == "system" {
+			continue
+		}
+		f.macroSinks = append(f.macroSinks, macroSinkRec(name, "script", task, stepIdx, settable))
+		f.varConsumers = append(f.varConsumers, map[string]any{"name": name, "step_index": stepIdx, "via": "macro"})
+	}
+	for _, p := range paramNames(body) {
+		f.paramSinks = append(f.paramSinks, paramSinkRec(p, "script", "", task, stepIdx))
+	}
+	if name, isExec := classifyExecSink(body); isExec {
+		f.execSinks = append(f.execSinks, map[string]any{"name": name, "step_index": stepIdx})
+		f.executesCheckedOutCode = true
+	}
+	for _, bin := range bareBinaryCalls(body) {
+		f.bareBinaries = append(f.bareBinaries, map[string]any{"bin": bin, "step_index": stepIdx})
+	}
+	if matchesAICLI(body) {
+		f.aiTaskSinks = append(f.aiTaskSinks, map[string]any{
+			"task_id": "cli", "vendor": aiVendor(body), "capabilities": aiCapabilities(body),
+			"inputs": map[string]any{}, "source": "script", "step_index": stepIdx,
+		})
+	}
+	if strings.Contains(strings.ToLower(body), "system.accesstoken") {
+		f.referencesAccessToken = true
+	}
+	if src, ok := untrustedEcho(body); ok {
+		f.vsoEchoSources = append(f.vsoEchoSources, map[string]any{
+			"untrusted_source": src, "echo_mechanism": echoMechanism(shell), "step_index": stepIdx,
+			"has_literal_vso": reVsoLit.MatchString(body),
+		})
+	}
+}
+
+func (f *jobFacts) scanArgs(arg string, stepIdx int, task string, settable map[string]bool) {
+	for _, name := range macroNames(arg) {
+		if macroKind(name) == "system" {
+			continue
+		}
+		f.macroSinks = append(f.macroSinks, macroSinkRec(name, "task_input", task, stepIdx, settable))
+		f.varConsumers = append(f.varConsumers, map[string]any{"name": name, "step_index": stepIdx, "via": "macro"})
+	}
+	for _, p := range paramNames(arg) {
+		f.paramSinks = append(f.paramSinks, paramSinkRec(p, "task_input", "arguments", task, stepIdx))
+	}
+}
+
+func (f *jobFacts) scanTaskInput(val, inputName string, stepIdx int, task string, settable map[string]bool) {
+	for _, name := range macroNames(val) {
+		if macroKind(name) == "system" {
+			continue
+		}
+		f.macroSinks = append(f.macroSinks, macroSinkRec(name, "task_input", task, stepIdx, settable))
+	}
+	for _, p := range paramNames(val) {
+		loc := "task_input"
+		if isCompileKeywordInput(inputName) {
+			loc = "compile_keyword" // param selects the identity/target (input_target_redirect)
+		}
+		f.paramSinks = append(f.paramSinks, paramSinkRec(p, loc, inputName, task, stepIdx))
+	}
+}
+
+func (f *jobFacts) scanEnv(env map[string]any) {
+	for _, k := range sortedKeys(env) {
+		if strings.Contains(strings.ToLower(yamlStr(env[k])), "system.accesstoken") {
+			f.referencesAccessToken = true
+		}
+	}
+}
+
+// scanCompileKeyword records parameter/runtime-expression expansion into a
+// compile-time keyword (pool/container/checkout) — the target-redirect surface.
+// `$(macro)` does not expand in compile keywords, so only ${{ }}/$[ ] and
+// predefined-untrusted references count.
+func scanCompileKeyword(f *jobFacts, keyword, val string, stepIdx int, task string) {
+	if val == "" {
+		return
+	}
+	for _, p := range paramNames(val) {
+		f.paramSinks = append(f.paramSinks, paramSinkRec(p, "compile_keyword", keyword, task, stepIdx))
+	}
 }
 
 func normalizePool(v any) map[string]any {

--- a/internal/ado/normalize_test.go
+++ b/internal/ado/normalize_test.go
@@ -1,0 +1,344 @@
+package ado
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+func writeCollect(t *testing.T, dir, rel string, data any) {
+	t.Helper()
+	if err := engine.WriteJSON(filepath.Join(dir, rel), map[string]any{"_meta": map[string]any{}, "data": data}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A service connection shared into a second project must collapse to ONE
+// canonical node (keyed under the owner) that retains per-project authorization.
+func TestServiceConnectionDedup(t *testing.T) {
+	dir := t.TempDir()
+	cp, prior := engineCP(dir), engine.PriorPhase{RunDir: dir}
+	ref := func(n string) any { return map[string]any{"projectReference": map[string]any{"name": n}} }
+	sc := map[string]any{
+		"id": "conn-1", "name": "shared-sc", "type": "generic", "isShared": true,
+		"authorization":                    map[string]any{"scheme": "Token", "parameters": map[string]any{}},
+		"data":                             map[string]any{},
+		"serviceEndpointProjectReferences": []any{ref("Owner"), ref("ConsumerB")}, // owner listed first
+	}
+	writeCollect(t, dir, engine.CollectADOServiceConnections("Owner"), []any{sc})
+	writeCollect(t, dir, engine.CollectADOServiceConnections("ConsumerB"), []any{sc})
+
+	projs := []projectMeta{{ID: "o", Name: "Owner"}, {ID: "b", Name: "ConsumerB"}}
+	if err := normalizeServiceConnectionsShared(prior, cp, "org", projs, normTimer()); err != nil {
+		t.Fatal(err)
+	}
+	files, _ := filepath.Glob(filepath.Join(dir, "10-normalize/service-connections/*.json"))
+	if len(files) != 1 {
+		t.Fatalf("want 1 deduped node, got %d: %v", len(files), files)
+	}
+	rec := readRec(t, dir, engine.NormalizeADOServiceConnection("Owner", "conn-1"))
+	if rec["owner_project"] != "Owner" {
+		t.Errorf("owner_project = %v", rec["owner_project"])
+	}
+	ppa, _ := rec["per_project_authorization"].(map[string]any)
+	if _, ok := ppa["Owner"]; !ok {
+		t.Error("per_project_authorization missing Owner")
+	}
+	if _, ok := ppa["ConsumerB"]; !ok {
+		t.Error("per_project_authorization missing ConsumerB (shared-into project)")
+	}
+	if si, _ := rec["shared_into"].([]any); len(si) != 1 || si[0] != "ConsumerB" {
+		t.Errorf("shared_into = %v, want [ConsumerB]", rec["shared_into"])
+	}
+	// resolution: the connection is referable by name from BOTH projects
+	vp := map[string]bool{}
+	for _, p := range visibleProjects(rec) {
+		vp[p] = true
+	}
+	if !vp["Owner"] || !vp["ConsumerB"] {
+		t.Errorf("visibleProjects = %v, want Owner+ConsumerB", visibleProjects(rec))
+	}
+}
+
+// The VG dedup path mirrors the SC one. ADO does not currently permit
+// cross-project VG sharing (the endpoint returns "Sharing of variable group is
+// not allowed"), so this exercises the collapse logic against synthetic shared
+// input the same way TestServiceConnectionDedup does — proving the machinery is
+// correct if such data ever appears.
+func TestVariableGroupDedup(t *testing.T) {
+	dir := t.TempDir()
+	cp, prior := engineCP(dir), engine.PriorPhase{RunDir: dir}
+	ref := func(n string) any { return map[string]any{"projectReference": map[string]any{"name": n}} }
+	vg := map[string]any{
+		"id": float64(42), "name": "shared-vg", "type": "Vsts",
+		"variables":                      map[string]any{"TOKEN": map[string]any{"isSecret": true}},
+		"variableGroupProjectReferences": []any{ref("Owner"), ref("ConsumerB")},
+	}
+	writeCollect(t, dir, engine.CollectADOVariableGroups("Owner"), []any{vg})
+	writeCollect(t, dir, engine.CollectADOVariableGroups("ConsumerB"), []any{vg})
+
+	projs := []projectMeta{{ID: "o", Name: "Owner"}, {ID: "b", Name: "ConsumerB"}}
+	if err := normalizeVariableGroupsShared(prior, cp, "org", projs, normTimer()); err != nil {
+		t.Fatal(err)
+	}
+	files, _ := filepath.Glob(filepath.Join(dir, "10-normalize/variable-groups/*.json"))
+	if len(files) != 1 {
+		t.Fatalf("want 1 deduped VG node, got %d: %v", len(files), files)
+	}
+	rec := readRec(t, dir, engine.NormalizeADOVariableGroup("Owner", 42))
+	if rec["owner_project"] != "Owner" || rec["owner_collected"] != true {
+		t.Errorf("owner fields wrong: %v", rec)
+	}
+	ppa, _ := rec["per_project_authorization"].(map[string]any)
+	if _, ok := ppa["Owner"]; !ok {
+		t.Error("per_project_authorization missing Owner")
+	}
+	if _, ok := ppa["ConsumerB"]; !ok {
+		t.Error("per_project_authorization missing ConsumerB")
+	}
+	if si, _ := rec["shared_into"].([]any); len(si) != 1 || si[0] != "ConsumerB" {
+		t.Errorf("shared_into = %v, want [ConsumerB]", rec["shared_into"])
+	}
+	// the secret variable folds out to its own node + DEFINES edge
+	if _, err := filepath.Glob(filepath.Join(dir, "10-normalize/secret-variables/*.json")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ownerAuth returns the owner's authorization, or the deterministic
+// first-collected project's when the owner project was not itself collected.
+func TestOwnerAuthFallback(t *testing.T) {
+	ownerA := map[string]any{"checks": []any{"owner-check"}}
+	consB := map[string]any{"checks": []any{"b-check"}}
+	consC := map[string]any{"checks": []any{"c-check"}}
+
+	perProj := map[string]any{"Owner": ownerA, "ConsumerB": consB}
+	if got := ownerAuth(perProj, "Owner", map[string]bool{"Owner": true, "ConsumerB": true}); got["checks"].([]any)[0] != "owner-check" {
+		t.Errorf("owner present: got %v, want owner-check", got)
+	}
+	// owner not collected: fall back to the first (sorted) collected project.
+	perProj2 := map[string]any{"ConsumerC": consC, "ConsumerB": consB}
+	if got := ownerAuth(perProj2, "Owner", map[string]bool{"ConsumerC": true, "ConsumerB": true}); got["checks"].([]any)[0] != "b-check" {
+		t.Errorf("owner absent: got %v, want b-check (ConsumerB sorts first)", got)
+	}
+	if got := ownerAuth(map[string]any{}, "Owner", map[string]bool{}); got["pipeline_permissions"] == nil {
+		t.Errorf("empty default should carry pipeline_permissions: %v", got)
+	}
+}
+
+// TARGETS resolves a resource-scoped environment ("env.resource") to the
+// Environment node; RUNS_ON resolves a named pool to its ProjectAgentPool.
+func TestTargetsRunsOnResolution(t *testing.T) {
+	dir := t.TempDir()
+	cp, prior := engineCP(dir), engine.PriorPhase{RunDir: dir}
+	write := func(rel string, rec any) {
+		if err := engine.WriteJSON(filepath.Join(dir, rel), rec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(engine.NormalizeADOEnvironment("Mordor", "prod"), map[string]any{"project": "Mordor", "id": float64(5), "name": "prod"})
+	write(engine.NormalizeADOProjectAgentPool("Gondor", 12), map[string]any{"project": "Gondor", "id": float64(12), "name": "SelfHosted"})
+
+	jobs := []map[string]any{
+		{"project": "Mordor", "pipeline_id": float64(1), "stage": "deploy", "job": "ship", "targets_environment": "prod.bookings"},
+		{"project": "Gondor", "pipeline_id": float64(2), "stage": "build", "job": "b", "pool": map[string]any{"name": "SelfHosted"}},
+		{"project": "Gondor", "pipeline_id": float64(3), "stage": "build", "job": "h", "pool": map[string]any{"vm_image": "ubuntu-latest"}},
+	}
+	if err := deriveJobResourceEdges(prior, cp, normTimer(), jobs); err != nil {
+		t.Fatal(err)
+	}
+	tf, _ := filepath.Glob(filepath.Join(dir, "10-normalize/edges/targets/*.json"))
+	if len(tf) != 1 {
+		t.Fatalf("want 1 targets edge, got %d", len(tf))
+	}
+	var tgt map[string]any
+	if err := engine.ReadJSON(tf[0], &tgt); err != nil {
+		t.Fatal(err)
+	}
+	if tgt["environment"] != "prod" || tgt["resource"] != "bookings" || tgt["resolved"] != true || int64(tgt["environment_id"].(float64)) != 5 {
+		t.Errorf("targets resolution wrong: %v", tgt)
+	}
+	named := readRunsOn(t, dir, "Gondor", 2, "build", "b")
+	if named["pool_name"] != "SelfHosted" || named["resolved"] != true || int64(named["project_agent_pool_id"].(float64)) != 12 {
+		t.Errorf("named pool RUNS_ON not resolved: %v", named)
+	}
+	hosted := readRunsOn(t, dir, "Gondor", 3, "build", "h")
+	if hosted["is_hosted"] != true || hosted["resolved"] != false {
+		t.Errorf("vmImage pool should be hosted/unresolved: %v", hosted)
+	}
+}
+
+func readRunsOn(t *testing.T, dir, project string, pipelineID int64, stage, job string) map[string]any {
+	t.Helper()
+	key := fmt.Sprintf("%s__%d__%s__%s", project, pipelineID, stage, job)
+	return readRec(t, dir, engine.NormalizeADOEdges("runs-on", key))
+}
+
+func normTimer() *engine.PhaseTimer { return engine.StartPhaseTimer(engine.PhaseNormalize, "test") }
+
+func readRec(t *testing.T, dir, rel string) map[string]any {
+	t.Helper()
+	var rec map[string]any
+	if err := engine.ReadJSON(dir+"/"+rel, &rec); err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	return rec
+}
+
+// JOIN #1: the job-auth clamp. projectCollection is clamped to project when the
+// project enforces; passes through otherwise.
+func TestDeriveRunsAs_Clamp(t *testing.T) {
+	cp := engineCP(t.TempDir())
+	pipelines := []map[string]any{
+		{"id": float64(189), "project": "Gondor", "job_authorization_scope": "projectCollection"},
+		{"id": float64(200), "project": "Rohan", "job_authorization_scope": "projectCollection"},
+	}
+	pipelines = append(pipelines, map[string]any{"id": float64(300), "project": "Mirkwood", "job_authorization_scope": "projectCollection"})
+	projectsRec := []map[string]any{
+		{"project": "Gondor", "limit_job_auth_scope_to_current_project": true, "settings_observed": true},
+		{"project": "Rohan", "limit_job_auth_scope_to_current_project": false, "settings_observed": true},
+		// Mirkwood's general-settings soft-failed: enforcement is unobserved.
+		{"project": "Mirkwood", "limit_job_auth_scope_to_current_project": false, "settings_observed": false},
+	}
+	if err := deriveRunsAs(cp, normTimer(), pipelines, projectsRec); err != nil {
+		t.Fatal(err)
+	}
+	enforced := readRec(t, cp.RunDir, engine.NormalizeADOEdges("runs-as", "Gondor__189"))
+	if enforced["effective_scope"] != "project" || enforced["identity_scope"] != "project" {
+		t.Errorf("enforced pipeline not clamped: %v", enforced)
+	}
+	if enforced["enforce_provenance"] != "observed" {
+		t.Errorf("observed enforcement mis-tagged: %v", enforced["enforce_provenance"])
+	}
+	free := readRec(t, cp.RunDir, engine.NormalizeADOEdges("runs-as", "Rohan__200"))
+	if free["effective_scope"] != "projectCollection" || free["identity_scope"] != "collection" {
+		t.Errorf("unenforced pipeline wrongly clamped: %v", free)
+	}
+	// unobserved enforcement must fail CLOSED (clamp to project), not read false.
+	unk := readRec(t, cp.RunDir, engine.NormalizeADOEdges("runs-as", "Mirkwood__300"))
+	if unk["effective_scope"] != "project" || unk["identity_scope"] != "project" {
+		t.Errorf("unobserved enforcement failed open (should clamp to project): %v", unk)
+	}
+	if unk["enforce_provenance"] != "unknown" || unk["enforced_by_project"] != false {
+		t.Errorf("unobserved clamp mis-tagged: %v", unk)
+	}
+}
+
+// effectiveAllowMask: a PRESENT effectiveAllow of 0 is a real deny; only an
+// ABSENT effectiveAllow falls back to the local allow bits.
+func TestEffectiveAllowMask(t *testing.T) {
+	denied := map[string]any{"allow": float64(7), "extendedInfo": map[string]any{"effectiveAllow": float64(0)}}
+	if m := effectiveAllowMask(denied); m != 0 {
+		t.Errorf("present effectiveAllow=0 should deny (0), got %d", m)
+	}
+	absent := map[string]any{"allow": float64(7), "extendedInfo": map[string]any{}}
+	if m := effectiveAllowMask(absent); m != 7 {
+		t.Errorf("absent effectiveAllow should fall back to allow=7, got %d", m)
+	}
+	granted := map[string]any{"allow": float64(1), "extendedInfo": map[string]any{"effectiveAllow": float64(5)}}
+	if m := effectiveAllowMask(granted); m != 5 {
+		t.Errorf("present effectiveAllow=5 should win over allow=1, got %d", m)
+	}
+}
+
+// JOIN #2: policy-by-scope. A repositoryId scope attributes to that repo only; a
+// null repositoryId attributes to every repo in the project.
+func TestDerivePolicyAttribution(t *testing.T) {
+	cp := engineCP(t.TempDir())
+	repos := []map[string]any{
+		{"project": "P", "id": "repo-A", "name": "A"},
+		{"project": "P", "id": "repo-B", "name": "B"},
+	}
+	policies := []map[string]any{
+		{"project": "P", "config_id": float64(1), "policy_type": "Build", "is_blocking": true,
+			"settings": map[string]any{"buildDefinitionId": float64(247)},
+			"scope":    []any{map[string]any{"repositoryId": "repo-A", "refName": "refs/heads/main", "matchKind": "Exact"}}},
+		{"project": "P", "config_id": float64(2), "policy_type": "Minimum number of reviewers",
+			"scope": []any{map[string]any{"repositoryId": nil, "refName": "refs/heads/main", "matchKind": "Exact"}}},
+		// a Prefix-scoped policy protecting the whole refs/heads/release/* subtree
+		{"project": "P", "config_id": float64(3), "policy_type": "Build",
+			"scope": []any{map[string]any{"repositoryId": "repo-A", "refName": "refs/heads/release", "matchKind": "Prefix"}}},
+	}
+	if err := derivePolicyAttribution(cp, normTimer(), policies, repos); err != nil {
+		t.Fatal(err)
+	}
+	// repo-scoped policy → only repo A; config_id present on both records
+	a := readRec(t, cp.RunDir, engine.NormalizeADOEdges("has-policy", "P__A__1__refs-heads-main__Exact__repo-A"))
+	if a["repo"] != "A" || a["policy_type"] != "Build" || a["project_wide"] != false || a["is_prefix"] != false {
+		t.Errorf("repo-scoped attribution wrong: %v", a)
+	}
+	bv := readRec(t, cp.RunDir, engine.NormalizeADOEdges("build-validates", "P__A__1__refs-heads-main__Exact__repo-A"))
+	if int64(bv["build_definition_id"].(float64)) != 247 || int64(bv["config_id"].(float64)) != 1 {
+		t.Errorf("build-validates edge wrong: %v", bv)
+	}
+	// project-wide policy → both repos, keyed with the "all" scope discriminator
+	for _, r := range []string{"A", "B"} {
+		rec := readRec(t, cp.RunDir, engine.NormalizeADOEdges("has-policy", "P__"+r+"__2__refs-heads-main__Exact__all"))
+		if rec["project_wide"] != true {
+			t.Errorf("project-wide attribution missing for repo %s: %v", r, rec)
+		}
+	}
+	// Prefix scope → is_prefix true, match_kind Prefix
+	pre := readRec(t, cp.RunDir, engine.NormalizeADOEdges("has-policy", "P__A__3__refs-heads-release__Prefix__repo-A"))
+	if pre["is_prefix"] != true || pre["match_kind"] != "Prefix" {
+		t.Errorf("prefix attribution wrong: %v", pre)
+	}
+}
+
+// JOIN #3: effectiveAllow bit-decode (sorted, deterministic) + the SID bridge
+// that translates ACL identity descriptors to graph descriptors so nested-group
+// expansion actually resolves against real-shaped data.
+func TestDecodeActions(t *testing.T) {
+	actions := map[int64]string{1: "ViewBuilds", 128: "QueueBuilds", 32768: "CreateBuildDefinition", 2048: "EditBuildDefinition"}
+	got := decodeActions(1|128|32768, actions)
+	want := []any{"CreateBuildDefinition", "QueueBuilds", "ViewBuilds"} // sorted
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Errorf("decodeActions = %v, want sorted %v", got, want)
+	}
+}
+
+func TestSIDBridgeAndExpand(t *testing.T) {
+	// A graph group descriptor base64-encodes the SID the ACL ACE references.
+	sid := "S-1-9-1551374245-1032024721-2055204681-2363593361-0-0-0-1-2"
+	gdesc := "vssgp." + base64.RawStdEncoding.EncodeToString([]byte(sid))
+	if got := decodeGraphSID(gdesc); got != sid {
+		t.Fatalf("decodeGraphSID = %q, want %q", got, sid)
+	}
+	// A build-service graph user descriptor base64url-encodes "<org>:Build:<guid>",
+	// exactly the id a ServiceIdentity ACE references.
+	svcInner := "acfa0224-cf5c-4ffc-a9ed-df7dfbda07f2:Build:ab33fd1e-fa76-441d-be28-1dff80b1c239"
+	svcDesc := "svc." + base64.RawURLEncoding.EncodeToString([]byte(svcInner))
+	if got := decodeSubjectDescriptor(svcDesc); got != svcInner {
+		t.Fatalf("decodeSubjectDescriptor = %q, want %q", got, svcInner)
+	}
+	idIndex := map[string]string{sid: gdesc, svcInner: svcDesc}
+
+	// group-form ACE (TeamFoundation.Identity;S-1-…) bridges to the group desc
+	if got := aceGraphDescriptor("Microsoft.TeamFoundation.Identity;"+sid, idIndex); got != gdesc {
+		t.Fatalf("aceGraphDescriptor(group) = %q, want %q", got, gdesc)
+	}
+	// ServiceIdentity ACE bridges to the emitted svc. build-service node — the
+	// principal node exists, so this must resolve (was previously dropped).
+	if got := aceGraphDescriptor("Microsoft.TeamFoundation.ServiceIdentity;"+svcInner, idIndex); got != svcDesc {
+		t.Fatalf("aceGraphDescriptor(service identity) = %q, want %q", got, svcDesc)
+	}
+	// a built-in server SID not present in the graph resolves to "" (unexpanded).
+	if got := aceGraphDescriptor("Microsoft.TeamFoundation.Identity;S-1-9-0-0-0-0-0", idIndex); got != "" {
+		t.Fatalf("aceGraphDescriptor(unknown) = %q, want empty", got)
+	}
+
+	// group → {subgroup, user1}; subgroup → {user2}; cycle back must not loop.
+	sub, u1, u2 := "vssgp.SUB", "aad.U1", "aad.U2"
+	memberships := map[string][]string{gdesc: {sub, u1}, sub: {u2, gdesc}}
+	leaves := expandMembers(gdesc, memberships)
+	if len(leaves) != 2 || leaves[0] != u1 || leaves[1] != u2 { // sorted leaves
+		t.Fatalf("expandMembers = %v, want sorted [%s %s]", leaves, u1, u2)
+	}
+	// an unbridged (empty) descriptor expands to nothing
+	if len(expandMembers("", memberships)) != 0 {
+		t.Error("empty descriptor should expand to []")
+	}
+}

--- a/internal/ado/sinks.yaml
+++ b/internal/ado/sinks.yaml
@@ -1,0 +1,54 @@
+# ADO sink classifier table (analog of internal/github/sinks.yaml).
+#
+# The engine stamps taint facts onto each :Job as its steps are walked. Adding a
+# new sink pattern is a data edit here — no code change.
+#
+# exec_sinks:  regexes matched against a step's script body. Any match means the
+#              step builds/runs code from the checked-out tree (the cat-01
+#              executes_checked_out_code signal). First match wins; its name is
+#              recorded as the step's sink_class.
+# ai_task:     regexes matched against a task@version reference — a marketplace
+#              AI/LLM task (cat-12).
+# ai_cli:      regexes matched against a script body — an AI/LLM CLI invocation
+#              (cat-12), e.g. `claude -p "..."`.
+
+exec_sinks:
+  - name: npm_install
+    pattern: '\b(npm|pnpm|yarn)\s+(ci|i|install|add)\b'
+  - name: pip_install
+    pattern: '\bpip(3)?\s+install\b|\bpoetry\s+install\b|\buv\s+(pip|sync|run)\b'
+  - name: setup_py
+    pattern: '\bpython(3)?\s+setup\.py\s+(develop|install)\b'
+  - name: make
+    pattern: '(^|\s|;|&&)make(\s+|$)'
+  - name: cargo_build
+    pattern: '\bcargo\s+(build|run|test|install)\b'
+  - name: gradle_build
+    pattern: '(^|/)gradlew\s+|\bgradle\s+(build|test|run|assemble)\b'
+  - name: maven_build
+    pattern: '\bmvn\s+(compile|package|install|test|verify)\b'
+  - name: go_build
+    pattern: '\bgo\s+(build|run|test|install|generate)\b'
+  - name: dotnet_build
+    pattern: '\bdotnet\s+(build|run|test|publish|pack|restore)\b'
+  - name: docker_build
+    pattern: '\bdocker\s+(build|buildx\s+build)\b'
+  - name: local_script
+    pattern: '(^|\s|;|&&)\./[A-Za-z0-9_./-]+\.(sh|py|js|ts|rb|pl|ps1)\b'
+  - name: bash_local_script
+    pattern: '(^|\s|;|&&)(bash|sh)\s+\./'
+  - name: node_local_script
+    pattern: '(^|\s|;|&&)node\s+\./'
+  - name: python_local_script
+    pattern: '(^|\s|;|&&)python(3)?\s+\./'
+  - name: manage_py
+    pattern: '\bpython(3)?\s+manage\.py\b'
+  - name: task_runner
+    pattern: '\b(bundle\s+exec|rake|npx|tox|pytest|jest)\b'
+
+ai_task:
+  - pattern: '(?i)(openai|copilot|anthropic|claude|chatgpt|gpt-?[0-9]|\bllm\b|gemini|bedrock|cognitive)'
+  - pattern: '(?i)ai[-_ ]?(review|assist|agent|chat|bot|ops|complete|summar)'
+
+ai_cli:
+  - pattern: '(?i)(^|\s|;|&&|\||`|\()(claude|openai|llm|sgpt|aichat|ollama|chatgpt|q\s+chat)\b'

--- a/internal/engine/paths.go
+++ b/internal/engine/paths.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"path"
 	"strings"
@@ -304,8 +306,14 @@ func NormalizeADOPolicy(project, repo, policyType string) string {
 func NormalizeADOPrincipal(kind, descriptor string) string {
 	return adoNorm("principals", adoKey(kind), adoKey(descriptor)+".json")
 }
+// NormalizeADOEdges hashes the composite key into a fixed-length, collision-free
+// stem. Callers build keys by joining components with "__", but adoKey folds "_"
+// to "-", which would both flatten that delimiter and overflow the 255-byte path
+// limit for long branch/connection/input names. The readable components stay as
+// fields on the edge record; the filename only has to be unique.
 func NormalizeADOEdges(kind, key string) string {
-	return adoNorm("edges", adoKey(kind), adoKey(key)+".json")
+	sum := sha256.Sum256([]byte(key))
+	return adoNorm("edges", adoKey(kind), hex.EncodeToString(sum[:16])+".json")
 }
 func NormalizeADOSecretVariable(groupID int64, name string) string {
 	return adoNorm("secret-variables", fmt.Sprintf("%d__%s.json", groupID, adoKey(name)))

--- a/internal/engine/paths.go
+++ b/internal/engine/paths.go
@@ -124,7 +124,10 @@ func adoKey(s string) string {
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-' {
+		// '_' is deliberately NOT preserved: the NormalizeADO*/CollectADO* helpers
+		// join sanitized components with "__", so a component containing "_" would
+		// make that delimiter ambiguous (X + Y__Z vs X__Y + Z collide).
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '-' {
 			b.WriteByte(c)
 		} else {
 			b.WriteByte('-')
@@ -242,6 +245,76 @@ func CollectADOChecks(project, rtype, rid string) string {
 }
 func CollectADORepoACL(project, repo string) string {
 	return adoCollect("acl-repo", adoKey(project), adoKey(repo)+".json")
+}
+
+// ---- Azure DevOps normalize paths ----
+func adoNorm(parts ...string) string {
+	return path.Join(append([]string{dirNormalize}, parts...)...)
+}
+
+func NormalizeADOOrg(org string) string { return adoNorm("org", adoKey(org)+".json") }
+func NormalizeADOProject(project string) string {
+	return adoNorm("projects", adoKey(project)+".json")
+}
+func NormalizeADORepo(project, repo string) string {
+	return adoNorm("repos", adoKey(project)+"__"+adoKey(repo)+".json")
+}
+func NormalizeADOPipeline(project string, id int64) string {
+	return adoNorm("pipelines", fmt.Sprintf("%s__%d.json", adoKey(project), id))
+}
+func NormalizeADOJob(project string, pipelineID int64, stage, job string) string {
+	return adoNorm("jobs", fmt.Sprintf("%s__%d__%s__%s.json", adoKey(project), pipelineID, adoKey(stage), adoKey(job)))
+}
+func NormalizeADOServiceConnection(project, connID string) string {
+	return adoNorm("service-connections", adoKey(project)+"__"+adoKey(connID)+".json")
+}
+func NormalizeADOVariableGroup(project string, id int64) string {
+	return adoNorm("variable-groups", fmt.Sprintf("%s__%d.json", adoKey(project), id))
+}
+func NormalizeADOEnvironment(project, name string) string {
+	return adoNorm("environments", adoKey(project)+"__"+adoKey(name)+".json")
+}
+func NormalizeADOBranch(project, repo, branch string) string {
+	return adoNorm("branches", adoKey(project)+"__"+adoKey(repo)+"__"+adoKey(branch)+".json")
+}
+func NormalizeADOStage(project string, pipelineID int64, stage string) string {
+	return adoNorm("stages", fmt.Sprintf("%s__%d__%s.json", adoKey(project), pipelineID, adoKey(stage)))
+}
+func NormalizeADOKeyVault(project, vault string) string {
+	return adoNorm("key-vaults", adoKey(project)+"__"+adoKey(vault)+".json")
+}
+func NormalizeADOExtension(id string) string {
+	return adoNorm("extensions", adoKey(id)+".json")
+}
+func NormalizeADOSecureFile(project, id string) string {
+	return adoNorm("secure-files", adoKey(project)+"__"+adoKey(id)+".json")
+}
+func NormalizeADOServiceHook(id string) string {
+	return adoNorm("service-hooks", adoKey(id)+".json")
+}
+func NormalizeADOAgentPool(id int64) string {
+	return adoNorm("agent-pools", fmt.Sprintf("%d.json", id))
+}
+func NormalizeADOFeed(scope, id string) string {
+	return adoNorm("feeds", adoKey(scope)+"__"+adoKey(id)+".json")
+}
+func NormalizeADOPolicy(project, repo, policyType string) string {
+	return adoNorm("policies", adoKey(project)+"__"+adoKey(repo)+"__"+adoKey(policyType)+".json")
+}
+func NormalizeADOPrincipal(kind, descriptor string) string {
+	return adoNorm("principals", adoKey(kind), adoKey(descriptor)+".json")
+}
+func NormalizeADOEdges(kind, key string) string {
+	return adoNorm("edges", adoKey(kind), adoKey(key)+".json")
+}
+func NormalizeADOSecretVariable(groupID int64, name string) string {
+	return adoNorm("secret-variables", fmt.Sprintf("%d__%s.json", groupID, adoKey(name)))
+}
+func NormalizeADOWIFCredential(connID, subject string) string {
+	return adoNorm("wif-credentials", adoKey(connID)+"__"+adoKey(subject)+".json")
+}
+func NormalizeADOProjectAgentPool(project string, poolID int64) string {
+	return adoNorm("project-agent-pools", fmt.Sprintf("%s__%d.json", adoKey(project), poolID))
 }
 
 func NormalizeJob(repo, workflow, jobID string) string {

--- a/internal/engine/paths_test.go
+++ b/internal/engine/paths_test.go
@@ -1,6 +1,10 @@
 package engine
 
-import "testing"
+import (
+	"path"
+	"strings"
+	"testing"
+)
 
 func TestCollectPaths(t *testing.T) {
 	tests := []struct {
@@ -165,5 +169,20 @@ func TestBranchBuildersNonDefault(t *testing.T) {
 				t.Errorf("got %q, want %q", tt.got, tt.want)
 			}
 		})
+	}
+}
+
+// NormalizeADOEdges must hash the composite key into a bounded, collision-free
+// filename: distinct keys never share a file (the adoKey "__"->"--" flattening
+// used to alias them), and a long key never overflows the 255-byte path limit.
+func TestNormalizeADOEdgesBoundedDistinct(t *testing.T) {
+	a := NormalizeADOEdges("has-policy", "foo-bar__baz")
+	b := NormalizeADOEdges("has-policy", "foo__bar-baz")
+	if a == b {
+		t.Errorf("distinct composite keys collided to %q", a)
+	}
+	long := NormalizeADOEdges("uses-connection", strings.Repeat("refs/heads/very-long-branch/", 40))
+	if base := path.Base(long); len(base) > 64 {
+		t.Errorf("edge filename not bounded: %d bytes (%q)", len(base), base)
 	}
 }


### PR DESCRIPTION
## Summary

Adds the ADO `normalize` phase (collect → **normalize** → scan). It turns the raw
collected API JSON (`00-collect/`) into the security-graph records
(`10-normalize/`) the detection rules query: one record per node, the collected
and derived edges, and the three settings-resolution joins.

## What's included

**Nodes** — Organization, Project, Repository, Pipeline, Stage, Job, Branch,
BranchPolicy, Environment, ServiceConnection, VariableGroup, SecretVariable,
ProjectAgentPool, OrgAgentPool, ArtifactsFeed, WIFCredential,
User/SecurityGroup/BuildServiceIdentity, Extension/PipelineDecorator, SecureFile,
ServiceHookSubscription, KeyVault. Resource-scoped facts (checks, pipeline
permissions, secrets) fold onto their owning node.

**Edges** — HAS_POLICY, BUILD_VALIDATES, RUNS_AS, HAS_ROLE, MEMBER_OF,
REFERENCES_POOL, CONSUMES_GROUP (carrying declaration level), USES_CONNECTION,
TARGETS, RUNS_ON, DEFINED_BY, DEFINES, FEDERATES_TO, TRIGGERS_ON_COMPLETION,
LINKS_TO, INSTALLS.

**Settings-resolution joins** — (1) job-auth three-level clamp → Pipeline
`identity_scope` + RUNS_AS, fail-closed on unobserved enforcement; (2)
branch-policy-by-scope attribution → HAS_POLICY/BUILD_VALIDATES with a
materialized :Branch; (3) ACL effectiveAllow decode + graph identity bridge →
HAS_ROLE with resolved principal and target node.

**Cross-project dedup** — shared service connections and variable groups collapse
to a single owner-keyed node retaining per-project authorization.

**Pipeline YAML** — Stage/Job facts (service-connection usages, variable-group
consumption by level, checkout/task refs, pool, environment target, CI/PR
triggers, runtime parameters), extends/template source resolution (source repo +
ref + cross-project), and resources.pipelines completion triggers.

Records conform to `schema_reference.md` — labels, property names, `_id`/
`_provenance` conventions, and empties serialized as `[]`/`null`.

## Verification

Runs end-to-end against a live org: 0 collect errors → 0 normalize errors,
deterministic output, every edge endpoint resolving to an emitted node. The
settings joins and cross-project dedup are validated against firing-range ground
truth. Unit tests cover the joins (clamp, policy attribution, effectiveAllow/SID
and ServiceIdentity bridge, token resolution), dedup, CONSUMES_GROUP levels,
template-source resolution, and parameter classification.

Includes a small collect-side change (`includeSharedServiceEndpoints`) so shared
connections surface in every consuming project for the dedup pass.

Fixes LAB-4283
