### PR TITLE
Implement GitLab normalization (normalize + correlate) [LAB-4288]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,13 @@ coverage.out
 coverage*.out
 coverage.html
 
-# Docs
-docs/
+# Docs — ignored except the GitLab normalized-field contract, a tracked repo
+# artifact (the forward contract between normalize and the detection rules).
+# Re-include each ancestor before the file, and re-exclude the sibling local docs.
+docs/*
+!docs/gitlab/
+docs/gitlab/*
+!docs/gitlab/gitlab-normalized-fields.md
 
 # IDE
 .vscode/
@@ -24,9 +29,6 @@ docs/
 
 # Claude outputs
 .claude/
-
-# Research and planning docs
-docs/
 
 # WASM browser build artifacts
 browser/trajan.wasm

--- a/docs/gitlab/gitlab-normalized-fields.md
+++ b/docs/gitlab/gitlab-normalized-fields.md
@@ -1,0 +1,456 @@
+# GitLab normalized field contract
+
+## Purpose
+
+This document is the **interface** between two pieces of GitLab work that are being built in parallel:
+
+- the **detection rules** (`internal/detection-rules/gitlab/`, the catalog PRs) — declarative YAML whose `where` / `chain_of` predicates key on field names, and
+- the **normalize phase** (LAB-4288) — the Go that turns collected GitLab facts into the per-subject records those predicates evaluate against.
+
+A rule predicate is a runtime string lookup against a `map[string]any` (`internal/github/getpath.go`); nothing validates the field name at compile time. If a rule reads `merge_request.approvals_required` but normalize emits `mr.required_approvals`, the rule silently matches nothing — no error, just a dead rule. This doc fixes the names **once, up front**, so both sides converge instead of guessing. When authoring a rule, use only field paths listed here; when implementing normalize, emit exactly these paths. Add or rename a field here first, in a PR, before either side depends on it.
+
+This is a contract, not an implementation. It says nothing about *how* facts are collected (LAB-4287) or *how* the engine loads GitLab rules (the loader/subject-dispatch generalization, LAB-4987). Severity and confidence are carried per-variant from the corpus, not produced by normalize.
+
+## Status & consolidation follow-up (do during LAB-4288 / LAB-4987, before normalize is implemented against this)
+
+This doc grew to ~286 field roots while all 141 rules were authored, one field-vocabulary per family. It is a **draft** to be hardened as the first step of normalize/engine work — deferred on purpose, and safe to defer because these fields are not in any PR (this file is local/gitignored) and the rules are inert until the engine + normalize land, so any rename is a mechanical sweep across the rule YAML with zero behavioral regression. Consolidation checklist:
+
+- **Dedup / normalize naming** — collapse near-duplicate fields and align naming conventions across families (authoring produced some overlap).
+- **Fold out deferred state** — a few computed booleans risk encoding deferred/uncollectable state (e.g. `dotenv_content_attacker_influenced`, `cache_paths_executable`). Per the corpus, deferred state justifies the *confidence tier*, not a predicate; move these out of `where` where that's the case.
+- **Fidelity spot-check** — re-read predicates against the corpus for the families that initially failed workflow review: cat-03, 04, 07, 09, 11, 12.
+- **Reconcile with real normalize output** — as LAB-4288 emits records, rename fields here to match and sweep the rule YAML; decide whether this file becomes a tracked repo artifact (e.g. `internal/detection-rules/gitlab/FIELDS.md`) rather than a local doc.
+
+### Fix-pass follow-ups (2026-07-18 — rule-side engine-mechanics bugs corrected in the open PRs; normalizer must honor the contracts below)
+
+A pass over the DSL-mechanics review corrected six categories in the PR branches (cat-03 field-refs folded into the `protected-var-reachability` join; cat-04 `>= "developer"` → `>= 30`; cat-12 guest existential → `has_guest_member`; cat-13 guardrail enum → uppercase; explicit `for_each` on all cat-03/09/11/12 chain rules). The normalizer must honor these to keep the rules correct-by-construction:
+
+- **Emit `[]`, never null/omitted, for every list field (C1).** Several rules gate on `field != []` / `field == []` and `valuesEqual(nil, []any{})` is false, so an absent list makes `!= []` fire on nothing and `== []` never fire. Un-fixed rule-side (kept as-is, relying on this contract): cat-06 `external_status_checks`, cat-08 `projects`, cat-09 `consumer.cross_project_needs`, cat-11 `backing_identity_breadth`, cat-12 `artifact_paths`/`agent.ci_access_targets`, cat-14 `custom_headers`, cat-15 `environments_filter` (the dangerous direction — `== []` silently never fires if omitted).
+- **`for_each` item-list keys are a hard contract** — see the Chain-joins table; each join must emit tuples under exactly the named key (unset → engine defaults to `links` → iterates nothing).
+- **Guardrail enum verbatim, uppercase** — `duo_guardrail_level`/`duo_instance_guardrail_level` carry the GraphQL `promptInjectionProtectionLevel` value as-is (`LOG_ONLY`/`NO_CHECKS`/`INTERRUPT`); do not lowercase.
+- **Role representation pinned numeric (C3)** — access levels are numeric (`>= 30` developer, `>= 40` maintainer), matching the corpus and cat-04's fix; reconcile the remaining string-enum uses (cat-12 `default_membership_role`) at normalize.
+- **Still open, not rule-fixes:** protected-ref vocabulary split (`runs_on_protected_ref` bool vs `protected_ref_gate == "strong"` — pick the boolean; 7 cat-09 + cat-10 refs), token-freshness field (`revoked` vs `active`), runner `ref_protected != true` vs `== false`, and the missing `tier`/`namespace_plan` gate (C6, Premium/Ultimate rules false-positive on Free). These are precision items, not "cannot fire" bugs — defer to the normalize pass.
+
+### Collectability finding — SAML SSO default membership role is UI-only, no API path (2026-07-18)
+
+Verified against GitLab official docs + both live firing-range instances (self-hosted 19.2.0-ee groups 280/287/291/293; SaaS gitlab.com group 137657479), across REST, GraphQL, SCIM, and instance application-settings, with `read_api` (Owner) **and** admin (self-hosted root + `sudo` + `admin_mode`; SaaS group-owner full-`api`) tokens. **No route on any credential exposes the group SAML SSO "Default membership role."** It is a UI-only setting (group Settings → SAML SSO). Routes tried, all field-absent: `GET /groups/:id` (`?with_saml`), `/groups/:id/saml` (404), `/groups/:id/saml_group_links` (401), `/groups/:id/scim/identities` (no role field), `/application/settings` (has `lock_memberships_to_saml`, not the default role), GraphQL full-schema introspection (no `SamlProvider` type, no `defaultMembershipRole` field). The gating precondition `saml_provisioning_active` is likewise not tenant-readable. The custom-role variant is doubly blind — it derives from this blind field, and `member_roles` is 400/403 even to root on self-managed.
+
+- **Affected rules (3, cat-12):** `saml-scim-default-membership-role-developer`, `saml-scim-default-membership-role-maintainer`, `saml-scim-default-custom-cicd-role`. These cannot fire under any credential we would use.
+- **Status: flagged, NOT removed** (pending decision). Candidate disposition: pull from the active catalog into a manual-gap list — "verify manually in group Settings → SAML SSO."
+- **Do NOT** wire these to `saml_group_links.access_level` / `member_role_id` as a proxy: that is the per-linked-group role mapping, a *different* setting from the SSO default.
+
+## Conventions (mirrored from the GitHub rule set)
+
+- **snake_case** field names; dot-paths for nesting (`approval.author_approval_allowed`, `oidc.sub_claim_components`).
+- **Semantic names, not raw API attributes.** The normalized field is a concise meaning (`fork_pipelines_run_in_parent`); the raw GitLab attribute it derives from lives in the *Source* column (`ci_allow_fork_pipelines_to_run_in_parent_project`). This keeps predicates readable and insulates rules from GitLab's attribute churn.
+- **Booleans are always present**, defaulting `false` — never omitted. A rule writes `x == true` / `x != true`.
+- **Enums are lowercase strings** (`visibility == "public"`, `runner_type == "instance_type"`).
+- **Sets** use `∋` membership (`triggers ∋ {merge_request_event}`); **lists** compare against `[]` (`cross_project_needs != []`).
+- **Empty collections serialize as `[]`, absent scalars as `null`** — predicates key on both, so normalize must not drop them (per project CLAUDE.md).
+- **`_provenance`** rides on every record for evidence templating: `{config_file, yaml_line_range, project_path}` (mirrors GitHub's `_provenance.workflow_file`).
+- **Chain participants** are addressed by role prefix inside a `chain_of.where` (`producer.`, `consumer.`, `source.`, `target.`), matching GitHub's `caller.`/`callee.` style.
+
+## Subject kinds
+
+Each kind is one normalized record type, written to its own directory under `10-normalize/` and loaded by the scan phase. GitLab needs the `subjectDirs` map (`internal/github/scan.go:15`) extended to these — that is Go work, tracked under the engine-generalization ticket, not a rules PR.
+
+| `subject:` | normalize dir | GitLab entity | nearest GitHub analog |
+|---|---|---|---|
+| `job` | `jobs` | resolved `.gitlab-ci.yml` job | `job` |
+| `project` | `projects` | project settings, protected refs, variables | `repo` |
+| `group` | `groups` | group settings + inheritance tree | — |
+| `instance` | `instance` | instance/admin settings | `org` |
+| `merge_request` | `merge-requests` | MR & approval configuration | — |
+| `environment` | `environments` | environment + protected-env + deployment approval | `environment` |
+| `runner` | `runners` | instance/group/project runner | (self-hosted) |
+| `agent` | `agents` | Kubernetes agent `ci_access` | — |
+| `credential` | `credentials` | access/deploy token, PAT, deploy key, static cloud cred | `deploy_key` |
+| `integration` | `integrations` | webhook, integration, pull-mirror, Pages | — |
+| `chain` | (produced by `correlate`) | cross-entity join | `chain` |
+
+## `job`
+
+The core subject — one record per resolved job in a project's `.gitlab-ci.yml` (includes expanded, `rules:`/`workflow:` evaluated). Most of cat-01/02/09/10 key here.
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `triggers` | set | pipeline sources the job runs on: `merge_request_event`, `push`, `schedule`, `web`, `api`, `trigger`, `pipeline`, `external_pull_request_event` | `rules:` / `workflow:` / `$CI_PIPELINE_SOURCE` | 01,02,03,09 |
+| `runs_on_untrusted_ref` | bool | reachable on an attacker-nameable / unprotected ref (fork MR, feature branch, attacker tag) | ref + `rules:` resolution | 01,03,09 |
+| `runs_fork_mr_in_parent` | bool | eligible to execute a fork MR pipeline in the parent project | job × project `fork_pipelines_run_in_parent` | 01 |
+| `reads_cicd_variable` | bool | job exposes ≥1 CI/CD variable to its script/env | variable scope × job | 01,03 |
+| `reads_protected_variable` | bool | a `protected` variable is reachable by this job | variable metadata × ref | 01,03 |
+| `mints_id_token` | bool | job declares `id_tokens:` | `id_tokens:` | 01,10 |
+| `id_token_aud` | list | OIDC audience(s) requested | `id_tokens:*:aud` | 10 |
+| `deploys_environment` | bool | job binds an `environment:` | `environment:` | 01,03,07 |
+| `environment_name` | string | bound environment name (may be ref-templated) | `environment:name` | 01,07 |
+| `attacker_input_fields` | set | categories of untrusted input reaching an exec context: `mr_metadata`, `ref_name`, `commit_message`, `component_input` | `script:` + `$[[ inputs ]]` | 01 |
+| `script_uses_untrusted_input` | bool | ≥1 `attacker_input_fields` reaches an exec context | `script:` analysis | 01 |
+| `includes` | list | resolved includes: `{type: local\|remote\|project\|component\|template, ref, pinned: bool, source_host, cross_trust: bool}` | `include:` | 02 |
+| `remote_include_untrusted_host` | bool | `include:remote` from a non-instance / non-first-party host with no `integrity:` pin | `include:remote` | 02 |
+| `remote_include_cleartext` | bool | `include:remote` over `http://` with no `integrity:` pin | `include:remote` URL scheme | 02 |
+| `mutable_cross_trust_project_include` | bool | `include:project` at a mutable/unprotected ref in a different trust scope | `include:project` + referenced `/protected_branches` | 02 |
+| `mutable_component_version` | bool | `include:component` at a mutable `@version` from a third-party publisher | `include:component` | 02 |
+| `include_ref_interpolated` | bool | an `include:` `ref`/`file`/`remote` interpolates a user-controllable predefined variable | `include:` | 02 |
+| `child_pipeline_from_cross_project_artifact` | bool | `trigger:include:` sourced from a generator fed a cross-project artifact on a lower-trust ref | `trigger:include:` + `needs:project:` | 02 |
+| `remote_step_untrusted_ref` | bool | a `run:` `step`/`func` from a remote git ref that is mutable, lower-trust-writable, or third-party | `run:` | 02 |
+| `include_bare_ref_shadowable` | bool | a bare `ref:` in `include`/`trigger` matches a protected branch but not a protected tag in a referenced project with Developer members | `include`/`trigger` + `/protected_branches` + `/protected_tags` | 02 |
+| `runs_on_protected_ref` | bool | job executes in a protected-ref context (poisoned config reaches a protected surface) | ref + `/protected_branches` | 02 |
+| `outbound_job_token_broad` | bool | the job's `CI_JOB_TOKEN` outbound reach is broad | `ci_job_token_scope` posture | 02 |
+| `cross_project_needs` | list | `needs:project:`/`needs:pipeline:` pulling artifacts across projects: `{project, artifacts: bool}` | `needs:project:` | 02,09 |
+| `produces_dotenv` | bool | emits a dotenv report artifact | `artifacts:reports:dotenv` | 09 |
+| `consumes_dotenv` | bool | inherits dotenv variables from a `needs:` producer | `needs:` + dotenv | 09 |
+| `cache` | list | cache entries: `{key, key_files: [], policy}` | `cache:` | 09 |
+| `artifact_paths` | list | published artifact paths | `artifacts:paths` | 12,14 |
+| `publishes_pages` | bool | this is a `pages:` job | `pages:` | 14 |
+| `image_ref` | string | container image reference | `image:` | 09 |
+| `image_from_variable` | bool | image tag comes from a variable | `image: $VAR` | 09 |
+| `image_pinned_digest` | bool | image pinned by `@sha256:` | `image:` | 09 |
+| `job_token_cross_project_use` | enum | `none` \| `read` \| `terraform_state` \| `git_push` — how the job wields `CI_JOB_TOKEN` off-project | `script:` + `$CI_JOB_TOKEN` | 04 |
+| `runner_tags` | set | tags selecting a runner | `tags:` | 08,13 |
+| `protected_ref_gate` | enum | `none` \| `weak` \| `strong` — strength of `$CI_COMMIT_REF_PROTECTED` gating on the job | `rules:if` | 09 |
+| `is_duo_flow` | bool | job runs a GitLab Duo flow/agent in CI | `.gitlab/duo/flows/*` wiring | 13 |
+| `targets_self_managed_runner` | bool | job lands on a self-managed runner (not the gitlab.com shared fleet) | `/runners` runner_type × `tags:` | 01 |
+| `targets_protected_runner` | bool | job can land on a `ref_protected` runner | `/runners` `access_level` × `tags:` | 01 |
+| `mr_pipelines_unprotected` | bool | effective: this job's project has `protect_merge_request_pipelines == false` | `protect_merge_request_pipelines` | 01 |
+| `runs_on_merged_result` | bool | job runs against a merged-results / merge-train commit | `merge_pipelines_enabled` / `merge_trains_enabled` | 01 |
+| `developer_controls_mr_branches` | bool | effective: a Developer-role actor can push/create refs matching the protected pattern for both a candidate MR source and target (loose / over-broad protected-branch scheme) | `/protected_branches` + role model | 01 |
+| `env_scoped_secret_reachable` | bool | an unprotected variable whose `environment_scope` matches this job's `environment:` reaches it | `cicd_variables` × `environment:` | 01 |
+| `environment_name_interpolated` | bool | the job's `environment:name:` value contains a variable interpolation (`$VAR`, `${VAR}`, `review/$CI_COMMIT_REF_SLUG`) whose input a Developer can control, so the environment (and the scope it selects) is chosen at run time and no exact-match protected entry can cover it | `environment:name` (interpolation syntax) | 07 |
+| `dotenv_content_attacker_influenced` | bool | producer's `script:` writes non-constant / attacker-influenceable content into the dotenv file (redirection of a variable, fetched value, printf/echo of derived data) rather than a fixed literal set | `script:` analysis of the dotenv-producing job | 09 |
+| `dotenv_content_from_untrusted_source` | bool | a trusted-ref producer builds its dotenv content from untrusted input fetched at runtime from a lower-trust source (a Developer-pushable artifact/ref/submodule) with no review gate | `script:` fetch analysis of the dotenv-producing job | 09 |
+| `dotenv_inheritance_unnarrowed` | bool | consumer does not narrow dotenv inheritance: no `dependencies: []` and no `inherit: {variables: false}` / restricted list | job `dependencies:`/`inherit:` analysis | 09 |
+| `inherited_var_in_exec_sink` | bool | consumer references an inherited-only (or job/global-scope-declared) variable in an execution-sensitive position: `image: $VAR`, `$VAR` in a script command, or a deploy target/URL | `script:`/`image:` analysis of the consumer job | 09 |
+| `dotenv_key_collides_declared_var` | bool | a reachable producer emits a dotenv `KEY=value` whose key matches a variable the consumer declares at job-level or global `variables:` scope (name collision) | producer dotenv keys × consumer `variables:` | 09 |
+| `colliding_var_in_exec_sink` | bool | the colliding job/global-declared variable is used by the consumer in an execution-sensitive position (`image:`, script interpolation, deploy target/URL) | `script:`/`image:` analysis of the consumer job | 09 |
+| `cache_separation_enabled` | bool | project's protected/unprotected cache separation setting (contract lists `cache_separation_enabled` on project); false collapses both classes into one cache namespace | `ci_separated_caches` (project setting joined onto the job) | 09 |
+| `cache_key_static_cross_boundary` | bool | the job's `cache:key` is static/global or built only from values shared by protected and unprotected pipelines (no `$CI_COMMIT_REF_SLUG` / protection component), so it collides across the protection boundary | `cache:key` analysis | 09 |
+| `cache_key_files_attacker_writable` | bool | the job uses `cache:key:files:` over files writable by lower-trust actors on an unprotected branch, enabling a content-addressed collision into a protected pipeline's bucket | `cache:key:files` + repo file writability | 09 |
+| `cache_policy_writes` | bool | the job's cache policy writes the cache (`policy: pull-push` or `push`) | `cache:policy` | 09 |
+| `cache_paths_executable` | bool | the cached `paths:` are executable/loaded (dependency dirs like `node_modules/`, `vendor/`, `.venv/`, `.m2/`, toolchains, or a path the consumer sources/executes) rather than inert data | `cache:paths` + `script:` usage | 09 |
+| `artifact_source_ref_mutable` | bool | the `needs:project` source is referenced by a mutable branch ref, not a pinned tag or commit SHA | `needs:project` `ref:` analysis | 09 |
+| `executes_fetched_artifact` | bool | the consumer extracts/executes the fetched artifact (`tar x` / `unzip` / `source` / `./` / install / copy-into-runtime-path) | `script:` analysis of the consumer job | 09 |
+| `artifact_integrity_checked` | bool | the consumer verifies artifact integrity before use (`sha256sum -c` / `cosign verify` / `gpg --verify` / pinned digest); false when no such step exists | `script:` analysis of the consumer job | 09 |
+| `on_consumer_job_token_allowlist` | bool | the private source project is on the consumer's job-token inbound allowlist, so the cross-project artifact fetch succeeds | inbound job-token allowlist metadata | 09 |
+| `source_ref_developer_pushable` | bool | the source project's referenced ref is an unprotected branch or one a Developer of the source project can push | source project `/protected_branches` | 09 |
+| `consumes_cross_pipeline_artifact` | bool | job uses `needs:pipeline:job:` (or `needs:pipeline` with `artifacts: true`) to fetch an artifact from a different pipeline in the same project | `needs:pipeline:` analysis | 09 |
+| `upstream_pipeline_untrusted_ref_reachable` | bool | the referenced upstream pipeline is not constrained to protected refs by `rules:`/`workflow:`, so a Developer's unprotected-branch pipeline can be the source | referenced upstream job `rules:`/`workflow:` resolution | 09 |
+| `fetches_cross_project_artifact` | bool | job fetches an artifact from a different project via a bare `CI_JOB_TOKEN` job-artifacts API call (`JOB-TOKEN: $CI_JOB_TOKEN` against `/projects/.../jobs/artifacts/...`) or `needs:project:...:artifacts:true` | `script:` + `needs:project:` analysis | 09 |
+| `artifact_source_visibility` | enum | visibility of the source project the artifact is fetched from: `public` \| `internal` \| `private` (public/internal means the job-token allowlist never gates the fetch) | source project visibility metadata | 09 |
+| `image_from_registry_mutable_tag` | bool | job references a registry image by a mutable tag (`latest`, `staging`, an environment name) rather than an immutable digest or self-built commit-SHA tag | `image:` analysis | 09 |
+| `registry_tag_protection_covers_consumed_tag` | bool | a protected container tag rule exists whose pattern covers the consumed tag (any covering rule restricts push/delete to Maintainer+); false is the vulnerable absent-rule state | `/registry/protection/tag/rules` API × consumed tag | 09 |
+| `registry_push_reachable_by_developer` | bool | registry push/overwrite of the consumed tag is reachable by a lower-trust actor via default project registry permissions (Developer+ can push) | default project registry permissions × member roles | 09 |
+| `installs_gitlab_registry_package` | bool | job installs a package from the GitLab package registry | `script:` package-install analysis | 09 |
+| `package_version_mutable_range` | bool | the installed package is resolved at a mutable range (floating version, `latest`/`*`/caret/tilde, otherwise unpinned) | manifest / install command version spec | 09 |
+| `package_version_checksum_verified` | bool | the install pins an exact version and verifies a checksum; false when neither is present | manifest lockfile / `script:` analysis | 09 |
+| `package_protection_covers_consumed_name` | bool | a package protection rule exists limiting the consumed package name/pattern to a minimum push role of Maintainer+; false is the vulnerable absent/Developer-role state | package protection rules API × consumed name | 09 |
+| `package_publish_reachable_by_developer` | bool | package publish/overwrite of the consumed name is reachable by a lower-trust actor via default package-registry permissions (Developer+ can publish) | default package-registry permissions × member roles | 09 |
+| `write_registry_token_reachable_low_trust` | bool | a `write_registry` deploy token (group-level usable across the group, or the auto-exposed `gitlab-deploy-token` as `CI_DEPLOY_USER`/`CI_DEPLOY_PASSWORD`) is reachable from a low-trust pipeline the attacker can influence | deploy-token metadata (scope `write_registry`, group vs project) × variable exposure to non-protected branches | 09 |
+| `reuses_ondisk_checkout` | bool | job depends on reused on-disk state across jobs: `GIT_STRATEGY` in {`fetch`,`none`}, or a persisted cache/build path or `GIT_SUBMODULE_STRATEGY` reuse, rather than a clean clone into a wiped directory | `variables.GIT_STRATEGY` / `cache:` / `GIT_SUBMODULE_STRATEGY` in pipeline config | 08 |
+| `runs_on_cross_trust_shared_runner` | bool | effective: this job lands on a self-managed shared (or multi-project) runner, not restricted to protected refs, that also services higher-trust jobs (protected branch / deploy / other trust level) — so reused state crosses a trust boundary | job tags/ref resolution against `/runners` metadata (self_managed, is_shared, ref_protected) and the runner's cross-trust job set | 08 |
+| `sub_claim_omits_ref` | bool | effective: this job's project narrowed `ci_id_token_sub_claim_components` so the id_token sub omits both ref and ref_type (every branch mints an identical sub). Folds the project-level `oidc.sub_claim_components` setting onto the minting job as a computed effective-property boolean | `project.oidc.sub_claim_components` evaluated against the default `["project_path","ref_type","ref"]` | 10 |
+| `artifacts_access_unrestricted` | bool | a saving job leaves its artifacts at default-public: no `artifacts:public: false` and no `artifacts:access developer\|maintainer\|none` | `artifacts:public` / `artifacts:access` | 12 |
+| `non_member_readable_pipelines` | bool | effective: this job's project is non-member-readable (visibility public or internal AND `public_pipelines == true`), so its pipeline artifacts/logs are downloadable by non-members | `project.visibility` × `project.public_pipelines` | 12 |
+| `duo_flow_context_sources` | set | categories of untrusted content the Duo flow ingests as context: `fork_mr` (fork-MR description/diff/comments), `issue_comment` (issue or comment text) | `.gitlab/duo/agent-config.yml` flow wiring + project visibility/MR/issue-access settings | 13 |
+| `duo_flow_secrets_in_scope` | bool | effective: the flow's CI job carries secrets an injection could steer it to read — at least one `protected=false` CI/CD variable reachable and/or a broad `CI_JOB_TOKEN` inbound allowlist | `cicd_variables` (protected) × job scope + inbound `job_token_allowlist` | 13 |
+| `duo_flow_autonomous_write` | bool | effective: the flow's agent has write-capable actions (post comments, push, open MRs, call the API) and no per-action human-approval gate | `.gitlab/duo/agent-config.yml` / flow config (tool set + approval settings) | 13 |
+| `duo_group_features_enabled` | bool | effective on the job: the group governing this flow has Duo/Agent-Platform enabled (folds `group.duo_features_enabled` onto the job subject) | GraphQL `Group.duoFeaturesEnabled` for the job's owning group | 13 |
+| `duo_guardrail_level` | enum | effective on the job: the group prompt-injection protection level governing this flow — `NO_CHECKS` \| `LOG_ONLY` \| `INTERRUPT`, the GraphQL enum verbatim (do **not** lowercase; rules compare against the uppercase form) (folds group `aiSettings` onto the job subject) | GraphQL `group(fullPath).aiSettings.promptInjectionProtectionLevel` | 13 |
+| `duo_instance_features_enabled` | bool | effective on the job: instance-level Duo/Agent-Platform enabled (self-managed; folds `instance.duo_features_enabled` onto the job subject) | admin-scoped instance Duo/AI settings (DuoSettings) | 13 |
+| `duo_instance_guardrail_level` | enum | effective on the job: instance-level prompt-injection protection level (self-managed) — `NO_CHECKS` \| `LOG_ONLY` \| `INTERRUPT`, the GraphQL enum verbatim (do **not** lowercase) (folds `instance.prompt_injection_protection_level` onto the job subject) | admin-scoped instance Duo settings `promptInjectionProtectionLevel` | 13 |
+| `duo_workflow_mcp_enabled` | bool | effective on the job: MCP integration enabled for the group's agents governing this flow (default false; folds instance/group `duo_workflow_mcp_enabled` onto the job subject) | GraphQL `group(fullPath).aiSettings.duoWorkflowMcpEnabled` | 13 |
+| `duo_mcp_endpoint_untrusted_host` | bool | the flow is wired via `.gitlab/duo/mcp.json` to an MCP server whose endpoint host is not org-internal/allowlisted (third-party/community/public FQDN) | `.gitlab/duo/mcp.json` server url/host (cf. `project.duo.mcp_endpoint`) | 13 |
+| `duo_external_agent_untrusted_host` | bool | the flow is wired via `.gitlab/duo/flows/*.yaml` to an external agent (third-party model provider) whose endpoint host is not org-internal/allowlisted; GitLab does not scan external-agent output | `.gitlab/duo/flows/*.yaml` agent provider/endpoint | 13 |
+| `pages_references_secret_variable` | bool | the Pages producer job explicitly references (`variables:`/`secrets:`) a CI/CD variable whose metadata is protected or masked | job variables/secrets refs × `cicd_variables` metadata | 14 |
+| `pages_public` | bool | effective: the job's project serves Pages public (`pages_access_level == public`) with no instance-level public-Pages disable | `project.pages_access_level` folded onto job | 14 |
+| `downloads_secure_file` | bool | the job downloads a project secure file (download-secure-files tool or `.secure_files/` path) and the project has secure-file metadata | job `script` + secure-files API | 14 |
+| `artifact_paths_broad` | bool | the Pages job's `artifacts:paths` publishes the whole workspace (`.`), the repo root, or a non-dedicated site output directory | `artifacts:paths` analysis | 14 |
+| `source_ci_writable_by_lower_trust` | bool | the executed source CI (this job's `.gitlab-ci.yml`, includes resolved) or the ref it runs on is writable by a lower-trust member: the ref is unprotected, or protected without CODEOWNERS gating on `.gitlab-ci.yml`, or an `include:` resolves a mutable/attacker-writable location | resolved `.gitlab-ci.yml` includes × `/protected_branches` × CODEOWNERS coverage of the CI config | 04 |
+| `_provenance` | object | `{config_file, yaml_line_range, project_path}` | — | all |
+
+## `project`
+
+Project settings, protected refs, and the project's CI/CD variable inventory.
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `visibility` | enum | `public` \| `internal` \| `private` | `visibility` | 01,12 |
+| `forking_enabled` | bool | forks permitted | `forking_access_level` | 01 |
+| `fork_pipelines_run_in_parent` | bool | fork MR pipelines may run in the parent | `ci_allow_fork_pipelines_to_run_in_parent_project` | 01 |
+| `mr_pipelines_protected` | bool | MR pipeline protection on | `protect_merge_request_pipelines` | 01 |
+| `merged_results_pipelines` | bool | merged-results / merge trains on | `merge_pipelines_enabled` | 01 |
+| `inbound_job_token_scope_enabled` | bool | inbound `CI_JOB_TOKEN` allowlist enforced | `ci_job_token_scope_enabled` | 01,04 |
+| `job_token_allowlist` | object | `{mode: disabled\|open\|group_scoped\|project_scoped, entries: [], fine_grained: bool}` | inbound allowlist API | 04 |
+| `job_token_push_allowed` | bool | git push via job token permitted | `ci_push_repository_for_job_token_allowed` | 04,14 |
+| `job_token_cross_project_push_allowed` | bool | an allowlisted *other* project's job token may git push into this repo (the second, distinct toggle; both this and `job_token_push_allowed` must be on for a cross-project push) | GraphQL `crossProjectPushForJobTokenAllowed` (`project.ciCdSettings`) | 04 |
+| `uses_managed_terraform_state` | bool | project uses GitLab's managed Terraform/OpenTofu state backend (state objects present at `terraform/state/:name`) | `/projects/:id/terraform/state` objects present | 04 |
+| `cache_separation_enabled` | bool | protected/unprotected cache separation on | `ci_separated_caches` | 09 |
+| `oidc.sub_claim_components` | list | components composing the id_token `sub` | `ci_id_token_sub_claim_components` | 10 |
+| `pages_access_level` | enum | `public` \| `internal` \| `private` | `pages_access_level` | 14 |
+| `auto_devops_enabled` | bool | Auto DevOps on (project override) | `auto_devops_enabled` | 12 |
+| `pipeline_execution_policy_from_mutable_project` | bool | a `pipeline_execution_policy` sources CI content from a mutable / lower-trust-writable policy project | `.gitlab/security-policies` + referenced `/protected_branches` | 02 |
+| `has_cicd_config` | bool | `.gitlab-ci.yml` present | repo tree | many |
+| `protected_branches` | list | `{pattern, push_access_levels: [], merge_access_levels: [], allow_force_push: bool, code_owner_approval_required: bool}` | `/protected_branches` | 01,02,03,05 |
+| `protected_tags` | list | `{pattern, create_access_levels: []}` | `/protected_tags` | 03,05 |
+| `default_branch_protected` | enum | protection level of the default branch | `/protected_branches` | 03,05 |
+| `push_rules` | object | server-side push rule metadata | `/push_rule` | 06 |
+| `cicd_variables` | list | `{key, protected: bool, masked: bool, environment_scope, scope_level: project\|group\|instance}` — **values never collected** | `/variables` | 01,03,05,07,11,13,14 |
+| `has_developer_reachable_secret` | bool | derived: ≥1 `cicd_variables` entry reachable by a Developer-pushable ref | `cicd_variables` × `protected_branches` | 01,03 |
+| `members` | list | `{access_level, is_bot}` | `/members/all` | 03,11 |
+| `has_reachable_runner` | bool | project has ≥1 runner its pipelines can land on (project/group/instance) | `/runners` (+ inherited/instance) | 01 |
+| `has_self_managed_runner` | bool | ≥1 reachable runner is self-managed (not the gitlab.com shared fleet) | `/runners` runner_type | 01 |
+| `holds_protected_resources` | bool | project holds protected CI/CD variables or a protected runner a reused credential could reach | `cicd_variables` / `/runners` | 11 |
+| `registry_protection_rules` | list | container/package registry tag protection | `/registry/protection/...` | 11 |
+| `duo` | object | `{config_present: bool, flows: [], mcp_endpoint}` from `.gitlab/duo/*` | repo tree | 13 |
+| `has_masked_unprotected_secret_var` | bool | derived: ≥1 `cicd_variables` entry has `masked==true` AND `protected==false` AND a secret-shaped key (secret-name heuristic). Folds the masked-not-protected tri-state combo plus the value-is-a-secret heuristic into one collectable boolean | `cicd_variables` (key/masked/protected) | 03 |
+| `has_plain_unprotected_secret_var` | bool | derived: ≥1 `cicd_variables` entry has `protected==false` AND `masked==false` AND a secret-shaped key. The precision rests entirely on the secret-name heuristic; must never fire on unprotected variables alone | `cicd_variables` (key/masked/protected) | 03 |
+| `has_scoped_unprotected_secret_var` | bool | derived: ≥1 `cicd_variables` entry has `environment_scope != "*"` AND `protected==false` AND a secret-shaped key. Scope is not a ref boundary (the job names the environment), so this scoped-not-protected combo is reachable from any ref | `cicd_variables` (key/environment_scope/protected) | 03 |
+| `has_developer_pushable_unprotected_ref` | bool | derived: ≥1 pushable ref not restricted to a trusted set — no covering `protected_branches` rule, or a wildcard rule whose `push_access_levels` includes Developer (30) — so a Developer can create/push a feature branch and run its pipeline. Complements `has_developer_reachable_secret` by capturing same-scope untrusted-ref reachability | `protected_branches` × default push role | 03 |
+| `developer_pushable_protected_branch` | bool | effective: a protected-branch rule on a CI-trusted ref lists Developer (access level 30) or a group/user entry under push access (Allowed to push and merge) | `/protected_branches` `push_access_levels` × role model | 05 |
+| `developer_mergeable_protected_branch` | bool | effective: a protected-branch rule on a CI-trusted ref lists Developer (30) or a group/user entry under merge access (Allowed to merge) | `/protected_branches` `merge_access_levels` × role model | 05 |
+| `developer_writable_protected_branch` | bool | effective: a protected-branch rule on a CI-trusted ref grants push OR merge to Developer (30) or a group/user entry (either write path) | `/protected_branches` `push`+`merge_access_levels` × role model | 05 |
+| `developer_creatable_wildcard_branch` | bool | effective: a WILDCARD protected-branch rule (pattern contains a glob) grants push or merge to Developer (30) or a group/user entry, so a Developer can create a matching protected branch | `/protected_branches` name pattern × `push`/`merge_access_levels` | 05 |
+| `protected_var_scoped_to_writable_ref` | bool | effective join: a `protected:true` CI/CD variable (project-defined or group-inherited) is scoped to the ref/pattern the low-trust actor can write | `cicd_variables` (protected, environment_scope) × `protected_branches` ref | 05 |
+| `protected_var_scoped_to_tag_pipeline` | bool | effective join: a `protected:true` CI/CD variable is in scope for a tag pipeline (protected variables apply to protected tags) and `.gitlab-ci.yml` has `$CI_COMMIT_TAG` / `only:tags` jobs consuming it | `cicd_variables` × `protected_tags` × `.gitlab-ci.yml` tag jobs | 05 |
+| `author_can_self_merge` | bool | effective: no required-approval rule blocks the MR author from merging alone (approvals_required 0 or author-satisfiable, author-approval not prevented) | `/approvals` + `/approval_rules` | 05 |
+| `has_protected_self_managed_runner` | bool | effective: a runner with `access_level ref_protected` that is self-managed (not gitlab.com shared fleet) is reachable by the project's pipelines via matching tags or run_untagged | `/runners` `access_level` × `runner_type` × tags/run_untagged | 05 |
+| `inherited_default_branch_developer_pushable` | bool | effective: the project's default branch has an inherited protected-branch rule whose push access includes Developer (30) with `allow_force_push false` (still a protected ref) and no stricter project override | `/projects/:id` default_branch × `/protected_branches` vs instance/group defaults | 05 |
+| `inherited_protection_source` | enum | origin of the lowered default-branch protection the project inherited: `instance` \| `group` \| `project` | `/application/settings` default_branch_protection_defaults vs `/groups/:id` default_branch_protection_defaults | 05 |
+| `force_push_by_low_trust_pusher` | bool | effective: a protected-branch rule on a CI-trusted ref has `allow_force_push true` and its push list includes a non-Maintainer (Developer 30 or broad group/user) | `/protected_branches` `allow_force_push` × `push_access_levels` | 05 |
+| `ref_is_ci_trusted` | bool | the ref is CI-trusted: a protected variable is scoped to it or it feeds a deploy pipeline (default branch or a ref used by pipeline jobs) | `cicd_variables` × `protected_branches` × `.gitlab-ci.yml` | 05 |
+| `push_access_shadowed_by_permissive_rule` | bool | effective: ≥2 protected-branch rules match one CI-trusted branch and the unioned (most-permissive) push access includes a lower-trust actor than the narrowest matching rule intended | `/protected_branches` per-branch glob resolution of `push_access_levels` | 05 |
+| `no_one_push_creatable_via_merge` | bool | effective: a protected pattern has push access = No one (empty `push_access_levels`) but a matching rule grants merge access to Developer (30) or a group/user entry, permitting branch creation | `/protected_branches` `push_access_levels` empty × matching `merge_access_levels` | 05 |
+| `force_push_shadowed_by_permissive_rule` | bool | effective: ≥2 rules match one CI-trusted branch, the narrowest has `allow_force_push false` but a broader matching rule has `allow_force_push true` (most-permissive grants force push), and a non-Maintainer is in the effective push list | `/protected_branches` per-branch resolution of `allow_force_push` × `push_access_levels` | 05 |
+| `developer_creatable_protected_tag` | bool | effective: a protected-tag rule's `create_access_levels` includes Developer (30) or a group/user entry, for a pattern matching the tag scheme used by privileged tag jobs | `/protected_tags` `create_access_levels` × `.gitlab-ci.yml` tag jobs | 05 |
+| `create_access_shadowed_by_permissive_tag_rule` | bool | effective: ≥2 protected-tag rules match a release tag pattern used by tag jobs and the unioned (most-permissive) create access includes a lower-trust actor than the narrowest matching rule intended | `/protected_tags` per-pattern glob resolution of `create_access_levels` | 05 |
+| `ref_has_deferred_deploy_identity` | bool | a job on the ref carries a deploy indicator whose credential is minted/scoped outside GitLab: an `id_tokens:` OIDC block and/or an `environment:` naming a protected/production environment | `.gitlab-ci.yml` `id_tokens:` / `environment:` | 05 |
+| `public_pipelines` | bool | project-based pipeline visibility on: job logs/artifacts/CI menu readable at the project's visibility scope (default enabled) | `public_jobs` / `public_pipelines` | 12 |
+| `has_guest_member` | bool | effective: the project has ≥1 direct member at the Guest access level (10) — precomputed because the engine's `∋` set-membership cannot express an existential over member maps | `/projects/:id/members` `access_level == 10` | 12 |
+| `ci_debug_trace_enabled` | bool | `CI_DEBUG_TRACE` set truthy as a global/job variable or a project/group CI/CD variable, forcing every non-masked variable into the job trace | `variables:` `CI_DEBUG_TRACE` / `cicd_variables` key | 12 |
+| `auto_devops_deploy_creds_wired` | bool | instance/group Auto DevOps deploy plumbing is present in scope: `AUTO_DEVOPS_*`/`KUBE_*` CI/CD variables, a configured container registry, or a bound Kubernetes agent the deploy stage targets | `cicd_variables` (`AUTO_DEVOPS_*`/`KUBE_*`) / registry / agent | 12 |
+| `group_inherited_deploy_vars` | bool | effective: the project inherits group-level Auto DevOps deploy variables (`KUBE_*`/`AUTO_DEVOPS_*` or a group-wired registry) into its Auto DevOps pipeline | `group.cicd_variables` (inherited) key heuristic | 12 |
+| `_provenance` | object | `{project_path}` | — | all |
+
+## `group`
+
+Group-level settings and the inheritance tree descendants inherit from. Drives the inheritance chain joins.
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `default_membership_role` | enum | role auto-granted via SAML/SCIM: `guest` \| `reporter` \| `developer` \| `maintainer` \| `owner` | `default_membership_role` | 12 |
+| `default_branch_protection` | enum | group default-branch protection default | `default_branch_protection_defaults` | 03 |
+| `project_creation_role` | enum | minimum role that can create projects | `default_project_creation` | 08,12 |
+| `project_access_token_creation_allowed` | bool | descendants may mint project access tokens | `project_access_token_creation_allowed` | 11 |
+| `shared_runners_enabled` | bool | group runners reachable by descendants | group runner settings | 08,12 |
+| `duo_features_enabled` | bool | Duo enabled at group scope | `duoFeaturesEnabled` | 13 |
+| `domain_allowlist` | list | egress allowlist (SSRF surface) | `domain_allowlist` | 12 |
+| `cicd_variables` | list | group variables (same shape as `project.cicd_variables`) | `/groups/:id/variables` | 03,11 |
+| `descendants` | list | project/subgroup paths inheriting from this group | `/groups/:id/projects` (+ subgroups) | 03,11,12 |
+| `group_open_project_creation` | bool | effective: the group permits non-Owner project/subgroup creation so any Developer+ (or open self-service) user can self-create a descendant project reaching the group runner | `project_creation_role` / `subgroup_creation_level` | 12 |
+| `saml_provisioning_active` | bool | group has SAML SSO and/or SCIM provisioning configured (identities auto-provisioned via the IdP) | `/groups/:id/saml` + SCIM token issued | 12 |
+| `default_role_custom_cicd_ability` | bool | effective: the group's `default_membership_role` references a custom member role whose enabled abilities include a CI/CD-admin permission (`admin_cicd_variables`, `manage_project_access_tokens`, `manage_group_access_tokens`, runner management) on a low base role | `default_membership_role` × custom-role ability set | 12 |
+| `_provenance` | object | `{group_path}` | — | all |
+
+## `instance`
+
+Self-managed instance / admin settings. On gitlab.com most are fixed defaults; instance-scope collection needs an admin token.
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `allow_local_requests_from_webhooks` | bool | webhooks/services may reach local network | `allow_local_requests_from_web_hooks_and_services` | 12,14 |
+| `runner_registration_token_allowed` | bool | legacy reusable registration tokens permitted | `allow_runner_registration_token` | 08 |
+| `valid_runner_registrars` | list | who may register runners | `valid_runner_registrars` | 08 |
+| `auto_devops_enabled` | bool | Auto DevOps default on | `auto_devops_enabled` | 12 |
+| `signup_enabled` | bool | open self-registration | `signup_enabled` | 12 |
+| `service_token_expiration_enforced` | bool | service-account tokens must expire | `service_access_tokens_expiration_enforced` | 11 |
+| `duo_features_enabled` | bool | Duo enabled instance-wide | `duoFeaturesEnabled` | 13 |
+| `duo_workflow_mcp_enabled` | bool | external MCP tool calls permitted | `duoWorkflowMcpEnabled` | 13 |
+| `prompt_injection_protection_level` | enum | `no_checks` \| `log_only` \| `interrupt` | `aiSettings.promptInjectionProtectionLevel` | 13 |
+| `project_creation_unrestricted` | bool | project creation is not restricted to admins/specific roles — any authenticated user can create projects | `default_project_creation` application setting | 08 |
+| `can_create_group` | bool | users may create top-level groups (lets an attacker host a fresh project escaping group-level restrictions) | `can_create_group` application setting | 08 |
+| `shared_runners_enabled` | bool | instance runners are enabled at instance level and default-enabled for new projects, so a freshly created project is auto-entitled to the shared instance runner pool | `shared_runners_enabled` application setting (+ new-project default) | 08 |
+| `self_managed_shared_runner_serves_higher_trust` | bool | effective: at least one self-managed instance-shared runner (not GitLab-hosted SaaS) reachable by a new project's default pipeline also services a higher-trust project (protected variables / deploy tokens / protected environments in scope) | `/runners` metadata (runner_type=instance_type, self-managed, ref_protected, run_untagged) cross-referenced with higher-trust project entitlement | 08 |
+| `reusable_token_scope_serves_secrets` | bool | effective: the scope (instance/group/project) reachable via the reusable registration token services pipelines carrying protected variables or deploy credentials — so a rogue runner racing for those jobs steals something of value | runner scope cross-referenced with co-located protected variables / deploy tokens | 08 |
+| `open_project_creation` | bool | effective: any authenticated user can create a project reaching instance runners (instance runners available to new projects AND permissive project/top-level-group creation AND, self-managed, sign-up enabled) | instance runner-for-new-projects × `default_project_creation` × `signup_enabled` | 12 |
+| `outbound_local_requests_allowlist_effective` | bool | a tight local-address allowlist confining which internal hosts webhooks/integrations may reach is in effect (false = empty or overly broad) | `outbound_local_requests_whitelist` | 12 |
+| `require_admin_approval_after_signup` | bool | new self-registered accounts are held for admin approval before becoming active (default false = active immediately) | `require_admin_approval_after_user_signup` | 12 |
+| `closed_audience_instance` | bool | effective: this self-managed instance is not intended to be public (hosts internal/private organisational projects, or open project creation onto shared runners), so open unapproved sign-up is a misconfiguration rather than a community-server norm; not applicable to GitLab.com | instance visibility content + domain_allowlist heuristic | 12 |
+| `_provenance` | object | `{}` | — | all |
+
+## `merge_request`
+
+The project's MR/approval posture (cat-06). Modeled per-project; predicates read the effective configuration.
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `author_approval_allowed` | bool | MR author may approve their own MR | `merge_requests_author_approval` | 06 |
+| `committer_approval_disabled` | bool | committers barred from approving (false = they may) | `merge_requests_disable_committers_approval` | 06 |
+| `approvals_required` | int | minimum approvals to merge | `/approvals` | 06 |
+| `author_controls_approver_count` | bool | author can lower required approvers in-MR | approval rule scope | 06 |
+| `reset_approvals_on_push` | bool | approvals reset after a post-approval commit | `reset_approvals_on_push` | 06 |
+| `code_owner_approval_required` | bool | CODEOWNERS approval enforced | protected-branch rule | 06 |
+| `selective_code_owner_removal` | bool | code-owner requirement resettable selectively | approval config | 06 |
+| `codeowners.optional_sections` | bool | CODEOWNERS has `^[optional]` sections | `CODEOWNERS` | 06 |
+| `codeowners.covers_cicd_config` | bool | CODEOWNERS covers `/.gitlab-ci.yml` | `CODEOWNERS` | 06 |
+| `only_merge_if_pipeline_succeeds` | bool | merge gated on green pipeline | `only_allow_merge_if_pipeline_succeeds` | 06 |
+| `only_merge_if_status_checks_pass` | bool | merge gated on external checks | `only_allow_merge_if_all_status_checks_passed` | 06 |
+| `allow_merge_on_skipped_pipeline` | bool | skipped pipeline counts as success | `allow_merge_on_skipped_pipeline` | 06 |
+| `external_status_checks` | list | configured external status checks | `/external_status_checks` | 06 |
+| `approval_policy` | object | `{enforcement_type: warn\|..., fallback_behavior: fail_open\|fail_closed, scanners: [], bypass_settings, scope_broad: bool}` | security policy project | 06 |
+| `approver_set_broad` | bool | effective: the applicable approval rule's eligible-approver set is broad (a broad group, the Developer role, or "all eligible users"), so a likely author/committer is themselves an eligible approver | approval rule eligible-approver membership × project role model | 06 |
+| `independent_approver_count` | int | count of distinct eligible approvers who are neither the MR author nor a committer on the MR (the enforceable independent-review capacity of the rule) | approval rule eligible-approver set minus author + committer identities | 06 |
+| `trust_relevant_path_optional_only` | bool | effective: at least one trust-relevant path (`.gitlab-ci.yml`, CI include, deploy, `/CODEOWNERS`) is owned in CODEOWNERS only under a `^`-prefixed Optional section, so its owner approval is structurally never required | CODEOWNERS section-header parsing × path trust-relevance | 06 |
+| `approval_policy.enabled` | bool | the merge-request approval policy is present and enabled (relied on as the security-approval gate) | security policy project / policies API (enabled) | 06 |
+| `approval_policy.fallback_behavior` | enum | policy fallback when a rule cannot evaluate: `fail_open` \| `fail_closed` | `approval_policy` `fallback_behavior` (fail: open\|closed) | 06 |
+| `approval_policy.named_scanner_absent` | bool | effective: a scanner named in the policy's `scan_finding` rule has no corresponding job/include in the target project's resolved `.gitlab-ci.yml`, so the rule cannot evaluate | policy `scanners:` × target resolved pipeline jobs | 06 |
+| `approval_policy.enforcement_type` | enum | policy enforcement mode: `warn` (dismissable) vs the blocking mode | `approval_policy` `enforcement_type` | 06 |
+| `approval_policy.binds_trusted_target` | bool | effective: the policy's effective scope actually binds the CI-trusted target branch (false when the target is unprotected, out of `policy_scope`, or the policy is disabled) | policy branches/`policy_scope`/enabled × protected-branches list × CI-trust of branch | 06 |
+| `approval_policy.scope_excludes_target` | bool | the policy's `policy_scope` / `branches` list excludes the target project or branch | `approval_policy` `policy_scope` / `branches:` | 06 |
+| `target_branch_ci_trusted_unprotected` | bool | effective: a CI-trusted target branch (protected variables/runners/deploy-on-merge) is not in the project's protected-branches list, so approval policies (which bind only protected branches) do not enforce there | protected-branches list × CI-trust metadata for the branch | 06 |
+| `approval_policy.bypass_actor_broad` | bool | effective: the policy's `bypass_settings` exempts a broadly-held or lower-trust actor (Developer role, large group, shared token/service account, or permissive branch pattern) rather than a single break-glass identity | `approval_policy` `bypass_settings` × group/role membership breadth | 06 |
+| `required_jobs_evadable` | bool | effective: the project's required security/test jobs are gated behind author-controllable `rules:`/`workflow:` conditions (or `[skip ci]`) so an MR can legitimately produce a skipped/empty pipeline | resolved `.gitlab-ci.yml` `rules:`/`workflow:` analysis | 06 |
+| `codeowners.self_owned_required` | bool | CODEOWNERS contains a required (non-Optional) entry owning its own path (`/CODEOWNERS`, `CODEOWNERS`, `/.gitlab/CODEOWNERS`), so editing the reviewer-defining file itself demands owner approval | CODEOWNERS self-referential path coverage × section requiredness | 06 |
+| `_provenance` | object | `{project_path}` | — | 06 |
+
+## `environment`
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `name` | string | environment name | environments API | 07 |
+| `tier` | enum | `production` \| `staging` \| … (self-declared) | `deployment_tier` | 07 |
+| `protected` | bool | environment is a protected environment | `/protected_environments` | 07 |
+| `self_declared_scope` | bool | name/scope treated as a boundary but not backed by protection | derived | 07 |
+| `deploy_approvals_required` | int | required deployment approvals | `required_approval_count` | 07 |
+| `approval_rules` | list | `{access_level, is_bot, self_approval_allowed}` | `approval_rules[]` | 07 |
+| `allow_pipeline_trigger_approve_deployment` | bool | protected environment permits the pipeline triggerer to approve their own pending deployment (the per-env 'Allow pipeline triggerer to approve deployment' toggle) | `/protected_environments` `allow_pipeline_trigger_approve_deployment` | 07 |
+| `carries_deploy_context` | bool | effective: the environment carries real deploy context worth gating (an environment-scoped deploy credential whose `environment_scope` matches its name, an `id_tokens`/OIDC deploy identity, or a production/staging `deployment_tier`) rather than being a throwaway review env | `cicd_variables.environment_scope` × environment name / `id_tokens:` / `deployment_tier` | 07 |
+| `near_miss_protected_name` | bool | effective: this environment name has no exact-match Protected Environments entry but is a near-neighbor of a protected name (case-insensitive equal, differs only by a `/<suffix>`, or a common alias such as prod↔production), so project-level exact-match protection does not cover it | environment name set (`environment:name` across jobs) diffed against `/projects/:id/protected_environments` exact names | 07 |
+| `group_tier_protection_escaped` | bool | effective: a top-level group protects a `deployment_tier` set, but this environment's self-declared `deployment_tier` (or the guessed default) falls outside that set and no project-level Protected Environments entry covers it, so the group's tier-scoped deploy-access/approval rules do not apply | `/groups/:id/protected_environments` protected tiers × environment `deployment_tier` × `/projects/:id/protected_environments` | 07 |
+| `approval_rule_bot_approver` | bool | effective: at least one `approval_rules[]` member is a non-human principal (a service account or a group/project access-token bot user, `is_bot == true`) that is an eligible approver — so an automatable identity can supply a required deployment approval | `approval_rules[]` `is_bot` member classification | 07 |
+| `_provenance` | object | `{project_path}` | — | 07 |
+
+## `runner`
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `runner_type` | enum | `instance_type` \| `group_type` \| `project_type` | `runner_type` | 08 |
+| `is_shared` | bool | shared across projects | `is_shared` | 08,12 |
+| `ref_protected` | bool | only runs protected-ref jobs | `access_level == ref_protected` | 08 |
+| `run_untagged` | bool | picks up untagged jobs | `run_untagged` | 01,12 |
+| `locked` | bool | locked to its project | `locked` | 12 |
+| `tags` | set | runner tags | `tags` | 08,13 |
+| `projects` | list | projects sharing this runner (co-residency) | `/runners/:id/projects` | 08 |
+| `registration_token_reusable` | bool | registered via a reusable token | instance setting × runner | 08 |
+| `self_managed` | bool | runner is self-managed (operator-controlled host lifecycle), not a GitLab-hosted ephemeral SaaS runner. Load-bearing classifier that separates a finding from safe ephemeral SaaS runners | runner platform/description metadata / runner_type classification | 08 |
+| `spans_trust_boundary` | bool | effective: this runner is entitled to (or its projects list contains) both a low-trust/broad-membership project and at least one higher-trust project (protected variables / deploy tokens / protected environments) — i.e. its scope straddles a trust boundary | `/runners/:id/projects` (or instance/group entitlement) cross-referenced with per-project protected variables / protected environments / membership breadth | 08 |
+| `serves_protected_ref_only_jobs` | bool | effective: the runner (by id/tag) is targeted by jobs that run only on protected refs (`rules:if $CI_COMMIT_REF_PROTECTED` or `only:[main,tags]`) — marking it a trusted/deploy runner | jobs' `rules:`/`only:` resolution cross-referenced with runner tags/id | 08 |
+| `serves_untrusted_ref_jobs` | bool | effective: the same runner also picks up jobs reachable from arbitrary/non-protected branches — no protected-ref separation between trusted and untrusted workloads on the runner | jobs' ref/rules resolution cross-referenced with runner tags/id | 08 |
+| `untrusted_ref_job_matches_tags` | bool | effective: an attacker-writable `.gitlab-ci.yml` on a non-protected ref carries `tags:` matching this runner (no CODEOWNERS/required-review gate on `.gitlab-ci.yml`), so a job can be deliberately steered onto it | jobs' `tags:` (from attacker-writable `.gitlab-ci.yml`) cross-referenced with runner tags | 08 |
+| `bridges_trust_boundary` | bool | effective: this project runner is enabled on ≥2 projects of differing trust (e.g. one with protected variables/environments, one without) | `runner.projects` × per-project protected-var/protected-env posture | 12 |
+| `_provenance` | object | `{scope}` | — | 08 |
+
+## `agent`
+
+Kubernetes agent `ci_access` (cat-15). The decisive control (in-cluster RBAC) is deferred — these carry `confidence: low` in the corpus.
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `config_path` | string | agent config file | `.gitlab/agents/<name>/config.yaml` | 15 |
+| `ci_access_scope` | enum | `project` \| `group` \| `instance` | `ci_access.{projects,groups,instance}` | 12,15 |
+| `ci_access_targets` | list | groups/projects granted CI access | `ci_access.groups` / `.projects` | 15 |
+| `implicit_config_project` | bool | grant implied by config-project location, not explicit | agent config location | 15 |
+| `protected_branches_only` | bool | access limited to protected branches | `protected_branches_only` | 15 |
+| `environments_filter` | list | `environments:` scoping (forgeable if self-declared) | `ci_access.environments` | 15 |
+| `impersonation` | object | `access_as` impersonation config | `access_as` | 15 |
+| `default_permissions` | bool | uses default (broad) permissions | `defaultPermissions` | 04,15 |
+| `grant_has_lower_trust_developer` | bool | effective: at least one lower-trust Developer-role (access level 30) member exists in the authorized group subtree who does not otherwise hold cluster access (folds agent grant → group/subgroup/project membership join) | `ci_access.groups[]` × group/subgroup/project `/members/all` | 15 |
+| `grant_developer_pushable_unprotected_branch` | bool | effective: an authorized (project-scoped) grant reaches a project where a Developer-role member can push at least one non-protected branch whose pipeline is authorized (folds agent grant → project members + protected-branches join) | `ci_access.projects[]` × `/members/all` × `/protected_branches` | 15 |
+| `config_project_developer_reachable` | bool | effective: the implicitly-authorized agent configuration project has Developer-role members (or a Developer-pushable non-protected branch) who are not cluster operators (folds config-project location → its membership + protected-branches join) | agent config project × `/members/all` × `/protected_branches` | 15 |
+| `instance_agent_authorization_enabled` | bool | effective: the self-managed admin setting permitting instance-level agent authorization is enabled, so a `ci_access.instance` grant takes effect (folds instance setting onto the agent subject) | instance admin setting for instance-level agent authorization | 15 |
+| `environments_filter_wildcard` | bool | the `ci_access` environments filter contains a wildcard entry (`*` or a prefix/suffix wildcard such as `review/*`) that matches attacker-authored environment slugs | `ci_access.*.environments` (shape analysis) | 15 |
+| `environments_filter_unprotected` | bool | effective: at least one fixed (non-wildcard) name in the `ci_access` environments filter is absent from the in-scope project's protected-environments list (or protected with a Developer-inclusive deployer list), so the name gates nothing (folds filter → protected-environments API join) | `ci_access.*.environments` × `/projects/:id/protected_environments` | 15 |
+| `grant_developer_authors_matching_env_job` | bool | effective: a Developer in an in-scope project can author a job that sets `environment:` to a filter-matching value while running on a non-protected ref (folds agent grant → resolved `.gitlab-ci.yml` + members + protected-branches) | `ci_access` grant × resolved `.gitlab-ci.yml` × `/members/all` × `/protected_branches` | 15 |
+| `namespace_plan` | enum | the namespace billing plan: `free` \| `premium` \| `ultimate` — on free, protected environments and impersonation do not exist | namespace/plan metadata API | 15 |
+| `grant_protected_ref_developer_writable` | bool | effective: an in-scope project has a protected branch whose push/merge access includes the Developer level, a wildcard protected pattern a Developer may create matching branches under, or a protected tag a Developer may create — so a Developer can land a pipeline on a ref satisfying `protected_branches_only` (folds agent grant → protected-branches + protected-tags API join) | `ci_access` grant × `/protected_branches` × `/protected_tags` | 15 |
+| `_provenance` | object | `{project_path}` | — | 15 |
+
+## `credential`
+
+One record per long-lived credential (cat-11). Values are never collected; reachability via a variable is a deferred leg (hence `confidence: medium\|low`).
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `kind` | enum | `project_access_token` \| `group_access_token` \| `personal_access_token` \| `deploy_token` \| `deploy_key` \| `static_cloud_cred` | resource API / heuristic | 11 |
+| `scopes` | set | granted scopes | `scopes` | 11 |
+| `access_level` | enum | role of the token/backing identity | `access_level` | 11 |
+| `non_expiring` | bool | no expiry set | `expires_at == null` | 11 |
+| `revoked` | bool | revoked/expired | `revoked` / `expired` | 11 |
+| `auto_injected` | bool | structurally injected into CI (e.g. `gitlab-deploy-token`) | `name == "gitlab-deploy-token"` | 11 |
+| `in_unprotected_variable` | bool | credential believed reachable via an unprotected variable (deferred) | `cicd_variables` key heuristic | 11 |
+| `key_pattern` | enum | variable key matches `*DEPLOY_KEY*` / PAT / cloud-cred pattern | variable key | 11 |
+| `deploy_key_fingerprint` | string | public-key fingerprint (for reuse join) | `/deploy_keys` | 11 |
+| `can_push` | bool | write-capable deploy key | `can_push` | 11 |
+| `backing_identity_breadth` | list | projects/groups the backing identity is a member of | `/users/:id/memberships` | 11 |
+| `is_schedule_owner` | bool | the pipeline's triggering identity owns the schedule that starts the run | schedule metadata | 04 |
+| `creator_has_target_protected_access` | bool | the credential's creator holds protected-resource access on the target project | membership × `/protected_branches` | 11 |
+| `scope_level` | enum | origin scope of an access/deploy token: `project` \| `group` \| `instance` — distinguishes project vs group deploy/access tokens (group tokens inherit tree-wide). Contract has `scope_level` only inside `cicd_variables` entries; this lifts it to the credential subject | resource API (project vs group deploy_tokens / access_tokens endpoint) | 11 |
+| `service_account` | bool | the token's backing identity is a GitLab service account (vs a human user), distinguishing scenario 04 from scenario 03 | service-accounts API / user type | 11 |
+| `long_lived` | bool | effective: `expires_at` is null OR far in the future (≥ ~330 days out) — covers both the legacy non-expiring service-account token and the current ~1-year default, per scenario 04's core signal which `non_expiring` (`expires_at == null`) alone cannot express | `expires_at` + instance `service_token_expiration_enforced` | 11 |
+| `name` | string | the token's name (used in evidence templating; `auto_injected` derives from `name == "gitlab-deploy-token"`) | deploy/access token `name` | 11 |
+| `project_uses_oidc` | bool | effective: the credential's project (or inherited group) resolves an `id_tokens:` OIDC path for cloud auth; folds scenario 09's "no `id_tokens` block" compounding signal onto the credential subject so its absence (`!= true`) flags static-key retention | resolved `.gitlab-ci.yml` `id_tokens:` (including `include:`) | 11 |
+| `_provenance` | object | `{scope}` | — | 11 |
+
+## `integration`
+
+Webhooks, integrations, pull-mirroring, Pages (cat-14, cat-12).
+
+| Field | Type | Meaning | Source | Families |
+|---|---|---|---|---|
+| `kind` | enum | `webhook` \| `integration` \| `pull_mirror` \| `pages` | resource type | 12,14 |
+| `url` | string | target URL | `url` / `import_url` | 14 |
+| `url_mutable` | bool | URL editable by a lower-trust role (redirect/SSRF surface) | member roles × integration | 14 |
+| `token_present` | bool | a secret/credential is attached | `token_present` | 14 |
+| `custom_headers` | list | custom HTTP headers (may carry creds) | `custom_headers[]` | 14 |
+| `allows_local_network` | bool | may reach internal/local addresses | integration × instance `allow_local_requests_*` | 12,14 |
+| `mirror.trigger_pipelines` | bool | mirrored refs auto-run CI | mirror settings | 14 |
+| `mirror.all_branches` | bool | mirror pulls all branches | mirror settings | 14 |
+| `pages.reads_secret` | bool | a Pages job reads a secret into `public/` | job × `pages:` | 14 |
+| `webhook_signing_token_present` | bool | webhook has a per-request HMAC signing token (the non-replayable alternative to a shared secret token) | webhook signing-token metadata | 14 |
+| `firable_event_trigger` | bool | the webhook/integration has at least one enabled event trigger a lower-trust role can cause on demand (push/note/merge_requests/pipeline/issues), or a Maintainer-invokable Test-settings delivery | hook/integration event-trigger flags | 14 |
+| `editor_below_credential_trust` | bool | effective: a role that can edit the delivery/server URL (Maintainer / group Owner) sits below the trust level of the write-only credential attached, and is not the credential-setter | membership roles × hook/integration credential ownership | 14 |
+| `mirror.upstream_untrusted_host` | bool | the pull-mirror `import_url` host is external to the project's own group/namespace (lower-trust upstream) | `import_url` host vs instance/group | 14 |
+| `mirror.protected_default_branch` | bool | effective: the mirrored default branch is protected, so the auto-triggered mirror pipeline runs in a trusted context | mirror settings × project protected_branches | 14 |
+| `mirror.reaches_protected_variable` | bool | effective: a protected CI/CD variable is reachable by the auto-triggered mirror pipeline on the protected mirrored branch | project/group `cicd_variables` × mirror branch protection | 14 |
+| `mirror.reaches_unprotected_variable` | bool | effective: an unprotected (or masked) CI/CD variable is reachable by the auto-triggered mirror pipeline on any mirrored branch | project/group `cicd_variables` × mirror all-branches | 14 |
+| `mirror.job_token_push_allowed` | bool | effective: the mirroring project permits the CI job token to push to the repository (`ci_push_repository_for_job_token_allowed`) | `project.job_token_push_allowed` folded onto the pull-mirror record | 14 |
+| `_provenance` | object | `{project_path}` | — | 12,14 |
+
+## Chain joins (`correlate` keyspaces)
+
+`subject: chain` rules join facts across records. Each keyspace below is a correlation `correlate` (part of normalize, LAB-4288) must materialize; the rule then reads participant fields by role prefix. Names reuse the GitHub set where semantics match (`cache-keyspace`, `deploy-key-reuse`, `env-deployments`).
+
+The `for_each` column is the item-list key each join's output must expose — the rule's `chain_of.for_each` reads it, and `iterChainItems` defaults to `links` when a rule omits it (so an unset `for_each` silently iterates nothing). Every chain rule sets it explicitly; the normalizer must emit each join's tuples under exactly this key. Names reuse the GitHub item names where the join is shared (`cache-keyspace` → `prefix_overlaps`, `deploy-key-reuse` → `reused_keys`, `env-deployments` → `deploys`, edge-lists → `edges`).
+
+| `join:` | `for_each` | Correlates | Participant fields (examples) | Families |
+|---|---|---|---|---|
+| `dotenv-flow` | `edges` | producer job → consumer job via dotenv artifact | `producer.produces_dotenv`, `producer.runs_on_untrusted_ref`, `consumer.consumes_dotenv`, `consumer.image_from_variable` | 09 |
+| `cache-keyspace` | `prefix_overlaps` | jobs sharing a cache key prefix across a trust boundary | `writer.runs_on_untrusted_ref`, `reader.protected_ref_gate`, overlap on `cache.key` | 09 |
+| `job-token-allowlist` | `edges` | source project token posture → target project inbound allowlist + triggerer role | `source.inbound_job_token_scope_enabled`, `source.source_ci_writable_by_lower_trust`, `target.job_token_allowlist`, `triggerer.access_level`, `triggerer.is_bot`, `triggerer.is_schedule_owner` (Pipeline Schedules API owner) | 01,04,09 |
+| `cross-project-artifact` | `edges` | `needs:project:` consumer → producer project trust | `consumer.cross_project_needs`, `producer.visibility`, `producer.has_developer_reachable_secret` | 02,09 |
+| `deploy-key-reuse` | `reused_keys` | same deploy-key fingerprint across projects | `key.deploy_key_fingerprint`, `key.can_push`, `key.creator_has_target_protected_access` (the key's creating user holds access to the `target` project's protected environments/variables — the privilege the pushed pipeline inherits), per-project `access_level`, `source.in_unprotected_variable`, `target.holds_protected_resources` (the `target` project holds protected environments and/or protected CI/CD variables, marking it the higher-trust side of the span) | 11 |
+| `protected-var-reachability` | `reachable_vars` | protected variable ↔ the ref path that reaches it. The join itself resolves the two correlations the DSL cannot express in `where` (its predicate RHS is always a literal, never a field reference): (a) the ref/member project lies in the variable's inheritance scope (`group.descendants`, or any project for instance-scope), and (b) `member` belongs to the same project as the `branch`/`tag` participant. It emits only tuples where both hold, so rules carry **only literal-valued predicates** (`var.protected == true`, `branch.push_access_levels ∋ {30}`, `member.access_level == 30`, …). | `var.protected`, `var.scope_level`, `branch.push_access_levels`, `tag.create_access_levels`, `group.default_branch_protection`, `member.access_level` | 01,03,05 |
+| `oidc-trust` | `edges` | id_token job ↔ sub-claim narrowing ↔ ref protection | `job.mints_id_token`, `job.runs_on_untrusted_ref`, `project.oidc.sub_claim_components`, `job.environment_name` | 01,10 |
+| `agent-ci-access` | `grants` | agent grant ↔ target membership ↔ branch/env guard | `agent.ci_access_scope`, `agent.protected_branches_only`, `agent.environments_filter`, `project.protected_branches` | 12,15 |
+| `runner-reachability` | `reachable_runners` | instance/shared runner posture ↔ the instance open-project-creation posture that lets any account reach it | `runner.runner_type`, `runner.is_shared`, `runner.run_untagged`, `runner.ref_protected`, `instance.open_project_creation` | 12 |
+| `group-runner-reachability` | `reachable_runners` | group-scoped runner ↔ its owning group's creation-governance posture (inherited to all descendants) | `runner.runner_type`, `runner.run_untagged`, `runner.ref_protected`, `group.group_open_project_creation` | 12 |
+| `env-deployments` | `deploys` | protected environment ↔ approver identity | `environment.protected`, `environment.approval_rules[].self_approval_allowed`, `environment.approval_rules[].is_bot` | 07 |
+| `mirror-pipeline` | `edges` | pull mirror ↔ auto-run upstream CI ↔ write-back protection | `integration.mirror.trigger_pipelines`, `project.has_cicd_config`, `project.protected_branches` | 14 |
+| `group-inheritance` | `edges` | group setting/token/variable ↔ descendant membership | `group.default_membership_role`, `group.cicd_variables`, `group.descendants`, `member.access_level` | 03,11,12 |
+
+## Engine dependencies (not in scope of the rule PRs)
+
+These rules stay inert until three pieces of Go land — none of which is a catalog PR:
+
+1. **Loader dispatch** — `LoadRules` (`internal/github/rules.go:116`) walks a hardcoded `"github"` subtree; a GitLab equivalent (or a platform-parameterized loader) must walk `gitlab`.
+2. **Subject-kind registration** — `subjectDirs` (`internal/github/scan.go:15`) must gain the kinds in the table above, or a GitLab rule's subject silently loads zero records.
+3. **`normalize` + `correlate` (LAB-4288)** — must emit the records and join keyspaces defined here.
+
+Track these under the engine-generalization ticket; the catalog PRs depend on them to produce findings, and behavioral validation against the firing range (LAB-4297) is gated on all three.

--- a/internal/engine/paths.go
+++ b/internal/engine/paths.go
@@ -252,6 +252,37 @@ func CollectGLUserMemberships(id int64) string {
 	return glCollect("user-memberships", fmt.Sprintf("%d.json", id))
 }
 
+// ---- GitLab normalize paths ----
+//
+// Node records key by glKey(subjectKey); jobs by project + workflow stem + job
+// name; chains one file per join. NormalizeGLChain is the GitLab analog of the
+// GitHub unexported chainPath.
+func glNormalize(parts ...string) string {
+	return path.Join(append([]string{dirNormalize}, parts...)...)
+}
+
+func NormalizeGLProject(p string) string      { return glNormalize("projects", glKey(p)+".json") }
+func NormalizeGLGroup(g string) string        { return glNormalize("groups", glKey(g)+".json") }
+func NormalizeGLInstance() string             { return glNormalize("instance", "instance.json") }
+func NormalizeGLMergeRequest(p string) string { return glNormalize("merge-requests", glKey(p)+".json") }
+func NormalizeGLEnvironment(p, env string) string {
+	return glNormalize("environments", glKey(p), glKey(env)+".json")
+}
+func NormalizeGLRunner(id int64) string { return glNormalize("runners", fmt.Sprintf("%d.json", id)) }
+func NormalizeGLAgent(p, name string) string {
+	return glNormalize("agents", glKey(p), glKey(name)+".json")
+}
+func NormalizeGLCredential(kind, key string) string {
+	return glNormalize("credentials", kind, glKey(key)+".json")
+}
+func NormalizeGLIntegration(p, kind, key string) string {
+	return glNormalize("integrations", glKey(p), kind+"-"+glKey(key)+".json")
+}
+func NormalizeGLJob(p, workflow, jobName string) string {
+	return glNormalize("jobs", fmt.Sprintf("%s__%s__%s.json", glKey(p), wfStem(workflow), glKey(jobName)))
+}
+func NormalizeGLChain(join string) string { return glNormalize("chains", join+".json") }
+
 func NormalizeJob(repo, workflow, jobID string) string {
 	return path.Join(dirNormalize, "jobs",
 		fmt.Sprintf("%s__%s__%s.json", repo, wfStem(workflow), jobID))

--- a/internal/gitlab/correlate.go
+++ b/internal/gitlab/correlate.go
@@ -1,0 +1,914 @@
+package gitlab
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// correlate loads the normalized corpus back as generic maps and writes the nine
+// chains/<join>.json files the chain rules read. Each file is one JSON object
+// carrying its tuples under the exact for_each key the rules iterate (an unset or
+// mismatched key silently iterates nothing), with each tuple nesting the
+// participant records under their role prefix (producer./consumer./source./…) so
+// a rule's chain_of.where resolves role.field by nested map access.
+//
+// A join that fails to load its inputs is a phase-fatal error; per-tuple issues
+// (a job whose project record is missing, a malformed member map) are skipped so
+// one bad subject never sinks the run.
+func correlate(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, org string, timer *engine.PhaseTimer) error {
+	jobs, err := loadRecords(prior, "10-normalize/jobs")
+	if err != nil {
+		return fmt.Errorf("correlate: load jobs: %w", err)
+	}
+	projects, err := loadRecords(prior, "10-normalize/projects")
+	if err != nil {
+		return fmt.Errorf("correlate: load projects: %w", err)
+	}
+	groups, err := loadRecords(prior, "10-normalize/groups")
+	if err != nil {
+		return fmt.Errorf("correlate: load groups: %w", err)
+	}
+	instances, err := loadRecords(prior, "10-normalize/instance")
+	if err != nil {
+		return fmt.Errorf("correlate: load instance: %w", err)
+	}
+	runners, err := loadRecords(prior, "10-normalize/runners")
+	if err != nil {
+		return fmt.Errorf("correlate: load runners: %w", err)
+	}
+	agents, err := loadRecords(prior, "10-normalize/agents")
+	if err != nil {
+		return fmt.Errorf("correlate: load agents: %w", err)
+	}
+	credentials, err := loadRecords(prior, "10-normalize/credentials")
+	if err != nil {
+		return fmt.Errorf("correlate: load credentials: %w", err)
+	}
+
+	c := &correlator{
+		org:       org,
+		jobs:      jobs,
+		projects:  indexByID(projects),
+		groups:    indexByID(groups),
+		instance:  firstOrEmpty(instances),
+		runners:   runners,
+		agents:    agents,
+		creds:     credentials,
+		projList:  projects,
+		groupList: groups,
+	}
+
+	for _, w := range []struct {
+		join string
+		fn   func() map[string]any
+	}{
+		{"job-token-allowlist", c.jobTokenAllowlist},
+		{"protected-var-reachability", c.protectedVarReachability},
+		{"dotenv-flow", c.dotenvFlow},
+		{"cache-keyspace", c.cacheKeyspace},
+		{"cross-project-artifact", c.crossProjectArtifact},
+		{"deploy-key-reuse", c.deployKeyReuse},
+		{"agent-ci-access", c.agentCIAccess},
+		{"runner-reachability", c.runnerReachability},
+		{"group-runner-reachability", c.groupRunnerReachability},
+	} {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := emit(cp, timer, engine.NormalizeGLChain(w.join), w.fn()); err != nil {
+			return fmt.Errorf("correlate: write %s: %w", w.join, err)
+		}
+	}
+	return nil
+}
+
+type correlator struct {
+	org       string
+	jobs      []map[string]any
+	projects  map[string]map[string]any
+	groups    map[string]map[string]any
+	instance  map[string]any
+	runners   []map[string]any
+	agents    []map[string]any
+	creds     []map[string]any
+	projList  []map[string]any
+	groupList []map[string]any
+}
+
+func indexByID(recs []map[string]any) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(recs))
+	for _, r := range recs {
+		out[mStr(r, "_id")] = r
+	}
+	return out
+}
+
+func firstOrEmpty(recs []map[string]any) map[string]any {
+	if len(recs) > 0 {
+		return recs[0]
+	}
+	return map[string]any{}
+}
+
+// jobProject splits a job _id ("project/path:jobname") into its project path.
+func jobProject(job map[string]any) string {
+	id := mStr(job, "_id")
+	i := strings.LastIndex(id, ":")
+	if i < 0 {
+		return ""
+	}
+	return id[:i]
+}
+
+// ---- JOIN 1: job-token-allowlist (for_each: edges) — heaviest, x6 rules ----
+//
+// A source project whose CI uses another project's job token (needs:project: or
+// a CI_JOB_TOKEN script use) is the token-bearing side; the target project's
+// inbound allowlist is what admits it. The edge carries the source posture, the
+// target allowlist, and the triggerer role so cat-01/04/09 rules read literals.
+func (c *correlator) jobTokenAllowlist() map[string]any {
+	edges := []map[string]any{}
+	for _, job := range c.jobs {
+		srcPath := jobProject(job)
+		src := c.projects[srcPath]
+		if src == nil {
+			continue
+		}
+		targets := jobTokenTargets(job)
+		if len(targets) == 0 {
+			continue
+		}
+		srcPart := map[string]any{
+			"_id":                                  srcPath,
+			"inbound_job_token_scope_enabled":      mBool(src, "inbound_job_token_scope_enabled"),
+			"source_ci_writable_by_lower_trust":    mGet(job, "source_ci_writable_by_lower_trust"),
+			"job_token_push_allowed":               mBool(src, "job_token_push_allowed"),
+			"job_token_cross_project_push_allowed": mBool(src, "job_token_cross_project_push_allowed"),
+			"job_token_cross_project_use":          mStr(job, "job_token_cross_project_use"),
+		}
+		triggerer := c.triggererRole(src)
+		for _, tgtPath := range targets {
+			tgt := c.projects[tgtPath]
+			allowlist := map[string]any{"mode": "open", "entries": []any{}, "fine_grained": false}
+			tgtInbound := false
+			var tgtVisibility any
+			if tgt != nil {
+				if al := mMap(tgt, "job_token_allowlist"); al != nil {
+					allowlist = al
+				}
+				tgtInbound = mBool(tgt, "inbound_job_token_scope_enabled")
+				tgtVisibility = mGet(tgt, "visibility")
+			}
+			admits := allowlistAdmits(allowlist, srcPath)
+			// trusts_source is the admit flag the rules read at
+			// target.job_token_allowlist.trusts_source; kept also at
+			// target.source_in_allowlist for older references.
+			allowlist = withTrustsSource(allowlist, admits)
+			edges = append(edges, map[string]any{
+				"_id":    fmt.Sprintf("jtoken__%s__%s", srcPath, tgtPath),
+				"source": srcPart,
+				"target": map[string]any{
+					"_id":                                    tgtPath,
+					"present":                                tgt != nil,
+					"job_token_allowlist":                    allowlist,
+					"inbound_job_token_scope_enabled":        tgtInbound,
+					"source_in_allowlist":                    admits,
+					"visibility":                             tgtVisibility,
+					"uses_managed_terraform_state":           tgt != nil && mBool(tgt, "uses_managed_terraform_state"),
+					"job_token_push_allowed":                 tgt != nil && mBool(tgt, "job_token_push_allowed"),
+					"job_token_cross_project_push_allowed":   tgt != nil && mBool(tgt, "job_token_cross_project_push_allowed"),
+					"developer_writable_protected_branch":    tgt != nil && mBool(tgt, "developer_writable_protected_branch"),
+					"has_developer_pushable_unprotected_ref": tgt != nil && mBool(tgt, "has_developer_pushable_unprotected_ref"),
+				},
+				"triggerer": triggerer,
+			})
+		}
+	}
+	return map[string]any{"chain": "job-token-allowlist", "edges": edges, "edge_count": len(edges)}
+}
+
+// jobTokenTargets is the set of other projects a job reaches with its job token:
+// explicit needs:project: targets, plus (when the script drives CI_JOB_TOKEN at
+// another project we cannot name statically) the source project itself as a
+// self-referential marker so the token-posture rules still see an edge.
+func jobTokenTargets(job map[string]any) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(p string) {
+		if p != "" && !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	for _, raw := range mList(job, "cross_project_needs") {
+		add(mStr(entMap(raw), "project"))
+	}
+	if mStr(job, "job_token_cross_project_use") != "none" {
+		add(jobProject(job))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// withTrustsSource returns a shallow copy of the allowlist carrying trusts_source
+// so the shared target-project record map is never mutated in place.
+func withTrustsSource(allowlist map[string]any, admits bool) map[string]any {
+	out := make(map[string]any, len(allowlist)+1)
+	for k, v := range allowlist {
+		out[k] = v
+	}
+	out["trusts_source"] = admits
+	return out
+}
+
+func allowlistAdmits(allowlist map[string]any, srcPath string) bool {
+	switch mStr(allowlist, "mode") {
+	case "disabled", "open":
+		return true
+	}
+	for _, e := range mList(allowlist, "entries") {
+		if entStr(e) == srcPath {
+			return true
+		}
+	}
+	return false
+}
+
+// triggererRole summarizes the identity that can start the source pipeline. The
+// access_level is the highest role held by any member; is_bot / is_schedule_owner
+// reflect whether a bot member or a schedule owner is present.
+func (c *correlator) triggererRole(src map[string]any) map[string]any {
+	var maxLevel int64
+	bot := false
+	for _, raw := range mList(src, "members") {
+		m := entMap(raw)
+		if lvl := entInt64(m["access_level"]); lvl > maxLevel {
+			maxLevel = lvl
+		}
+		if entBool(m["is_bot"]) {
+			bot = true
+		}
+	}
+	return map[string]any{
+		"access_level":      maxLevel,
+		"is_bot":            bot,
+		"is_schedule_owner": mBool(src, "is_schedule_owner"),
+	}
+}
+
+// ---- JOIN 2: protected-var-reachability (for_each: reachable_vars) ----
+//
+// Self-resolving join (x4 rules): its output tuple pairs a protected variable
+// with a ref (protected branch / tag) and a member that can push to it, BUT the
+// normalizer resolves the two correlations the DSL cannot express — (a) the ref's
+// owning project lies in the variable's inheritance scope, and (b) the member
+// belongs to the same project as the ref. Only tuples where both hold are
+// emitted, so the rules carry only literal-valued predicates.
+func (c *correlator) protectedVarReachability() map[string]any {
+	tuples := []map[string]any{}
+
+	// A project-scoped variable is reachable only from that project's own
+	// protected refs and members (both correlations trivially satisfied).
+	for _, p := range c.projList {
+		for _, raw := range mList(p, "cicd_variables") {
+			v := entMap(raw)
+			if !entBool(v["protected"]) {
+				continue
+			}
+			c.emitVarTuples(&tuples, p, v, "project", c.varScopeGroup(mStr(p, "_id")))
+		}
+	}
+	// A group-scoped variable inherits to every descendant project (correlation
+	// (a) = descendant membership); each descendant's own refs+members satisfy (b).
+	for _, g := range c.groupList {
+		gpath := mStr(g, "_id")
+		for _, raw := range mList(g, "cicd_variables") {
+			v := entMap(raw)
+			if !entBool(v["protected"]) {
+				continue
+			}
+			for _, dp := range c.descendantProjects(g) {
+				if p := c.projects[dp]; p != nil {
+					c.emitVarTuples(&tuples, p, v, "group:"+gpath, g)
+				}
+			}
+		}
+	}
+	// An instance-scoped CI/CD variable (self-managed /admin/ci/variables) inherits
+	// to every project on the instance (correlation (a) = any project); each
+	// project's own refs+members satisfy (b).
+	for _, raw := range mList(c.instance, "cicd_variables") {
+		v := entMap(raw)
+		if !entBool(v["protected"]) {
+			continue
+		}
+		for _, p := range c.projList {
+			c.emitVarTuples(&tuples, p, v, "instance", map[string]any{})
+		}
+	}
+	return map[string]any{"chain": "protected-var-reachability", "reachable_vars": tuples, "var_count": len(tuples)}
+}
+
+// emitVarTuples pairs a reachable protected variable with each (protected ref ×
+// member) of the project it reaches. scopeTag disambiguates project vs group
+// origin in the tuple _id; group is the owning group participant (or empty).
+func (c *correlator) emitVarTuples(tuples *[]map[string]any, p, v map[string]any, scopeTag string, group map[string]any) {
+	proj := mStr(p, "_id")
+	members := mList(p, "members")
+	scopeLevel := "project"
+	switch {
+	case strings.HasPrefix(scopeTag, "group"):
+		scopeLevel = "group"
+	case scopeTag == "instance":
+		scopeLevel = "instance"
+	}
+	provHere := []provenance{{"project_path": proj}}
+	pair := func(refKind string, ref map[string]any) {
+		refPart := withProvenance(ref, provHere)
+		for _, mraw := range members {
+			m := entMap(mraw)
+			tup := map[string]any{
+				"_id":     fmt.Sprintf("pvr__%s__%s__%s:%s__m:%d", scopeTag, mStr(v, "key"), refKind, entStr(ref["pattern"]), entInt64(m["access_level"])),
+				"var":     varParticipant(v, scopeLevel, proj),
+				"branch":  map[string]any{},
+				"tag":     map[string]any{},
+				"group":   group,
+				"member":  withProvenance(memberParticipant(m), provHere),
+				"project": proj,
+			}
+			tup[refKind] = refPart
+			*tuples = append(*tuples, tup)
+		}
+	}
+	for _, braw := range mList(p, "protected_branches") {
+		pair("branch", entMap(braw))
+	}
+	for _, traw := range mList(p, "protected_tags") {
+		pair("tag", entMap(traw))
+	}
+}
+
+// withProvenance returns a shallow copy of a participant carrying _provenance so
+// evidence templates that read {project_path} resolve; the source record map is
+// never mutated in place.
+func withProvenance(m map[string]any, prov []provenance) map[string]any {
+	out := make(map[string]any, len(m)+1)
+	for k, v := range m {
+		out[k] = v
+	}
+	out["_provenance"] = prov
+	return out
+}
+
+func varParticipant(v map[string]any, scopeLevel, proj string) map[string]any {
+	return map[string]any{
+		"key":               mStr(v, "key"),
+		"protected":         mBool(v, "protected"),
+		"masked":            mBool(v, "masked"),
+		"environment_scope": mStr(v, "environment_scope"),
+		"scope_level":       scopeLevel,
+		"project":           proj,
+	}
+}
+
+func memberParticipant(m map[string]any) map[string]any {
+	return map[string]any{
+		"access_level": entInt64(m["access_level"]),
+		"is_bot":       entBool(m["is_bot"]),
+	}
+}
+
+// varScopeGroup surfaces the owning group participant for a project-scoped
+// variable (empty when the project has no parent group in the corpus).
+func (c *correlator) varScopeGroup(proj string) map[string]any {
+	if g := c.groups[parentGroup(proj)]; g != nil {
+		return g
+	}
+	return map[string]any{}
+}
+
+func (c *correlator) descendantProjects(g map[string]any) []string {
+	var out []string
+	for _, raw := range mList(g, "descendants") {
+		if s := entStr(raw); s != "" {
+			if _, isProject := c.projects[s]; isProject {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+// ---- JOIN 3: dotenv-flow (for_each: edges) — x3 rules ----
+//
+// A dotenv artifact produced by one job flows into every consuming job in the
+// same project (dotenv is inherited via the pipeline's needs/dependencies graph).
+func (c *correlator) dotenvFlow() map[string]any {
+	byProject := map[string][]map[string]any{}
+	for _, job := range c.jobs {
+		byProject[jobProject(job)] = append(byProject[jobProject(job)], job)
+	}
+	edges := []map[string]any{}
+	for _, jobs := range byProject {
+		var producers, consumers []map[string]any
+		for _, j := range jobs {
+			if mBool(j, "produces_dotenv") {
+				producers = append(producers, j)
+			}
+			if mBool(j, "consumes_dotenv") {
+				consumers = append(consumers, j)
+			}
+		}
+		for _, prod := range producers {
+			for _, cons := range consumers {
+				if mStr(prod, "_id") == mStr(cons, "_id") {
+					continue
+				}
+				edges = append(edges, map[string]any{
+					"_id":      fmt.Sprintf("dotenv__%s__%s", mStr(prod, "_id"), mStr(cons, "_id")),
+					"producer": dotenvProducer(prod),
+					"consumer": dotenvConsumer(cons),
+				})
+			}
+		}
+	}
+	sortByID(edges)
+	return map[string]any{"chain": "dotenv-flow", "edges": edges, "edge_count": len(edges)}
+}
+
+func dotenvProducer(j map[string]any) map[string]any {
+	return map[string]any{
+		"_id":                                  mStr(j, "_id"),
+		"produces_dotenv":                      mBool(j, "produces_dotenv"),
+		"runs_on_untrusted_ref":                mBool(j, "runs_on_untrusted_ref"),
+		"runs_on_protected_ref":                mBool(j, "runs_on_protected_ref"),
+		"dotenv_content_attacker_influenced":   mBool(j, "dotenv_content_attacker_influenced"),
+		"dotenv_content_from_untrusted_source": mBool(j, "dotenv_content_from_untrusted_source"),
+		"triggers":                             listOrEmptyGL(j, "triggers"),
+	}
+}
+
+func dotenvConsumer(j map[string]any) map[string]any {
+	return map[string]any{
+		"_id":                              mStr(j, "_id"),
+		"consumes_dotenv":                  mBool(j, "consumes_dotenv"),
+		"dotenv_inheritance_unnarrowed":    mBool(j, "dotenv_inheritance_unnarrowed"),
+		"image_from_variable":              mGet(j, "image_from_variable"),
+		"inherited_var_in_exec_sink":       mBool(j, "inherited_var_in_exec_sink"),
+		"dotenv_key_collides_declared_var": mBool(j, "dotenv_key_collides_declared_var"),
+		"colliding_var_in_exec_sink":       mBool(j, "colliding_var_in_exec_sink"),
+		"cross_project_needs":              listOrEmptyGL(j, "cross_project_needs"),
+		"runs_on_protected_ref":            mBool(j, "runs_on_protected_ref"),
+		"protected_ref_gate":               mStr(j, "protected_ref_gate"),
+		"triggers":                         listOrEmptyGL(j, "triggers"),
+	}
+}
+
+// ---- JOIN 4: cache-keyspace (for_each: prefix_overlaps) — x2 rules ----
+//
+// Jobs sharing a static cache-key prefix can poison each other's cache across a
+// trust boundary. Group cache entries by literal key prefix; emit an overlap
+// where ≥2 distinct jobs share it.
+func (c *correlator) cacheKeyspace() map[string]any {
+	byPrefix := map[string][]map[string]any{}
+	for _, job := range c.jobs {
+		for _, raw := range mList(job, "cache") {
+			cache := entMap(raw)
+			prefix := cacheKeyPrefix(mStr(cache, "key"))
+			if prefix == "" {
+				continue
+			}
+			byPrefix[prefix] = append(byPrefix[prefix], map[string]any{"job": job, "cache": cache})
+		}
+	}
+	prefixes := make([]string, 0, len(byPrefix))
+	for p := range byPrefix {
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(prefixes)
+
+	overlaps := []map[string]any{}
+	for _, prefix := range prefixes {
+		participants := byPrefix[prefix]
+		ids := map[string]bool{}
+		for _, part := range participants {
+			ids[mStr(mMap(part, "job"), "_id")] = true
+		}
+		if len(ids) < 2 {
+			continue
+		}
+		writers := []map[string]any{}
+		readers := []map[string]any{}
+		var producer, consumer map[string]any
+		untrustedWriter := false
+		for _, part := range participants {
+			job := mMap(part, "job")
+			cache := mMap(part, "cache")
+			p := cacheParticipant(job, cache)
+			if cachePolicyWritesGL(cache) {
+				writers = append(writers, p)
+				if mBool(job, "runs_on_untrusted_ref") {
+					untrustedWriter = true
+					if producer == nil {
+						producer = p
+					}
+				}
+			} else {
+				readers = append(readers, p)
+			}
+			if consumer == nil && mStr(job, "protected_ref_gate") == "strong" {
+				consumer = p
+			}
+		}
+		overlaps = append(overlaps, map[string]any{
+			"_id":                   "cache_overlap__" + prefix,
+			"key_prefix":            prefix,
+			"producer":              firstOrEmptyMap(producer),
+			"consumer":              firstOrEmptyMap(consumer),
+			"writer":                firstParticipant(writers),
+			"reader":                firstParticipant(readers),
+			"writers":               nonNilList(writers),
+			"readers":               nonNilList(readers),
+			"writer_count":          len(writers),
+			"reader_count":          len(readers),
+			"low_trust_participant": untrustedWriter,
+		})
+	}
+	return map[string]any{"chain": "cache-keyspace", "prefix_overlaps": overlaps, "overlap_count": len(overlaps)}
+}
+
+func cacheParticipant(job, cache map[string]any) map[string]any {
+	return map[string]any{
+		"_id":                               mStr(job, "_id"),
+		"runs_on_untrusted_ref":             mBool(job, "runs_on_untrusted_ref"),
+		"protected_ref_gate":                mStr(job, "protected_ref_gate"),
+		"cache_paths_executable":            mBool(job, "cache_paths_executable"),
+		"cache_key_files_attacker_writable": mBool(job, "cache_key_files_attacker_writable"),
+		"cache_key_static_cross_boundary":   mBool(job, "cache_key_static_cross_boundary"),
+		"cache_policy_writes":               mBool(job, "cache_policy_writes"),
+		"cache_separation_enabled":          mBool(job, "cache_separation_enabled"),
+		"triggers":                          listOrEmptyGL(job, "triggers"),
+		"cache":                             cache,
+	}
+}
+
+func firstOrEmptyMap(m map[string]any) map[string]any {
+	if m != nil {
+		return m
+	}
+	return map[string]any{}
+}
+
+func firstParticipant(list []map[string]any) map[string]any {
+	if len(list) > 0 {
+		return list[0]
+	}
+	return map[string]any{}
+}
+
+// cacheKeyPrefix extracts the literal (non-interpolated) prefix of a cache key.
+// A per-ref key ($CI_COMMIT_REF_SLUG) or a files:-derived key has no shared
+// static prefix and cannot collide across a boundary — return "".
+func cacheKeyPrefix(key string) string {
+	if key == "" {
+		return ""
+	}
+	if i := strings.IndexByte(key, '$'); i >= 0 {
+		key = key[:i]
+	}
+	return strings.Trim(key, "-_/")
+}
+
+func cachePolicyWritesGL(cache map[string]any) bool {
+	return mStr(cache, "policy") != "pull"
+}
+
+// ---- JOIN 5: cross-project-artifact (for_each: edges) — x1 ----
+//
+// A consumer job with needs:project: reaches into a producer project; the edge
+// carries the producer's trust posture so cat-02/09 rules see whether the
+// fetched artifact comes from a lower-trust, developer-reachable source.
+func (c *correlator) crossProjectArtifact() map[string]any {
+	edges := []map[string]any{}
+	for _, job := range c.jobs {
+		needs := mList(job, "cross_project_needs")
+		if len(needs) == 0 {
+			continue
+		}
+		consumer := crossArtifactConsumer(job)
+		consumerPath := jobProject(job)
+		for _, raw := range needs {
+			need := entMap(raw)
+			prodPath := entStr(need["project"])
+			prod := c.projects[prodPath]
+			producer := map[string]any{"_id": prodPath, "present": prod != nil}
+			if prod != nil {
+				devPushable := mBool(prod, "has_developer_pushable_unprotected_ref") || mBool(prod, "developer_writable_protected_branch")
+				producer["visibility"] = mGet(prod, "visibility")
+				producer["has_developer_reachable_secret"] = mBool(prod, "has_developer_reachable_secret")
+				producer["has_developer_pushable_unprotected_ref"] = mBool(prod, "has_developer_pushable_unprotected_ref")
+				producer["developer_writable_protected_branch"] = mBool(prod, "developer_writable_protected_branch")
+				producer["source_ref_developer_pushable"] = devPushable
+				producer["on_consumer_job_token_allowlist"] = allowlistAdmits(mMap(prod, "job_token_allowlist"), consumerPath)
+			}
+			edges = append(edges, map[string]any{
+				"_id":      fmt.Sprintf("xpart__%s__%s", mStr(job, "_id"), prodPath),
+				"consumer": consumer,
+				"producer": producer,
+				"need":     need,
+			})
+		}
+	}
+	return map[string]any{"chain": "cross-project-artifact", "edges": edges, "edge_count": len(edges)}
+}
+
+func crossArtifactConsumer(job map[string]any) map[string]any {
+	return map[string]any{
+		"_id":                                        mStr(job, "_id"),
+		"cross_project_needs":                        listOrEmptyGL(job, "cross_project_needs"),
+		"fetches_cross_project_artifact":             mBool(job, "fetches_cross_project_artifact"),
+		"executes_fetched_artifact":                  mBool(job, "executes_fetched_artifact"),
+		"artifact_integrity_checked":                 mBool(job, "artifact_integrity_checked"),
+		"child_pipeline_from_cross_project_artifact": mBool(job, "child_pipeline_from_cross_project_artifact"),
+		"artifact_source_ref_mutable":                mBool(job, "artifact_source_ref_mutable"),
+		"runs_on_protected_ref":                      mBool(job, "runs_on_protected_ref"),
+		"triggers":                                   listOrEmptyGL(job, "triggers"),
+	}
+}
+
+// ---- JOIN 6: deploy-key-reuse (for_each: reused_keys) — x1 ----
+//
+// The same deploy-key fingerprint added to ≥2 projects spans a trust boundary:
+// a push using the key on the low-trust project inherits access to the others.
+func (c *correlator) deployKeyReuse() map[string]any {
+	type inst struct {
+		project string
+		rec     map[string]any
+	}
+	byFP := map[string][]inst{}
+	var order []string
+	for _, cred := range c.creds {
+		if mStr(cred, "kind") != "deploy_key" {
+			continue
+		}
+		fp, _ := mGet(cred, "deploy_key_fingerprint").(string)
+		if fp == "" {
+			continue
+		}
+		if _, seen := byFP[fp]; !seen {
+			order = append(order, fp)
+		}
+		byFP[fp] = append(byFP[fp], inst{project: credProject(cred), rec: cred})
+	}
+
+	reused := []map[string]any{}
+	for _, fp := range order {
+		hits := byFP[fp]
+		projSet := map[string]bool{}
+		for _, h := range hits {
+			projSet[h.project] = true
+		}
+		if len(projSet) < 2 {
+			continue
+		}
+		anyWrite := false
+		creatorHasAccess := false
+		srcUnprotectedVar := false
+		tgtHoldsProtected := false
+		instances := []any{}
+		projects := []any{}
+		for _, h := range hits {
+			if mBool(h.rec, "can_push") {
+				anyWrite = true
+			}
+			if mBool(h.rec, "creator_has_target_protected_access") {
+				creatorHasAccess = true
+			}
+			if mBool(h.rec, "in_unprotected_variable") {
+				srcUnprotectedVar = true
+			}
+			holds := false
+			if p := c.projects[h.project]; p != nil {
+				holds = mBool(p, "holds_protected_resources")
+			}
+			if holds {
+				tgtHoldsProtected = true
+			}
+			instances = append(instances, map[string]any{
+				"project":                             h.project,
+				"can_push":                            mBool(h.rec, "can_push"),
+				"deploy_key_fingerprint":              mGet(h.rec, "deploy_key_fingerprint"),
+				"access_level":                        mGet(h.rec, "access_level"),
+				"in_unprotected_variable":             mBool(h.rec, "in_unprotected_variable"),
+				"creator_has_target_protected_access": mBool(h.rec, "creator_has_target_protected_access"),
+				"holds_protected_resources":           holds,
+			})
+			projects = append(projects, h.project)
+		}
+		reused = append(reused, map[string]any{
+			"_id": "deploykey_reuse__" + safePrefixGL(fp, 16),
+			"key": map[string]any{
+				"kind":                                "deploy_key",
+				"deploy_key_fingerprint":              fp,
+				"can_push":                            anyWrite,
+				"creator_has_target_protected_access": creatorHasAccess,
+			},
+			"source":            map[string]any{"in_unprotected_variable": srcUnprotectedVar},
+			"target":            map[string]any{"holds_protected_resources": tgtHoldsProtected},
+			"project_count":     len(projSet),
+			"projects":          projects,
+			"any_write_capable": anyWrite,
+			"instances":         instances,
+		})
+	}
+	return map[string]any{"chain": "deploy-key-reuse", "reused_keys": reused, "reuse_count": len(reused)}
+}
+
+// credProject reads the project path off the credential's _provenance scope
+// ("project:<path>").
+func credProject(cred map[string]any) string {
+	for _, raw := range mList(cred, "_provenance") {
+		if s := entStr(entMap(raw)["scope"]); strings.HasPrefix(s, "project:") {
+			return strings.TrimPrefix(s, "project:")
+		}
+	}
+	return ""
+}
+
+// ---- JOIN 7: agent-ci-access (for_each: grants) — x1 ----
+//
+// A GitLab agent's ci_access grant lets pipelines in the target project(s)
+// impersonate the agent against the cluster; the grant tuple carries the agent's
+// guard (protected_branches_only, environments_filter) and each target project's
+// protected-branch posture so cat-12/15 rules resolve reachability.
+func (c *correlator) agentCIAccess() map[string]any {
+	grants := []map[string]any{}
+	for _, agent := range c.agents {
+		agentPart := agentParticipant(agent)
+		targets := mList(agent, "ci_access_targets")
+		if len(targets) == 0 {
+			// implicit_config_project: the agent's own project is the only target.
+			targets = []any{agentProject(agent)}
+		}
+		for _, raw := range targets {
+			tgtPath := entStr(raw)
+			if tgtPath == "" {
+				continue
+			}
+			project := map[string]any{"_id": tgtPath, "present": false, "protected_branches": []any{}}
+			if p := c.projects[tgtPath]; p != nil {
+				project = map[string]any{
+					"_id":                                    tgtPath,
+					"present":                                true,
+					"protected_branches":                     listOrEmptyGL(p, "protected_branches"),
+					"developer_writable_protected_branch":    mBool(p, "developer_writable_protected_branch"),
+					"has_developer_pushable_unprotected_ref": mBool(p, "has_developer_pushable_unprotected_ref"),
+					"default_branch_protected":               mGet(p, "default_branch_protected"),
+					"auto_devops_enabled":                    mBool(p, "auto_devops_enabled"),
+					"has_cicd_config":                        mBool(p, "has_cicd_config"),
+					"has_reachable_runner":                   mBool(p, "has_reachable_runner"),
+				}
+			}
+			grants = append(grants, map[string]any{
+				"_id":     fmt.Sprintf("agentci__%s__%s", mStr(agent, "_id"), tgtPath),
+				"agent":   agentPart,
+				"project": project,
+			})
+		}
+	}
+	return map[string]any{"chain": "agent-ci-access", "grants": grants, "grant_count": len(grants)}
+}
+
+func agentParticipant(agent map[string]any) map[string]any {
+	return map[string]any{
+		"_id":                          mStr(agent, "_id"),
+		"ci_access_scope":              mStr(agent, "ci_access_scope"),
+		"ci_access_targets":            listOrEmptyGL(agent, "ci_access_targets"),
+		"protected_branches_only":      mBool(agent, "protected_branches_only"),
+		"environments_filter":          listOrEmptyGL(agent, "environments_filter"),
+		"environments_filter_wildcard": mBool(agent, "environments_filter_wildcard"),
+		"impersonation":                mGet(agent, "impersonation"),
+		"default_permissions":          mBool(agent, "default_permissions"),
+	}
+}
+
+func agentProject(agent map[string]any) string {
+	id := mStr(agent, "_id")
+	if i := strings.LastIndex(id, "/"); i >= 0 {
+		return id[:i]
+	}
+	return id
+}
+
+// ---- JOIN 8: runner-reachability (for_each: reachable_runners) — x1 ----
+//
+// An instance/shared runner is reachable by any account when the instance permits
+// open project creation; the tuple pairs the runner posture with the instance
+// governance so a cat-12 rule reads both as literals.
+func (c *correlator) runnerReachability() map[string]any {
+	instancePart := map[string]any{
+		"_id":                    "instance",
+		"open_project_creation":  mGet(c.instance, "open_project_creation"),
+		"signup_enabled":         mGet(c.instance, "signup_enabled"),
+		"shared_runners_enabled": mGet(c.instance, "shared_runners_enabled"),
+	}
+	tuples := []map[string]any{}
+	for _, r := range c.runners {
+		if mStr(r, "runner_type") != "instance_type" && !mBool(r, "is_shared") {
+			continue
+		}
+		tuples = append(tuples, map[string]any{
+			"_id":      "runreach__" + mStr(r, "_id"),
+			"runner":   runnerParticipant(r),
+			"instance": instancePart,
+		})
+	}
+	return map[string]any{"chain": "runner-reachability", "reachable_runners": tuples, "runner_count": len(tuples)}
+}
+
+// ---- JOIN 9: group-runner-reachability (for_each: reachable_runners) — x1 ----
+//
+// A group-scoped runner is reachable by any account that can create a project in
+// the owning group (governance inherited to all descendants); the tuple pairs the
+// runner with the group's group_open_project_creation posture.
+func (c *correlator) groupRunnerReachability() map[string]any {
+	tuples := []map[string]any{}
+	for _, r := range c.runners {
+		if mStr(r, "runner_type") != "group_type" {
+			continue
+		}
+		gpath := runnerScopeGroup(r)
+		group := map[string]any{"_id": gpath, "present": false}
+		if g := c.groups[gpath]; g != nil {
+			group = map[string]any{
+				"_id":                         gpath,
+				"present":                     true,
+				"group_open_project_creation": mBool(g, "group_open_project_creation"),
+				"project_creation_role":       mGet(g, "project_creation_role"),
+			}
+		}
+		tuples = append(tuples, map[string]any{
+			"_id":    "grpreach__" + mStr(r, "_id"),
+			"runner": runnerParticipant(r),
+			"group":  group,
+		})
+	}
+	return map[string]any{"chain": "group-runner-reachability", "reachable_runners": tuples, "runner_count": len(tuples)}
+}
+
+func runnerParticipant(r map[string]any) map[string]any {
+	return map[string]any{
+		"_id":           mStr(r, "_id"),
+		"runner_type":   mStr(r, "runner_type"),
+		"is_shared":     mBool(r, "is_shared"),
+		"run_untagged":  mBool(r, "run_untagged"),
+		"ref_protected": mBool(r, "ref_protected"),
+		"self_managed":  mBool(r, "self_managed"),
+		"locked":        mBool(r, "locked"),
+		"tags":          listOrEmptyGL(r, "tags"),
+		"projects":      listOrEmptyGL(r, "projects"),
+	}
+}
+
+// runnerScopeGroup reads the owning group path off the runner's _provenance
+// scope ("group:<path>").
+func runnerScopeGroup(r map[string]any) string {
+	for _, raw := range mList(r, "_provenance") {
+		if s := entStr(entMap(raw)["scope"]); strings.HasPrefix(s, "group:") {
+			return strings.TrimPrefix(s, "group:")
+		}
+	}
+	return ""
+}
+
+// ---- shared helpers ----
+
+func listOrEmptyGL(m map[string]any, key string) []any {
+	if v, ok := mGet(m, key).([]any); ok {
+		return v
+	}
+	return []any{}
+}
+
+func nonNilList(list []map[string]any) []any {
+	out := make([]any, 0, len(list))
+	for _, e := range list {
+		out = append(out, e)
+	}
+	return out
+}
+
+func sortByID(edges []map[string]any) {
+	sort.Slice(edges, func(i, j int) bool { return mStr(edges[i], "_id") < mStr(edges[j], "_id") })
+}
+
+func safePrefixGL(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/internal/gitlab/correlate_participant_fields_test.go
+++ b/internal/gitlab/correlate_participant_fields_test.go
@@ -1,0 +1,178 @@
+package gitlab
+
+import "testing"
+
+// These tests guard the chain-participant field contract: every `<role>.<field>`
+// predicate a chain rule reads must be projected onto that role's participant,
+// sourced from the underlying job/project/credential record. A dropped field
+// resolves to nil under the role prefix and the rule silently never fires. The
+// oracle is the frozen rule set (internal/detection-rules/gitlab/**), not what
+// the correlator happens to produce; joins are near-empty on live SaaS, so the
+// records here are synthetic. requireKeys asserts presence (a projected `false`
+// is a real literal; a missing key is the bug).
+
+func requireKeys(t *testing.T, role string, m map[string]any, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		if _, ok := m[k]; !ok {
+			t.Errorf("%s participant missing projected field %q", role, k)
+		}
+	}
+}
+
+// dotenv-flow (cat-09 x3): producer reads produces_dotenv, runs_on_untrusted_ref,
+// runs_on_protected_ref, dotenv_content_attacker_influenced,
+// dotenv_content_from_untrusted_source; consumer reads consumes_dotenv,
+// cross_project_needs, dotenv_inheritance_unnarrowed, inherited_var_in_exec_sink,
+// dotenv_key_collides_declared_var, colliding_var_in_exec_sink, runs_on_protected_ref.
+func TestDotenvParticipantFields(t *testing.T) {
+	c := &correlator{
+		jobs: []map[string]any{
+			{"_id": "g/p:prod", "produces_dotenv": true, "runs_on_untrusted_ref": true,
+				"runs_on_protected_ref": false, "dotenv_content_attacker_influenced": true,
+				"dotenv_content_from_untrusted_source": true},
+			{"_id": "g/p:cons", "consumes_dotenv": true, "dotenv_inheritance_unnarrowed": true,
+				"inherited_var_in_exec_sink": true, "dotenv_key_collides_declared_var": true,
+				"colliding_var_in_exec_sink": true, "runs_on_protected_ref": true,
+				"cross_project_needs": []any{map[string]any{"project": "g/up"}}},
+		},
+	}
+	e := c.dotenvFlow()["edges"].([]map[string]any)[0]
+	requireKeys(t, "dotenv.producer", e["producer"].(map[string]any),
+		"produces_dotenv", "runs_on_untrusted_ref", "runs_on_protected_ref",
+		"dotenv_content_attacker_influenced", "dotenv_content_from_untrusted_source")
+	cons := e["consumer"].(map[string]any)
+	requireKeys(t, "dotenv.consumer", cons,
+		"consumes_dotenv", "cross_project_needs", "dotenv_inheritance_unnarrowed",
+		"inherited_var_in_exec_sink", "dotenv_key_collides_declared_var",
+		"colliding_var_in_exec_sink", "runs_on_protected_ref")
+	if e["producer"].(map[string]any)["runs_on_protected_ref"] != false {
+		t.Error("producer.runs_on_protected_ref must carry the literal false, not be dropped")
+	}
+	if _, ok := cons["cross_project_needs"].([]any); !ok {
+		t.Error("consumer.cross_project_needs must be a list (C1: [] not null)")
+	}
+}
+
+// cross-project-artifact (cat-09 x1): consumer reads runs_on_protected_ref (plus
+// cross_project_needs, executes_fetched_artifact, artifact_integrity_checked,
+// artifact_source_ref_mutable); producer reads source_ref_developer_pushable and
+// on_consumer_job_token_allowlist.
+func TestCrossProjectArtifactParticipantFields(t *testing.T) {
+	c := &correlator{
+		jobs: []map[string]any{
+			{"_id": "g/cons:gen", "runs_on_protected_ref": true, "executes_fetched_artifact": true,
+				"artifact_integrity_checked": false, "artifact_source_ref_mutable": true,
+				"cross_project_needs": []any{map[string]any{"project": "g/prod", "artifacts": true}}},
+		},
+		projects: map[string]map[string]any{
+			"g/prod": {"_id": "g/prod", "has_developer_pushable_unprotected_ref": true,
+				"job_token_allowlist": map[string]any{"mode": "project_scoped", "entries": []any{"g/cons"}}},
+		},
+	}
+	e := c.crossProjectArtifact()["edges"].([]map[string]any)[0]
+	requireKeys(t, "xpart.consumer", e["consumer"].(map[string]any),
+		"cross_project_needs", "executes_fetched_artifact", "artifact_integrity_checked",
+		"artifact_source_ref_mutable", "runs_on_protected_ref")
+	prod := e["producer"].(map[string]any)
+	requireKeys(t, "xpart.producer", prod, "source_ref_developer_pushable", "on_consumer_job_token_allowlist")
+	if prod["source_ref_developer_pushable"] != true {
+		t.Errorf("producer.source_ref_developer_pushable=%v want true (developer-pushable ref)", prod["source_ref_developer_pushable"])
+	}
+	if prod["on_consumer_job_token_allowlist"] != true {
+		t.Errorf("producer.on_consumer_job_token_allowlist=%v want true (consumer admitted by allowlist)", prod["on_consumer_job_token_allowlist"])
+	}
+}
+
+// agent-ci-access (cat-12 auto-devops): project reads auto_devops_enabled,
+// has_cicd_config, has_reachable_runner (plus agent.ci_access_targets).
+func TestAgentCIAccessProjectFields(t *testing.T) {
+	c := &correlator{
+		agents: []map[string]any{
+			{"_id": "g/p/agent", "ci_access_targets": []any{"g/p"}},
+		},
+		projects: map[string]map[string]any{
+			"g/p": {"_id": "g/p", "auto_devops_enabled": true, "has_cicd_config": false, "has_reachable_runner": true},
+		},
+	}
+	grant := c.agentCIAccess()["grants"].([]map[string]any)[0]
+	requireKeys(t, "agentci.agent", grant["agent"].(map[string]any), "ci_access_targets")
+	proj := grant["project"].(map[string]any)
+	requireKeys(t, "agentci.project", proj, "auto_devops_enabled", "has_cicd_config", "has_reachable_runner")
+	if proj["auto_devops_enabled"] != true || proj["has_cicd_config"] != false || proj["has_reachable_runner"] != true {
+		t.Errorf("project posture not folded: %v", proj)
+	}
+}
+
+// cache-keyspace (cat-09 x2) reads under producer./consumer. role prefixes.
+// producer: cache_separation_enabled, runs_on_untrusted_ref,
+// cache_key_files_attacker_writable, cache_key_static_cross_boundary,
+// cache_policy_writes, cache_paths_executable; consumer: protected_ref_gate,
+// cache_key_files_attacker_writable, cache_key_static_cross_boundary,
+// cache_paths_executable.
+func TestCacheKeyspaceParticipantRoles(t *testing.T) {
+	c := &correlator{
+		jobs: []map[string]any{
+			{"_id": "g/p:build", "runs_on_untrusted_ref": true, "protected_ref_gate": "none",
+				"cache_policy_writes": true, "cache_paths_executable": true,
+				"cache_key_static_cross_boundary": true, "cache_key_files_attacker_writable": true,
+				"cache": []any{map[string]any{"key": "deps-v1", "policy": "pull-push"}}},
+			{"_id": "g/p:deploy", "runs_on_untrusted_ref": false, "protected_ref_gate": "strong",
+				"cache_paths_executable": true, "cache_key_static_cross_boundary": true,
+				"cache": []any{map[string]any{"key": "deps-v1", "policy": "pull"}}},
+		},
+	}
+	ov := c.cacheKeyspace()["prefix_overlaps"].([]map[string]any)
+	if len(ov) != 1 {
+		t.Fatalf("overlaps=%d want 1", len(ov))
+	}
+	prod := ov[0]["producer"].(map[string]any)
+	cons := ov[0]["consumer"].(map[string]any)
+	requireKeys(t, "cache.producer", prod, "cache_separation_enabled", "runs_on_untrusted_ref",
+		"cache_key_files_attacker_writable", "cache_key_static_cross_boundary",
+		"cache_policy_writes", "cache_paths_executable")
+	requireKeys(t, "cache.consumer", cons, "protected_ref_gate", "cache_key_files_attacker_writable",
+		"cache_key_static_cross_boundary", "cache_paths_executable")
+	if prod["runs_on_untrusted_ref"] != true {
+		t.Error("producer role must be the untrusted-ref writer")
+	}
+	if cons["protected_ref_gate"] != "strong" {
+		t.Error("consumer role must be the strong-gate participant")
+	}
+}
+
+// deploy-key-reuse (cat-11 x1): key reads kind, can_push,
+// creator_has_target_protected_access; source reads in_unprotected_variable;
+// target reads holds_protected_resources.
+func TestDeployKeyReuseParticipantRoles(t *testing.T) {
+	c := &correlator{
+		creds: []map[string]any{
+			{"kind": "deploy_key", "deploy_key_fingerprint": "SHA256:abc", "can_push": true,
+				"in_unprotected_variable": true, "creator_has_target_protected_access": true,
+				"_provenance": []any{map[string]any{"scope": "project:g/low"}}},
+			{"kind": "deploy_key", "deploy_key_fingerprint": "SHA256:abc", "can_push": false,
+				"_provenance": []any{map[string]any{"scope": "project:g/high"}}},
+		},
+		projects: map[string]map[string]any{
+			"g/high": {"_id": "g/high", "holds_protected_resources": true},
+			"g/low":  {"_id": "g/low"},
+		},
+	}
+	rk := c.deployKeyReuse()["reused_keys"].([]map[string]any)
+	if len(rk) != 1 {
+		t.Fatalf("reused_keys=%d want 1", len(rk))
+	}
+	key := rk[0]["key"].(map[string]any)
+	requireKeys(t, "deploykey.key", key, "kind", "can_push", "creator_has_target_protected_access")
+	requireKeys(t, "deploykey.source", rk[0]["source"].(map[string]any), "in_unprotected_variable")
+	requireKeys(t, "deploykey.target", rk[0]["target"].(map[string]any), "holds_protected_resources")
+	if key["kind"] != "deploy_key" || key["can_push"] != true || key["creator_has_target_protected_access"] != true {
+		t.Errorf("key participant values wrong: %v", key)
+	}
+	if rk[0]["source"].(map[string]any)["in_unprotected_variable"] != true {
+		t.Error("source.in_unprotected_variable must aggregate the low-trust instance")
+	}
+	if rk[0]["target"].(map[string]any)["holds_protected_resources"] != true {
+		t.Error("target.holds_protected_resources must aggregate the high-trust instance")
+	}
+}

--- a/internal/gitlab/correlate_test.go
+++ b/internal/gitlab/correlate_test.go
@@ -1,0 +1,450 @@
+package gitlab
+
+import "testing"
+
+// TestChainForEachKeys is the hard for_each contract, guarded without a corpus:
+// each of the nine joins must expose its tuple list under exactly the key the
+// rules' chain_of.for_each reads (an unset/mismatched key makes iterChainItems
+// default to "links" and iterate nothing). The key set is the contract table in
+// docs/gitlab/gitlab-normalized-fields.md, not what the code returns.
+func TestChainForEachKeys(t *testing.T) {
+	c := &correlator{
+		instance: map[string]any{},
+		projects: map[string]map[string]any{},
+		groups:   map[string]map[string]any{},
+	}
+	cases := []struct {
+		name string
+		fn   func() map[string]any
+		key  string
+	}{
+		{"job-token-allowlist", c.jobTokenAllowlist, "edges"},
+		{"protected-var-reachability", c.protectedVarReachability, "reachable_vars"},
+		{"dotenv-flow", c.dotenvFlow, "edges"},
+		{"cache-keyspace", c.cacheKeyspace, "prefix_overlaps"},
+		{"cross-project-artifact", c.crossProjectArtifact, "edges"},
+		{"deploy-key-reuse", c.deployKeyReuse, "reused_keys"},
+		{"agent-ci-access", c.agentCIAccess, "grants"},
+		{"runner-reachability", c.runnerReachability, "reachable_runners"},
+		{"group-runner-reachability", c.groupRunnerReachability, "reachable_runners"},
+	}
+	for _, tc := range cases {
+		out := tc.fn()
+		if out["chain"] != tc.name {
+			t.Errorf("%s: chain=%v", tc.name, out["chain"])
+		}
+		v, present := out[tc.key]
+		if !present {
+			t.Errorf("%s: missing for_each key %q", tc.name, tc.key)
+			continue
+		}
+		// Even an empty join must emit the key as a (possibly empty) tuple list,
+		// never nil — a null list serializes to JSON null and iterates nothing.
+		tuples, ok := v.([]map[string]any)
+		if !ok {
+			t.Errorf("%s: key %q is %T, want []map[string]any", tc.name, tc.key, v)
+			continue
+		}
+		if tuples == nil {
+			t.Errorf("%s: key %q is nil slice (must be non-nil empty)", tc.name, tc.key)
+		}
+	}
+}
+
+// TestDotenvFlowTupleShape asserts the producer/consumer role nesting a cat-09
+// chain_of.where resolves by role prefix. The edge exists only within a project.
+func TestDotenvFlowTupleShape(t *testing.T) {
+	c := &correlator{
+		jobs: []map[string]any{
+			{"_id": "grp/a:build", "produces_dotenv": true, "runs_on_untrusted_ref": true},
+			{"_id": "grp/a:deploy", "consumes_dotenv": true, "image_from_variable": true},
+			{"_id": "grp/b:deploy", "consumes_dotenv": true}, // different project: no edge
+		},
+	}
+	edges := c.dotenvFlow()["edges"].([]map[string]any)
+	if len(edges) != 1 {
+		t.Fatalf("dotenv edges=%d want 1 (same-project producer→consumer only)", len(edges))
+	}
+	e := edges[0]
+	prod := e["producer"].(map[string]any)
+	cons := e["consumer"].(map[string]any)
+	if prod["produces_dotenv"] != true || prod["runs_on_untrusted_ref"] != true {
+		t.Errorf("producer participant fields wrong: %v", prod)
+	}
+	if cons["consumes_dotenv"] != true || cons["image_from_variable"] != true {
+		t.Errorf("consumer participant fields wrong: %v", cons)
+	}
+}
+
+// TestCrossProjectArtifactEdge asserts the consumer→producer edge carries the
+// producer's trust posture keyed off the needs:project target, and that a bare
+// (non-cross-project) need produces no edge.
+func TestCrossProjectArtifactEdge(t *testing.T) {
+	c := &correlator{
+		jobs: []map[string]any{
+			{"_id": "grp/consumer:gen", "cross_project_needs": []any{
+				map[string]any{"project": "grp/producer", "artifacts": true},
+			}},
+			{"_id": "grp/other:x", "cross_project_needs": []any{}},
+		},
+		projects: map[string]map[string]any{
+			"grp/producer": {"_id": "grp/producer", "visibility": "private", "has_developer_reachable_secret": true},
+		},
+	}
+	edges := c.crossProjectArtifact()["edges"].([]map[string]any)
+	if len(edges) != 1 {
+		t.Fatalf("cross-project edges=%d want 1", len(edges))
+	}
+	e := edges[0]
+	prod := e["producer"].(map[string]any)
+	if prod["present"] != true || prod["visibility"] != "private" || prod["has_developer_reachable_secret"] != true {
+		t.Errorf("producer trust posture not folded onto edge: %v", prod)
+	}
+	if e["need"].(map[string]any)["project"] != "grp/producer" {
+		t.Errorf("need not carried on edge: %v", e["need"])
+	}
+	// An absent producer project is marked present:false, never dropped.
+	c2 := &correlator{
+		jobs: []map[string]any{{"_id": "grp/c:g", "cross_project_needs": []any{
+			map[string]any{"project": "missing/proj"},
+		}}},
+		projects: map[string]map[string]any{},
+	}
+	e2 := c2.crossProjectArtifact()["edges"].([]map[string]any)[0]
+	if e2["producer"].(map[string]any)["present"] != false {
+		t.Error("missing producer must be present:false, not omitted")
+	}
+}
+
+// TestGroupRunnerReachabilityOwningGroup asserts the group-scoped runner tuple
+// resolves its owning group from _provenance scope and folds the group's
+// creation-governance posture, and that the group participant is marked present.
+func TestGroupRunnerReachabilityOwningGroup(t *testing.T) {
+	c := &correlator{
+		runners: []map[string]any{
+			{"_id": "9", "runner_type": "group_type", "_provenance": []any{
+				map[string]any{"scope": "group:grp/sub"},
+			}},
+		},
+		groups: map[string]map[string]any{
+			"grp/sub": {"_id": "grp/sub", "group_open_project_creation": true, "project_creation_role": "developer"},
+		},
+	}
+	tuples := c.groupRunnerReachability()["reachable_runners"].([]map[string]any)
+	if len(tuples) != 1 {
+		t.Fatalf("group-runner tuples=%d want 1", len(tuples))
+	}
+	g := tuples[0]["group"].(map[string]any)
+	if g["present"] != true || g["_id"] != "grp/sub" || g["group_open_project_creation"] != true {
+		t.Errorf("owning-group posture not folded: %v", g)
+	}
+}
+
+func TestCacheKeyPrefix(t *testing.T) {
+	cases := []struct{ key, want string }{
+		{"build-cache", "build-cache"},
+		{"deps-$CI_COMMIT_REF_SLUG", "deps"}, // per-ref suffix stripped
+		{"$CI_COMMIT_REF_SLUG", ""},          // fully interpolated: no static prefix
+		{"", ""},                             // files:-derived key (no literal)
+		{"node-modules-", "node-modules"},    // trailing delimiter trimmed
+		{"-leading", "leading"},              // leading delimiter trimmed
+	}
+	for _, c := range cases {
+		if got := cacheKeyPrefix(c.key); got != c.want {
+			t.Errorf("cacheKeyPrefix(%q)=%q want %q", c.key, got, c.want)
+		}
+	}
+}
+
+func TestAllowlistAdmits(t *testing.T) {
+	src := "grp/consumer"
+	cases := []struct {
+		mode    string
+		entries []any
+		want    bool
+	}{
+		{"open", nil, true},     // no inbound scoping: admits all
+		{"disabled", nil, true}, // scope off: admits all
+		{"project_scoped", []any{"grp/consumer"}, true},
+		{"project_scoped", []any{"grp/other"}, false}, // scoped and source not listed
+		{"group_scoped", []any{}, false},
+	}
+	for _, c := range cases {
+		al := map[string]any{"mode": c.mode, "entries": c.entries}
+		if got := allowlistAdmits(al, src); got != c.want {
+			t.Errorf("allowlistAdmits(mode=%s,entries=%v)=%v want %v", c.mode, c.entries, got, c.want)
+		}
+	}
+}
+
+func TestCachePolicyWrites(t *testing.T) {
+	if cachePolicyWritesGL(map[string]any{"policy": "pull"}) {
+		t.Error("pull-only cache must not count as a writer")
+	}
+	for _, p := range []string{"", "push", "pull-push"} {
+		if !cachePolicyWritesGL(map[string]any{"policy": p}) {
+			t.Errorf("policy %q must count as a writer (default is read-write)", p)
+		}
+	}
+}
+
+func TestJobTokenTargets(t *testing.T) {
+	// needs:project: targets are collected; a CI_JOB_TOKEN script use with no
+	// nameable target still yields the source project so token posture is seen.
+	job := map[string]any{
+		"_id": "grp/a:build",
+		"cross_project_needs": []any{
+			map[string]any{"project": "grp/b"},
+			map[string]any{"project": "grp/c"},
+		},
+		"job_token_cross_project_use": "git_push",
+	}
+	got := jobTokenTargets(job)
+	want := map[string]bool{"grp/a": true, "grp/b": true, "grp/c": true}
+	if len(got) != len(want) {
+		t.Fatalf("jobTokenTargets=%v want keys %v", got, want)
+	}
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected target %q", g)
+		}
+	}
+	// No cross-project use and no needs → no edge.
+	none := map[string]any{"_id": "grp/a:x", "job_token_cross_project_use": "none"}
+	if got := jobTokenTargets(none); len(got) != 0 {
+		t.Errorf("jobTokenTargets(no-use)=%v want empty", got)
+	}
+}
+
+// TestProtectedVarReachabilitySelfResolving asserts the two correlations the
+// join must resolve so the rules stay literal-only: (1) only protected vars are
+// emitted; (2) every emitted member belongs to the same project as the ref, and
+// every emitted branch/tag is that project's. It also checks a group-scoped var
+// reaches a descendant project but not a non-descendant.
+func TestProtectedVarReachabilitySelfResolving(t *testing.T) {
+	proj := map[string]any{
+		"_id": "grp/p1",
+		"cicd_variables": []any{
+			map[string]any{"key": "SECRET", "protected": true},
+			map[string]any{"key": "PUBLIC", "protected": false},
+		},
+		"protected_branches": []any{map[string]any{"pattern": "main", "push_access_levels": []any{int64(30)}}},
+		"protected_tags":     []any{},
+		"members":            []any{map[string]any{"access_level": int64(30)}},
+	}
+	nonDescendant := map[string]any{
+		"_id":                "other/p2",
+		"cicd_variables":     []any{},
+		"protected_branches": []any{map[string]any{"pattern": "main"}},
+		"members":            []any{map[string]any{"access_level": int64(40)}},
+	}
+	group := map[string]any{
+		"_id":         "grp",
+		"descendants": []any{"grp/p1"}, // p1 is a descendant; other/p2 is not
+		"cicd_variables": []any{
+			map[string]any{"key": "GROUP_SECRET", "protected": true},
+		},
+	}
+	c := &correlator{
+		projList:  []map[string]any{proj, nonDescendant},
+		groupList: []map[string]any{group},
+		projects:  indexByID([]map[string]any{proj, nonDescendant}),
+		groups:    indexByID([]map[string]any{group}),
+	}
+	out := c.protectedVarReachability()
+	tuples, _ := out["reachable_vars"].([]map[string]any)
+
+	seenKeys := map[string]bool{}
+	for _, tp := range tuples {
+		v := tp["var"].(map[string]any)
+		key := v["key"].(string)
+		seenKeys[key] = true
+		if v["protected"] != true {
+			t.Errorf("emitted non-protected var %q", key)
+		}
+		// correlation (b): member's tuple project == ref project.
+		if tp["project"] != v["project"] {
+			t.Errorf("var %q: tuple project %v != var project %v", key, tp["project"], v["project"])
+		}
+	}
+	if !seenKeys["SECRET"] {
+		t.Error("project-scoped protected var SECRET not emitted")
+	}
+	if seenKeys["PUBLIC"] {
+		t.Error("non-protected var PUBLIC must not be emitted")
+	}
+	if !seenKeys["GROUP_SECRET"] {
+		t.Error("group-scoped protected var must reach descendant project")
+	}
+	// correlation (a): the group var must reach ONLY the descendant (grp/p1),
+	// never the non-descendant (other/p2).
+	for _, tp := range tuples {
+		v := tp["var"].(map[string]any)
+		if v["key"] == "GROUP_SECRET" && tp["project"] == "other/p2" {
+			t.Error("group var reached a non-descendant project")
+		}
+	}
+}
+
+// TestInstanceScopedVarReachability: an instance-scoped protected CI/CD variable
+// reaches every project on the instance, with scope_level=="instance" (cat-03).
+func TestInstanceScopedVarReachability(t *testing.T) {
+	p1 := map[string]any{
+		"_id":                "grp/p1",
+		"cicd_variables":     []any{},
+		"protected_branches": []any{map[string]any{"pattern": "main", "push_access_levels": []any{int64(30)}}},
+		"members":            []any{map[string]any{"access_level": int64(30)}},
+	}
+	p2 := map[string]any{
+		"_id":                "other/p2",
+		"cicd_variables":     []any{},
+		"protected_branches": []any{map[string]any{"pattern": "main"}},
+		"members":            []any{map[string]any{"access_level": int64(40)}},
+	}
+	c := &correlator{
+		projList: []map[string]any{p1, p2},
+		projects: indexByID([]map[string]any{p1, p2}),
+		groups:   map[string]map[string]any{},
+		instance: map[string]any{
+			"cicd_variables": []any{
+				map[string]any{"key": "INSTANCE_SECRET", "protected": true},
+				map[string]any{"key": "INSTANCE_PLAIN", "protected": false},
+			},
+		},
+	}
+	tuples := c.protectedVarReachability()["reachable_vars"].([]map[string]any)
+	reachedProjects := map[string]bool{}
+	for _, tp := range tuples {
+		v := tp["var"].(map[string]any)
+		if v["key"] != "INSTANCE_SECRET" {
+			continue
+		}
+		if v["scope_level"] != "instance" {
+			t.Errorf("instance var scope_level=%v want instance", v["scope_level"])
+		}
+		reachedProjects[tp["project"].(string)] = true
+	}
+	if !reachedProjects["grp/p1"] || !reachedProjects["other/p2"] {
+		t.Errorf("instance-scoped protected var must reach every project, reached %v", reachedProjects)
+	}
+	// The unprotected instance var must never be emitted.
+	for _, tp := range tuples {
+		if tp["var"].(map[string]any)["key"] == "INSTANCE_PLAIN" {
+			t.Error("unprotected instance var must not be emitted")
+		}
+	}
+}
+
+// TestProtectedVarParticipantProvenance: the branch/tag and member participants
+// carry _provenance{project_path} for evidence templating (MUST-FIX 13).
+func TestProtectedVarParticipantProvenance(t *testing.T) {
+	proj := map[string]any{
+		"_id":                "grp/p1",
+		"cicd_variables":     []any{map[string]any{"key": "SECRET", "protected": true}},
+		"protected_branches": []any{map[string]any{"pattern": "main", "push_access_levels": []any{int64(30)}}},
+		"members":            []any{map[string]any{"access_level": int64(30)}},
+	}
+	c := &correlator{
+		projList: []map[string]any{proj},
+		projects: indexByID([]map[string]any{proj}),
+		groups:   map[string]map[string]any{},
+		instance: map[string]any{},
+	}
+	tuples := c.protectedVarReachability()["reachable_vars"].([]map[string]any)
+	if len(tuples) == 0 {
+		t.Fatal("expected at least one tuple")
+	}
+	tp := tuples[0]
+	for _, role := range []string{"branch", "member"} {
+		part := tp[role].(map[string]any)
+		prov, ok := part["_provenance"].([]provenance)
+		if !ok || len(prov) == 0 || prov[0]["project_path"] != "grp/p1" {
+			t.Errorf("%s participant missing _provenance{project_path}: %v", role, part["_provenance"])
+		}
+	}
+}
+
+// TestJobTokenTargetParticipant: cat-04 reads target.job_token_allowlist.trusts_source
+// plus the target's terraform/push/writable-branch posture. All must be emitted.
+func TestJobTokenTargetParticipant(t *testing.T) {
+	c := &correlator{
+		jobs: []map[string]any{
+			{"_id": "grp/src:build", "job_token_cross_project_use": "none", "cross_project_needs": []any{map[string]any{"project": "grp/tgt"}}},
+		},
+		projects: map[string]map[string]any{
+			"grp/src": {"_id": "grp/src", "members": []any{}},
+			"grp/tgt": {
+				"_id":                                    "grp/tgt",
+				"job_token_allowlist":                    map[string]any{"mode": "open", "entries": []any{}},
+				"uses_managed_terraform_state":           true,
+				"job_token_push_allowed":                 true,
+				"job_token_cross_project_push_allowed":   true,
+				"developer_writable_protected_branch":    true,
+				"has_developer_pushable_unprotected_ref": true,
+			},
+		},
+	}
+	edges := c.jobTokenAllowlist()["edges"].([]map[string]any)
+	if len(edges) != 1 {
+		t.Fatalf("edges=%d want 1", len(edges))
+	}
+	tgt := edges[0]["target"].(map[string]any)
+	al := tgt["job_token_allowlist"].(map[string]any)
+	if al["trusts_source"] != true {
+		t.Errorf("open allowlist must set target.job_token_allowlist.trusts_source=true, got %v", al["trusts_source"])
+	}
+	for _, k := range []string{"uses_managed_terraform_state", "job_token_push_allowed", "job_token_cross_project_push_allowed", "developer_writable_protected_branch", "has_developer_pushable_unprotected_ref"} {
+		if tgt[k] != true {
+			t.Errorf("target.%s=%v want true", k, tgt[k])
+		}
+	}
+	// A missing target project must default these to false, never omit them.
+	c2 := &correlator{
+		jobs:     []map[string]any{{"_id": "grp/src:b", "job_token_cross_project_use": "none", "cross_project_needs": []any{map[string]any{"project": "missing/p"}}}},
+		projects: map[string]map[string]any{"grp/src": {"_id": "grp/src", "members": []any{}}},
+	}
+	tgt2 := c2.jobTokenAllowlist()["edges"].([]map[string]any)[0]["target"].(map[string]any)
+	if tgt2["uses_managed_terraform_state"] != false {
+		t.Error("absent target must set uses_managed_terraform_state=false, not omit it")
+	}
+}
+
+func TestRunnerReachabilityTypeFilter(t *testing.T) {
+	runners := []map[string]any{
+		{"_id": "1", "runner_type": "instance_type", "is_shared": true},
+		{"_id": "2", "runner_type": "group_type", "is_shared": false},
+		{"_id": "3", "runner_type": "project_type", "is_shared": false},
+		{"_id": "4", "runner_type": "project_type", "is_shared": true}, // shared project runner still instance-reachable
+	}
+	c := &correlator{runners: runners, instance: map[string]any{"open_project_creation": true}}
+
+	inst := c.runnerReachability()["reachable_runners"].([]map[string]any)
+	if len(inst) != 2 { // ids 1 and 4 (instance_type OR is_shared)
+		t.Errorf("runner-reachability=%d want 2", len(inst))
+	}
+	grp := c.groupRunnerReachability()["reachable_runners"].([]map[string]any)
+	if len(grp) != 1 { // only id 2 (group_type)
+		t.Errorf("group-runner-reachability=%d want 1", len(grp))
+	}
+}
+
+func TestDeployKeyReuseSpansProjects(t *testing.T) {
+	creds := []map[string]any{
+		{"kind": "deploy_key", "deploy_key_fingerprint": "AAAA", "can_push": true, "_provenance": []any{map[string]any{"scope": "project:grp/a"}}},
+		{"kind": "deploy_key", "deploy_key_fingerprint": "AAAA", "can_push": false, "_provenance": []any{map[string]any{"scope": "project:grp/b"}}},
+		{"kind": "deploy_key", "deploy_key_fingerprint": "BBBB", "can_push": true, "_provenance": []any{map[string]any{"scope": "project:grp/a"}}}, // single project: not reuse
+		{"kind": "deploy_token", "deploy_key_fingerprint": "AAAA", "_provenance": []any{map[string]any{"scope": "project:grp/c"}}},                 // not a deploy_key
+	}
+	c := &correlator{creds: creds, projects: map[string]map[string]any{}}
+	reused := c.deployKeyReuse()["reused_keys"].([]map[string]any)
+	if len(reused) != 1 {
+		t.Fatalf("reused_keys=%d want 1 (only AAAA spans two projects)", len(reused))
+	}
+	r := reused[0]
+	if r["project_count"].(int) != 2 {
+		t.Errorf("project_count=%v want 2", r["project_count"])
+	}
+	if r["any_write_capable"] != true {
+		t.Error("any_write_capable must be true (grp/a key can_push)")
+	}
+}

--- a/internal/gitlab/facts_gitlab.go
+++ b/internal/gitlab/facts_gitlab.go
@@ -1,0 +1,269 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// Normalize-side read helpers, ported from the ADO/GitHub stacks (platform
+// agnostic): safe navigation over the collected {_meta,data} envelopes, raw-file
+// reads, and reading the normalized corpus back as generic maps for correlate.
+//
+// A soft-failed surface is written as data == {"_unobserved": <status>}. The
+// unwrap helpers return that object verbatim so a caller can distinguish "observed
+// empty" from "not observed" (entUnobserved) rather than collapsing to false/[].
+
+func entLoadData(prior engine.PriorPhase, rel string) map[string]any {
+	var env map[string]any
+	if err := engine.ReadJSON(prior.Abs(rel), &env); err != nil {
+		return nil
+	}
+	return entMap(env["data"])
+}
+
+// entLoadList returns the data array of a list surface, or nil for a missing file
+// / soft-failed surface (whose data is a {_unobserved} object, not an array).
+func entLoadList(prior engine.PriorPhase, rel string) []any {
+	var env map[string]any
+	if err := engine.ReadJSON(prior.Abs(rel), &env); err != nil {
+		return nil
+	}
+	return entList(env["data"])
+}
+
+// entLoadRaw reads a non-enveloped raw file (.gitlab-ci.yml, agent config,
+// CODEOWNERS, Duo files) written via WriteRaw. nil for a missing file.
+func entLoadRaw(prior engine.PriorPhase, rel string) []byte {
+	b, err := os.ReadFile(prior.Abs(rel))
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// entUnobserved reports whether a surface soft-failed (data == {_unobserved}).
+// A rule that keys on the observed/unobserved difference must not read absence as
+// false; callers use this to leave the field null instead.
+func entUnobserved(m map[string]any) bool {
+	if m == nil {
+		return false
+	}
+	_, un := m["_unobserved"]
+	return un
+}
+
+func entMap(v any) map[string]any {
+	m, _ := v.(map[string]any)
+	return m
+}
+
+func entList(v any) []any {
+	l, _ := v.([]any)
+	return l
+}
+
+// entListOrEmpty never returns nil so a list field serializes as [] not null
+// (hard contract C1: valuesEqual(nil, []any{}) is false).
+func entListOrEmpty(v any) []any {
+	if l, ok := v.([]any); ok {
+		return l
+	}
+	return []any{}
+}
+
+func entGetIn(m map[string]any, keys ...string) any {
+	var cur any = m
+	for _, k := range keys {
+		cm := entMap(cur)
+		if cm == nil {
+			return nil
+		}
+		cur = cm[k]
+	}
+	return cur
+}
+
+func entStr(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func entBool(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+func entInt64(v any) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case int:
+		return int64(x)
+	case int64:
+		return x
+	case string:
+		if n, err := strconv.ParseInt(x, 10, 64); err == nil {
+			return n
+		}
+	case json.Number:
+		if n, err := x.Int64(); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// ---- correlate read-side (normalized corpus as maps) ----
+
+func loadRecords(prior engine.PriorPhase, dir string) ([]map[string]any, error) {
+	files, err := prior.IterJSON(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]map[string]any, 0, len(files))
+	for _, f := range files {
+		var rec map[string]any
+		if err := json.Unmarshal(f.Data, &rec); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+func mGet(m map[string]any, key string) any {
+	if m == nil {
+		return nil
+	}
+	return m[key]
+}
+
+func mStr(m map[string]any, key string) string { s, _ := mGet(m, key).(string); return s }
+func mBool(m map[string]any, key string) bool  { b, _ := mGet(m, key).(bool); return b }
+func mMap(m map[string]any, key string) map[string]any {
+	v, _ := mGet(m, key).(map[string]any)
+	return v
+}
+func mList(m map[string]any, key string) []any { v, _ := mGet(m, key).([]any); return v }
+
+type provenance map[string]string
+
+func prov(files ...string) []provenance {
+	out := make([]provenance, 0, len(files))
+	for _, f := range files {
+		out = append(out, provenance{"file": f})
+	}
+	return out
+}
+
+// ---- GitLab-specific fact helpers ----
+
+// GitLab numeric access levels. Rules read >=30, ∋{30}, ==30 (hard contract C3).
+const (
+	accessGuest      int64 = 10
+	accessReporter   int64 = 20
+	accessDeveloper  int64 = 30
+	accessMaintainer int64 = 40
+	accessOwner      int64 = 50
+)
+
+var levelNames = map[int64]string{
+	accessGuest: "guest", accessReporter: "reporter", accessDeveloper: "developer",
+	accessMaintainer: "maintainer", accessOwner: "owner",
+}
+var nameLevels = map[string]int64{
+	"guest": accessGuest, "reporter": accessReporter, "developer": accessDeveloper,
+	"maintainer": accessMaintainer, "owner": accessOwner,
+}
+
+func levelToRoleName(lvl int64) string { return levelNames[lvl] }
+
+// roleNameToLevel maps a group default_membership_role that GitLab may return
+// either as the numeric access level (REST) or the string enum.
+func roleNameToLevel(v any) int64 {
+	switch x := v.(type) {
+	case string:
+		if n, ok := nameLevels[strings.ToLower(x)]; ok {
+			return n
+		}
+		return entInt64(x)
+	default:
+		return entInt64(v)
+	}
+}
+
+// accessLevelValues extracts the numeric access_level from a protected-branch /
+// protected-tag access-level list ([{access_level, group_id, user_id, ...}]). A
+// group/user entry (non-null group_id/user_id) is a named grant broader than the
+// bare role; it is surfaced as its numeric level and flagged by hasNamedGrant.
+func accessLevelValues(list any) []any {
+	out := []any{}
+	for _, raw := range entList(list) {
+		e := entMap(raw)
+		out = append(out, entInt64(e["access_level"]))
+	}
+	return out
+}
+
+func hasNamedGrant(list any) bool {
+	for _, raw := range entList(list) {
+		e := entMap(raw)
+		if e["group_id"] != nil || e["user_id"] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// levelsInclude reports whether a numeric access-level list contains lvl.
+func levelsInclude(levels []any, lvl int64) bool {
+	for _, v := range levels {
+		if entInt64(v) == lvl {
+			return true
+		}
+	}
+	return false
+}
+
+// levelsIncludeAtMost reports whether the list grants access to any actor at or
+// below maxLvl (i.e. a lower-trust actor than a strict Maintainer/Owner gate).
+func levelsIncludeAtMost(levels []any, maxLvl int64) bool {
+	for _, v := range levels {
+		if l := entInt64(v); l > 0 && l <= maxLvl {
+			return true
+		}
+	}
+	return false
+}
+
+// hasMemberAtLevel precomputes an existential over a members list (hard contract
+// C4): ∃ member with access_level == lvl. The engine's ∋ cannot express this.
+func hasMemberAtLevel(members []any, lvl int64) bool {
+	for _, raw := range members {
+		if entInt64(entMap(raw)["access_level"]) == lvl {
+			return true
+		}
+	}
+	return false
+}
+
+// secretShapedKey is the secret-name heuristic (cat-03/11). The three
+// unprotected-secret-var derived booleans rest entirely on it, so it must not
+// fire on ordinary config keys. Matches common credential-bearing key fragments.
+func secretShapedKey(key string) bool {
+	u := strings.ToUpper(key)
+	for _, frag := range []string{
+		"TOKEN", "SECRET", "PASSWORD", "PASSWD", "APIKEY", "API_KEY", "ACCESS_KEY",
+		"PRIVATE_KEY", "CREDENTIAL", "AUTH", "PAT", "KEY", "CERT", "SIGNING",
+		"AWS_", "AZURE_", "GCP_", "GCLOUD", "DOCKERHUB", "NPM_", "PYPI",
+	} {
+		if strings.Contains(u, frag) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -14,10 +14,6 @@ type ScanOptions struct {
 	GroupOnly bool
 }
 
-func Normalize(ctx context.Context, runDir string) error {
-	return engine.ErrNotImplemented
-}
-
 func Scan(ctx context.Context, runDir string, opts ScanOptions) error {
 	return engine.ErrNotImplemented
 }

--- a/internal/gitlab/normalize.go
+++ b/internal/gitlab/normalize.go
@@ -1,0 +1,111 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// projectMeta is the per-project roster GitLab lacks as a single surface: it is
+// rebuilt by scanning 00-collect/project/ (each project = one CollectGLProject
+// file) and reading path_with_namespace / id / default_branch off the detail.
+type projectMeta struct {
+	FullPath      string
+	ID            int64
+	DefaultBranch string
+}
+
+// Normalize turns the raw collected JSON (00-collect) into per-subject fact
+// records and cross-entity chain joins (10-normalize) per the GitLab normalized
+// field contract (docs/gitlab/gitlab-normalized-fields.md). Structural entity
+// records first, then the resolved-job records, then the correlation joins the
+// chain rules read. Per-item failures accumulate in timer.Errors and are skipped;
+// only IO / contract violations abort the phase.
+func Normalize(ctx context.Context, runDir string) error {
+	state, err := engine.LoadState(runDir)
+	if err != nil {
+		return err
+	}
+	if err := state.CheckPhase(engine.PhaseNormalize); err != nil {
+		return err
+	}
+	for _, d := range state.StaleDirs(engine.PhaseNormalize) {
+		if err := os.RemoveAll(filepath.Join(runDir, d)); err != nil {
+			return err
+		}
+	}
+	// Clear this phase's own output so a re-run against shrunk input leaves no
+	// orphan records for correlate to read back.
+	if err := os.RemoveAll(filepath.Join(runDir, "10-normalize")); err != nil {
+		return err
+	}
+	org := state.Org
+	if org == "" {
+		return fmt.Errorf("org not set in %s; run collect first", engine.RunMeta())
+	}
+
+	timer := engine.StartPhaseTimer(engine.PhaseNormalize, "normalize")
+	prior := engine.PriorPhase{RunDir: runDir}
+	cp := engine.CurrentPhase{RunDir: runDir}
+	projs := projects(prior)
+
+	normErr := normalizeEntities(ctx, prior, cp, org, projs, timer)
+	if normErr == nil {
+		_, normErr = normalizeJobs(ctx, prior, cp, org, projs, timer)
+	}
+	if normErr == nil {
+		normErr = correlate(ctx, prior, cp, org, timer)
+	}
+
+	state.RecordPhase(timer.Stop(normErr))
+	if err := state.Save(runDir); err != nil {
+		return err
+	}
+	return normErr
+}
+
+// emit writes one normalized record and counts it. Normalize is sequential, so
+// no locking is needed on the timer.
+func emit(cp engine.CurrentPhase, timer *engine.PhaseTimer, rel string, rec any) error {
+	if err := cp.Write(rel, rec); err != nil {
+		return err
+	}
+	timer.OutputFiles++
+	return nil
+}
+
+// itemErr records a per-item failure without aborting the phase.
+func itemErr(timer *engine.PhaseTimer, subject string, err error) {
+	timer.Errors = append(timer.Errors, fmt.Sprintf("%s: %v", subject, err))
+}
+
+// projects rebuilds the project roster from 00-collect/project/. Order is stable
+// (directory iteration) so re-runs produce identical output.
+func projects(prior engine.PriorPhase) []projectMeta {
+	files, err := prior.IterJSON("00-collect/project")
+	if err != nil {
+		return nil
+	}
+	out := make([]projectMeta, 0, len(files))
+	for _, f := range files {
+		var env map[string]any
+		if err := json.Unmarshal(f.Data, &env); err != nil {
+			continue
+		}
+		d := entMap(env["data"])
+		fp := entStr(d["path_with_namespace"])
+		if fp == "" || entUnobserved(d) {
+			continue
+		}
+		out = append(out, projectMeta{
+			FullPath:      fp,
+			ID:            entInt64(d["id"]),
+			DefaultBranch: entStr(d["default_branch"]),
+		})
+	}
+	return out
+}

--- a/internal/gitlab/normalize_agent_test.go
+++ b/internal/gitlab/normalize_agent_test.go
@@ -1,0 +1,121 @@
+package gitlab
+
+import (
+	"slices"
+	"testing"
+)
+
+// The agent ci_access config schema is GitLab's documented format
+// (https://docs.gitlab.com/user/clusters/agent/ci_cd_workflow): a top-level
+// ci_access with projects:/groups: entries, each carrying environments,
+// default_namespace, protected_branches_only, and an optional access_as
+// impersonation block. The firing-range cat-15 agents come back 403 over the
+// SaaS token, so these assert parseAgentConfig against that external schema
+// rather than corpus output.
+
+func TestParseAgentConfigCIAccessProjectScope(t *testing.T) {
+	cfg := parseAgentConfig([]byte(`
+gitops: {}
+ci_access:
+  projects:
+    - id: group/app
+      environments:
+        - production
+        - review/*
+      protected_branches_only: true
+`))
+	envs := entListOrEmpty(cfg["environments"])
+	got := make([]string, 0, len(envs))
+	for _, e := range envs {
+		got = append(got, entStr(e))
+	}
+	if !slices.Equal(got, []string{"production", "review/*"}) {
+		t.Fatalf("environments=%v want [production review/*]", got)
+	}
+	if cfg["protected_branches_only"] != true {
+		t.Errorf("protected_branches_only=%v want true", cfg["protected_branches_only"])
+	}
+	// No access_as → default (broad) permissions.
+	if !agentDefaultPermissions(cfg) {
+		t.Error("no access_as block must mean default_permissions=true")
+	}
+}
+
+func TestParseAgentConfigImpersonationDisablesDefault(t *testing.T) {
+	cfg := parseAgentConfig([]byte(`
+ci_access:
+  projects:
+    - id: group/app
+      access_as:
+        ci_job: {}
+`))
+	if _, ok := cfg["access_as"]; !ok {
+		t.Fatal("access_as not surfaced")
+	}
+	if agentDefaultPermissions(cfg) {
+		t.Error("an access_as impersonation block must set default_permissions=false")
+	}
+}
+
+func TestParseAgentConfigGroupScope(t *testing.T) {
+	// environments/protected_branches_only can live under a groups: entry too; the
+	// first-access lookup must reach it.
+	cfg := parseAgentConfig([]byte(`
+ci_access:
+  groups:
+    - id: top-group
+      environments:
+        - "*"
+`))
+	envs := entListOrEmpty(cfg["environments"])
+	if len(envs) != 1 || entStr(envs[0]) != "*" {
+		t.Fatalf("environments=%v want [*]", envs)
+	}
+}
+
+func TestParseAgentConfigMalformedIsEmpty(t *testing.T) {
+	if got := parseAgentConfig([]byte("\t: not: yaml:")); len(got) != 0 {
+		t.Errorf("malformed config must parse to empty map, got %v", got)
+	}
+	if got := parseAgentConfig(nil); len(got) != 0 {
+		t.Errorf("nil config must be empty map, got %v", got)
+	}
+}
+
+// The wildcard classifier is what cat-15 keys on to detect a forgeable env
+// filter. It must fire on a bare * and on prefix/suffix globs, not on fixed names.
+func TestAgentEnvWildcardClassification(t *testing.T) {
+	wild := []string{"*", "review/*", "*-preview"}
+	for _, s := range wild {
+		if !containsWildcard([]any{s}) {
+			t.Errorf("%q must classify as wildcard env filter", s)
+		}
+	}
+	fixed := []string{"production", "staging", "review"}
+	if containsWildcard(toAnyList(fixed)) {
+		t.Error("a filter of only fixed names must not be a wildcard filter")
+	}
+}
+
+// containsWildcard mirrors the environments_filter_wildcard predicate the agent
+// normalizer computes inline (anyStr over strings.Contains "*").
+func containsWildcard(envs []any) bool {
+	return anyStr(envs, func(s string) bool { return contains(s, "*") })
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func toAnyList(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}

--- a/internal/gitlab/normalize_approval_policy_test.go
+++ b/internal/gitlab/normalize_approval_policy_test.go
@@ -1,0 +1,70 @@
+package gitlab
+
+import "testing"
+
+// The cat-06 approval-policy rules read approval_policy.{fallback_behavior,
+// enforcement_type, bypass_actor_broad, scanners}. These assert the P2-collected
+// policy YAML is parsed into those literals. The oracle is the GitLab scan-result
+// policy schema (fallback_behavior.fail: open|closed; require_approval action;
+// bypass_settings actor lists) and the three frozen rule predicates.
+
+func TestApprovalPolicyFallbackFailOpen(t *testing.T) {
+	spec := parsePolicyYAML(`
+name: block on vulns
+rules:
+  - type: scan_finding
+    scanners: [sast, dependency_scanning]
+actions:
+  - type: require_approval
+    approvals_required: 1
+fallback_behavior:
+  fail: open
+`)
+	if spec == nil {
+		t.Fatal("policy YAML failed to parse")
+	}
+	if fb := entMap(spec["fallback_behavior"]); entStr(fb["fail"]) != "open" {
+		t.Fatalf("fallback fail=%q want open", entStr(fb["fail"]))
+	}
+	sc := policyScanners(spec)
+	if len(sc) != 2 || sc[0] != "sast" {
+		t.Errorf("scanners=%v want [sast dependency_scanning]", sc)
+	}
+	if warnMode(spec) {
+		t.Error("approvals_required:1 must not be warn mode")
+	}
+	if !hasRequireApproval(spec) {
+		t.Error("require_approval action must be detected")
+	}
+}
+
+func TestApprovalPolicyWarnMode(t *testing.T) {
+	spec := parsePolicyYAML(`
+actions:
+  - type: require_approval
+    approvals_required: 0
+`)
+	if !warnMode(spec) {
+		t.Error("approvals_required:0 require_approval must be warn mode (dismissable)")
+	}
+}
+
+func TestApprovalPolicyBypassBroad(t *testing.T) {
+	broad := parsePolicyYAML(`
+bypass_settings:
+  service_accounts:
+    - id: 7
+`)
+	if !bypassActorBroad(broad) {
+		t.Error("bypass_settings with a service_accounts list must be broad")
+	}
+	narrow := parsePolicyYAML(`
+name: no bypass
+actions:
+  - type: require_approval
+    approvals_required: 1
+`)
+	if bypassActorBroad(narrow) {
+		t.Error("absent bypass_settings must not be broad")
+	}
+}

--- a/internal/gitlab/normalize_ci.go
+++ b/internal/gitlab/normalize_ci.go
@@ -1,0 +1,149 @@
+package gitlab
+
+import (
+	"regexp"
+	"strings"
+)
+
+// GitLab .gitlab-ci.yml parsing for the job normalizer. P2 collects only the raw
+// entrypoint at the default branch (collectCIConfig) — included file bodies
+// (local/project/remote/component/template) are not on disk — so job discovery is
+// entrypoint-only and include: declarations are parsed for classification (cat-02)
+// rather than expanded into new jobs. rules:/workflow: are read structurally to
+// derive the job's trigger set and ref-protection gate.
+
+// reserved is the set of top-level keys that are pipeline configuration, not jobs.
+var reserved = map[string]bool{
+	"include": true, "variables": true, "stages": true, "workflow": true,
+	"default": true, "image": true, "services": true, "cache": true,
+	"before_script": true, "after_script": true, "pages": false, // pages is a real job (cat-14)
+	"spec": true, ".pre": true, ".post": true,
+}
+
+// parseCIPipeline decodes the raw entrypoint into a pipeline map. A `spec:` header
+// document (used for `inputs:` in reusable configs) precedes a `---` separator;
+// the pipeline is the last mapping document. Anchors/hidden `.templates` are left
+// in place — hidden keys (leading `.`) are filtered at job discovery. A
+// well-formed but empty/comment-only config returns (nil, nil): no jobs, not an
+// error. Only a YAML syntax error returns a non-nil error.
+func parseCIPipeline(raw []byte) (map[string]any, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	docs := splitYAMLDocs(raw)
+	for i := len(docs) - 1; i >= 0; i-- {
+		var m map[string]any
+		if err := yamlUnmarshal(docs[i], &m); err != nil {
+			return nil, err
+		} else if m != nil {
+			return m, nil
+		}
+	}
+	return nil, nil
+}
+
+var reDocSep = regexp.MustCompile(`(?m)^---\s*$`)
+
+func splitYAMLDocs(raw []byte) [][]byte {
+	parts := reDocSep.Split(string(raw), -1)
+	out := make([][]byte, 0, len(parts))
+	for _, p := range parts {
+		if strings.TrimSpace(p) != "" {
+			out = append(out, []byte(p))
+		}
+	}
+	if len(out) == 0 {
+		return [][]byte{raw}
+	}
+	return out
+}
+
+// jobNames returns the top-level job keys in stable (sorted) order: entries that
+// are maps, not reserved config keys, and not hidden templates (leading `.`).
+func jobNames(pipeline map[string]any) []string {
+	out := []string{}
+	for k, v := range pipeline {
+		if strings.HasPrefix(k, ".") || reserved[k] {
+			continue
+		}
+		if _, ok := v.(map[string]any); ok {
+			out = append(out, k)
+		}
+	}
+	sortStrings(out)
+	return out
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}
+
+// asStrList coerces a YAML scalar-or-sequence (script:, tags:, artifacts:paths:)
+// into a []string. Nested sequences are flattened one level (script blocks may
+// nest).
+func asStrList(v any) []string {
+	switch x := v.(type) {
+	case string:
+		return []string{x}
+	case []any:
+		out := []string{}
+		for _, e := range x {
+			switch ee := e.(type) {
+			case string:
+				out = append(out, ee)
+			case []any:
+				for _, n := range ee {
+					if s, ok := n.(string); ok {
+						out = append(out, s)
+					}
+				}
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// jobScriptText concatenates every script phase (before_script/script/after_script,
+// and a run: step block) into one blob for attacker-input and sink analysis.
+func jobScriptText(job map[string]any) string {
+	var b strings.Builder
+	for _, k := range []string{"before_script", "script", "after_script"} {
+		for _, line := range asStrList(job[k]) {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	if run, ok := job["run"].([]any); ok {
+		for _, s := range run {
+			if step, ok := s.(map[string]any); ok {
+				for _, line := range asStrList(step["script"]) {
+					b.WriteString(line)
+					b.WriteByte('\n')
+				}
+			}
+		}
+	}
+	return b.String()
+}
+
+// mergeDefault overlays the pipeline `default:` block onto a job for keys the job
+// does not set itself (image, cache, tags, before/after_script). GitLab applies
+// default: to every job unless overridden.
+func mergeDefault(job, def map[string]any) map[string]any {
+	if len(def) == 0 {
+		return job
+	}
+	merged := map[string]any{}
+	for k, v := range def {
+		merged[k] = v
+	}
+	for k, v := range job {
+		merged[k] = v
+	}
+	return merged
+}

--- a/internal/gitlab/normalize_ci_classify.go
+++ b/internal/gitlab/normalize_ci_classify.go
@@ -1,0 +1,368 @@
+package gitlab
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Trigger, ref-protection, include and sink classification over a parsed job.
+// Kept literal and conservative: a rule keys on the emitted set/enum, so a
+// false-negative (missing trigger) is safer than inventing one.
+
+// allTriggers is the default pipeline-source set a job runs on when neither
+// rules: nor workflow: constrains it (GitLab runs a job on every source unless
+// gated). Mirrors $CI_PIPELINE_SOURCE values the corpus reasons about.
+var allTriggers = []string{
+	"push", "web", "api", "schedule", "trigger", "pipeline",
+	"merge_request_event", "external_pull_request_event",
+}
+
+// pipelineSourceFor maps a rules:/workflow: `if:` expression's referenced
+// $CI_PIPELINE_SOURCE literal to a trigger. Multiple may appear.
+var reSourceEq = regexp.MustCompile(`\$CI_PIPELINE_SOURCE\s*==\s*["']([a-z_]+)["']`)
+var reSourceIn = regexp.MustCompile(`\$CI_PIPELINE_SOURCE\s*=~\s*/([^/]+)/`)
+
+// resolveTriggers derives the trigger set from workflow:rules then job rules.
+// When rules constrain $CI_PIPELINE_SOURCE, only the named sources survive;
+// otherwise the job is reachable from every source.
+func resolveTriggers(job, workflow map[string]any) []string {
+	jobRules := ruleExprs(job["rules"])
+	wfRules := ruleExprs(workflow["rules"])
+
+	constrained, sources := sourcesFromRules(append(append([]string{}, wfRules...), jobRules...))
+	if !constrained {
+		return append([]string{}, allTriggers...)
+	}
+	out := []string{}
+	for _, s := range allTriggers {
+		if sources[s] {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		// rules referenced a source we don't model; fall back to broad reachability.
+		return append([]string{}, allTriggers...)
+	}
+	return out
+}
+
+// ruleExprs extracts the `if:` strings from a rules: list (or the string form of
+// each entry). only:/except: are handled separately.
+func ruleExprs(rules any) []string {
+	out := []string{}
+	list, ok := rules.([]any)
+	if !ok {
+		return out
+	}
+	for _, r := range list {
+		switch x := r.(type) {
+		case string:
+			out = append(out, x)
+		case map[string]any:
+			if s, ok := x["if"].(string); ok {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+func sourcesFromRules(exprs []string) (bool, map[string]bool) {
+	sources := map[string]bool{}
+	constrained := false
+	for _, e := range exprs {
+		for _, m := range reSourceEq.FindAllStringSubmatch(e, -1) {
+			sources[m[1]] = true
+			constrained = true
+		}
+		for _, m := range reSourceIn.FindAllStringSubmatch(e, -1) {
+			for _, alt := range strings.Split(m[1], "|") {
+				sources[strings.Trim(alt, "^$() ")] = true
+			}
+			constrained = true
+		}
+	}
+	return constrained, sources
+}
+
+// hasMergeRequestTrigger reports the merge_request_event membership used across
+// cat-01/03/09.
+func hasMergeRequestTrigger(triggers []string) bool {
+	for _, t := range triggers {
+		if t == "merge_request_event" {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	reRefProtected  = regexp.MustCompile(`\$CI_COMMIT_REF_PROTECTED\s*==\s*["']?true`)
+	reDefaultBranch = regexp.MustCompile(`\$CI_COMMIT_BRANCH\s*==\s*\$CI_DEFAULT_BRANCH|\$CI_COMMIT_REF_NAME\s*==\s*["']?(main|master)`)
+	reCommitTag     = regexp.MustCompile(`\$CI_COMMIT_TAG`)
+)
+
+// protectedRefGate classifies how strongly a job's rules: gate its execution to a
+// protected-ref context: strong (explicit $CI_COMMIT_REF_PROTECTED), weak (pins a
+// specific protected branch/tag by name), or none.
+func protectedRefGate(job, workflow map[string]any) string {
+	exprs := append(ruleExprs(workflow["rules"]), ruleExprs(job["rules"])...)
+	if only := asStrList(job["only"]); len(only) > 0 {
+		exprs = append(exprs, strings.Join(only, " "))
+	}
+	joined := strings.Join(exprs, "\n")
+	if joined == "" {
+		return "none"
+	}
+	if reRefProtected.MatchString(joined) {
+		return "strong"
+	}
+	if reDefaultBranch.MatchString(joined) || reCommitTag.MatchString(joined) {
+		return "weak"
+	}
+	return "none"
+}
+
+// runsOnUntrustedRef reports whether the job is reachable on an attacker-nameable
+// / unprotected ref: MR-event reachable, or no protected-ref gating on its rules.
+func runsOnUntrustedRef(triggers []string, gate string) bool {
+	if gate == "strong" {
+		return false
+	}
+	if hasMergeRequestTrigger(triggers) {
+		return true
+	}
+	return gate != "weak"
+}
+
+// ---- attacker input surface (cat-01) ----
+
+var (
+	reMRMeta        = regexp.MustCompile(`\$CI_MERGE_REQUEST_(TITLE|DESCRIPTION|SOURCE_BRANCH_NAME|LABELS|MILESTONE|ASSIGNEES)`)
+	reRefName       = regexp.MustCompile(`\$CI_COMMIT_REF_(NAME|SLUG)|\$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME`)
+	reCommitMessage = regexp.MustCompile(`\$CI_COMMIT_(MESSAGE|DESCRIPTION|TITLE)`)
+	reComponentIn   = regexp.MustCompile(`\$\[\[\s*inputs\.`)
+)
+
+// attackerInputFields returns the categories of untrusted input reaching an exec
+// context (the job's script blocks). Order-stable.
+func attackerInputFields(scriptText string) []string {
+	out := []string{}
+	if reMRMeta.MatchString(scriptText) {
+		out = append(out, "mr_metadata")
+	}
+	if reRefName.MatchString(scriptText) {
+		out = append(out, "ref_name")
+	}
+	if reCommitMessage.MatchString(scriptText) {
+		out = append(out, "commit_message")
+	}
+	if reComponentIn.MatchString(scriptText) {
+		out = append(out, "component_input")
+	}
+	return out
+}
+
+// ---- include classification (cat-02) ----
+
+var reVarInterp = regexp.MustCompile(`\$\{?[A-Za-z_][A-Za-z0-9_]*\}?|\$\[\[`)
+
+// classifyIncludes parses the pipeline `include:` into normalized include tuples
+// {type, ref, pinned, source_host, cross_trust}. selfHost is the instance host
+// (project.web_url host) used to decide first-party vs third-party for remote.
+func classifyIncludes(includeNode any, selfHost, ownerNamespace string) ([]any, includeFlags) {
+	out := []any{}
+	var f includeFlags
+	for _, entry := range includeEntries(includeNode) {
+		typ, tup, flags := classifyOneInclude(entry, selfHost, ownerNamespace)
+		if typ == "" {
+			continue
+		}
+		out = append(out, tup)
+		f.merge(flags)
+	}
+	return out, f
+}
+
+type includeFlags struct {
+	remoteUntrustedHost bool
+	remoteCleartext     bool
+	mutableCrossTrust   bool
+	mutableComponent    bool
+	refInterpolated     bool
+	bareRefShadowable   bool
+}
+
+func (f *includeFlags) merge(o includeFlags) {
+	f.remoteUntrustedHost = f.remoteUntrustedHost || o.remoteUntrustedHost
+	f.remoteCleartext = f.remoteCleartext || o.remoteCleartext
+	f.mutableCrossTrust = f.mutableCrossTrust || o.mutableCrossTrust
+	f.mutableComponent = f.mutableComponent || o.mutableComponent
+	f.refInterpolated = f.refInterpolated || o.refInterpolated
+	f.bareRefShadowable = f.bareRefShadowable || o.bareRefShadowable
+}
+
+// includeEntries normalizes the several YAML shapes of include: (string, list of
+// strings, single map, list of maps) into a list of entries.
+func includeEntries(node any) []any {
+	switch x := node.(type) {
+	case nil:
+		return nil
+	case string:
+		return []any{map[string]any{"local": x}}
+	case map[string]any:
+		return []any{x}
+	case []any:
+		out := []any{}
+		for _, e := range x {
+			if s, ok := e.(string); ok {
+				out = append(out, map[string]any{"local": s})
+			} else {
+				out = append(out, e)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func classifyOneInclude(entry any, selfHost, ownerNamespace string) (string, map[string]any, includeFlags) {
+	m, ok := entry.(map[string]any)
+	if !ok {
+		return "", nil, includeFlags{}
+	}
+	var f includeFlags
+	tup := map[string]any{"pinned": false, "cross_trust": false, "source_host": nil}
+	var ref string
+	if r, ok := m["ref"].(string); ok {
+		ref = r
+	}
+	tup["ref"] = strOrNil(ref)
+	hasIntegrity := m["integrity"] != nil
+
+	switch {
+	case m["remote"] != nil:
+		u, _ := m["remote"].(string)
+		host := hostOf(u)
+		tup["type"] = "remote"
+		tup["source_host"] = strOrNil(host)
+		tup["pinned"] = hasIntegrity
+		firstParty := host == selfHost || host == ""
+		tup["cross_trust"] = !firstParty
+		if !firstParty && !hasIntegrity {
+			f.remoteUntrustedHost = true
+		}
+		if strings.HasPrefix(strings.ToLower(u), "http://") && !hasIntegrity {
+			f.remoteCleartext = true
+		}
+		if reVarInterp.MatchString(u) {
+			f.refInterpolated = true
+		}
+		return "remote", tup, f
+	case m["project"] != nil:
+		proj, _ := m["project"].(string)
+		tup["type"] = "project"
+		crossTrust := ownerNamespace != "" && !strings.HasPrefix(proj, ownerNamespace)
+		tup["cross_trust"] = crossTrust
+		pinned := isPinnedRef(ref)
+		tup["pinned"] = pinned
+		if !pinned && crossTrust {
+			f.mutableCrossTrust = true
+		}
+		if ref == "" || (!isPinnedRef(ref) && !isWildcard(ref)) {
+			f.bareRefShadowable = true
+		}
+		if fileInterpolated(m["file"]) || reVarInterp.MatchString(ref) {
+			f.refInterpolated = true
+		}
+		return "project", tup, f
+	case m["component"] != nil:
+		comp, _ := m["component"].(string)
+		version := componentVersion(comp)
+		tup["type"] = "component"
+		tup["source_host"] = strOrNil(hostOf(comp))
+		pinned := isPinnedRef(version)
+		tup["pinned"] = pinned
+		thirdParty := hostOf(comp) != selfHost && hostOf(comp) != ""
+		tup["cross_trust"] = thirdParty
+		if !pinned && thirdParty {
+			f.mutableComponent = true
+		}
+		return "component", tup, f
+	case m["template"] != nil:
+		tup["type"] = "template"
+		tup["pinned"] = true // GitLab-maintained templates are first-party
+		return "template", tup, f
+	case m["local"] != nil:
+		loc, _ := m["local"].(string)
+		tup["type"] = "local"
+		tup["pinned"] = true
+		if reVarInterp.MatchString(loc) {
+			f.refInterpolated = true
+		}
+		return "local", tup, f
+	}
+	return "", nil, includeFlags{}
+}
+
+func fileInterpolated(v any) bool {
+	for _, f := range asStrList(v) {
+		if reVarInterp.MatchString(f) {
+			return true
+		}
+	}
+	if s, ok := v.(string); ok {
+		return reVarInterp.MatchString(s)
+	}
+	return false
+}
+
+// isPinnedRef reports whether a ref is immutable: a 40-hex commit SHA or a
+// semver-looking tag. Branch names and moving tags (latest, ~x) are mutable.
+func isPinnedRef(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if len(ref) == 40 && isHex(ref) {
+		return true
+	}
+	return reSemverTag.MatchString(ref)
+}
+
+var reSemverTag = regexp.MustCompile(`^v?\d+\.\d+\.\d+`)
+
+func isHex(s string) bool {
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+// componentVersion extracts the @version suffix of a component reference
+// (gitlab.com/pub/comp@1.0). Absent → "" (treated mutable).
+func componentVersion(comp string) string {
+	if i := strings.LastIndex(comp, "@"); i >= 0 {
+		return comp[i+1:]
+	}
+	return ""
+}
+
+func hostOf(u string) string {
+	s := u
+	if i := strings.Index(s, "://"); i >= 0 {
+		s = s[i+3:]
+	}
+	if i := strings.IndexAny(s, "/:"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+func strOrNil(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/gitlab/normalize_ci_sinks.go
+++ b/internal/gitlab/normalize_ci_sinks.go
@@ -1,0 +1,492 @@
+package gitlab
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Sink and dependency-edge extraction over a parsed job: needs:/dotenv/cache/
+// artifacts/image/id_tokens/job-token usage. Feeds both the job record fields and
+// the dotenv-flow / cache-keyspace / cross-project-artifact correlate joins.
+
+// ---- needs / cross-project ----
+
+// crossProjectNeeds returns {project, artifacts} tuples for needs:project: (and
+// needs:pipeline: with a project) entries. Bare same-project needs are excluded.
+func crossProjectNeeds(job map[string]any) []any {
+	out := []any{}
+	for _, raw := range needsEntries(job["needs"]) {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if proj, ok := m["project"].(string); ok && proj != "" {
+			out = append(out, map[string]any{
+				"project":   proj,
+				"artifacts": entBool(m["artifacts"]),
+				"ref":       strOrNil(entStr(m["ref"])),
+			})
+		}
+	}
+	return out
+}
+
+func needsEntries(needs any) []any {
+	switch x := needs.(type) {
+	case []any:
+		return x
+	case string:
+		return []any{map[string]any{"job": x}}
+	}
+	return nil
+}
+
+// consumesCrossPipelineArtifact reports needs:pipeline:job: (or needs:pipeline
+// artifacts:true) fetching from a different pipeline in the same project.
+func consumesCrossPipelineArtifact(job map[string]any) bool {
+	for _, raw := range needsEntries(job["needs"]) {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["pipeline"] != nil && m["project"] == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func artifactSourceRefMutable(job map[string]any) bool {
+	for _, n := range crossProjectNeeds(job) {
+		ref := entStr(entMap(n)["ref"])
+		if !isPinnedRef(ref) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- dotenv ----
+
+func producesDotenv(job map[string]any) bool {
+	return entGetIn(job, "artifacts", "reports", "dotenv") != nil
+}
+
+// dotenvContentAttackerInfluenced reports whether the dotenv producer's script
+// writes non-constant content (command substitution, a variable, fetched value)
+// rather than a fixed literal set.
+var reCmdSubst = regexp.MustCompile(`\$\(|` + "`" + `|\$\{?[A-Za-z_]`)
+
+func dotenvContentAttackerInfluenced(job map[string]any) bool {
+	for _, line := range asStrList(job["script"]) {
+		if (strings.Contains(line, ".env") || strings.Contains(line, ">>")) && reCmdSubst.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// consumesDotenv reports whether the job inherits dotenv variables from a needs:
+// producer (a plain job dependency that isn't dependencies:[] narrowed).
+func consumesDotenv(job map[string]any, producers map[string]bool) bool {
+	for _, raw := range needsEntries(job["needs"]) {
+		var name string
+		switch m := raw.(type) {
+		case string:
+			name = m
+		case map[string]any:
+			name = entStr(m["job"])
+		}
+		if producers[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// dotenvInheritanceUnnarrowed reports the consumer does NOT narrow dotenv
+// inheritance: no dependencies:[] and no inherit:{variables:false}/list.
+func dotenvInheritanceUnnarrowed(job map[string]any) bool {
+	if deps, ok := job["dependencies"]; ok {
+		if l, ok := deps.([]any); ok && len(l) == 0 {
+			return false
+		}
+	}
+	if inh, ok := job["inherit"].(map[string]any); ok {
+		if v, ok := inh["variables"]; ok {
+			if b, ok := v.(bool); ok && !b {
+				return false
+			}
+			if _, ok := v.([]any); ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ---- cache ----
+
+// cacheEntries returns {key, key_files, policy} tuples. cache: may be a single
+// map or a list of maps.
+func cacheEntries(job map[string]any) []any {
+	out := []any{}
+	for _, c := range cacheList(job["cache"]) {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, files := cacheKey(m["key"])
+		out = append(out, map[string]any{
+			"key":       strOrNil(key),
+			"key_files": files,
+			"policy":    entStr(m["policy"]),
+		})
+	}
+	return out
+}
+
+func cacheList(c any) []any {
+	switch x := c.(type) {
+	case []any:
+		return x
+	case map[string]any:
+		return []any{x}
+	}
+	return nil
+}
+
+// cacheKey returns (literal key, files list). key may be a string or {files, prefix}.
+func cacheKey(k any) (string, []any) {
+	switch x := k.(type) {
+	case string:
+		return x, []any{}
+	case map[string]any:
+		files := []any{}
+		for _, f := range asStrList(x["files"]) {
+			files = append(files, f)
+		}
+		return entStr(x["prefix"]), files
+	}
+	return "", []any{}
+}
+
+func cachePolicyWrites(job map[string]any) bool {
+	for _, c := range cacheList(job["cache"]) {
+		p := entStr(entMap(c)["policy"])
+		if p == "" || p == "pull-push" || p == "push" {
+			return true
+		}
+	}
+	return false
+}
+
+// cacheKeyStaticCrossBoundary reports the cache:key is static/global (no
+// $CI_COMMIT_REF_SLUG / protection component), so it collides across the boundary.
+func cacheKeyStaticCrossBoundary(job map[string]any) bool {
+	entries := cacheEntries(job)
+	if len(entries) == 0 {
+		return false
+	}
+	for _, e := range entries {
+		m := entMap(e)
+		key := entStr(m["key"])
+		files := entList(m["key_files"])
+		if len(files) > 0 {
+			continue // content-addressed, handled by key_files_attacker_writable
+		}
+		if !strings.Contains(key, "CI_COMMIT_REF") && !strings.Contains(key, "PROTECTED") {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- artifacts / image / pages ----
+
+func artifactPaths(job map[string]any) []any {
+	out := []any{}
+	for _, p := range asStrList(entGetIn(job, "artifacts", "paths")) {
+		out = append(out, p)
+	}
+	return out
+}
+
+func artifactsAccessUnrestricted(job map[string]any) bool {
+	art := entMap(job["artifacts"])
+	if art == nil {
+		return false
+	}
+	if pub, ok := art["public"].(bool); ok && !pub {
+		return false
+	}
+	switch entStr(art["access"]) {
+	case "developer", "maintainer", "none":
+		return false
+	}
+	return true
+}
+
+func artifactPathsBroad(job map[string]any) bool {
+	for _, p := range asStrList(entGetIn(job, "artifacts", "paths")) {
+		t := strings.TrimSpace(p)
+		if t == "." || t == "./" || t == "/" || t == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func imageRef(job map[string]any) string {
+	switch x := job["image"].(type) {
+	case string:
+		return x
+	case map[string]any:
+		return entStr(x["name"])
+	}
+	return ""
+}
+
+var reImageDigest = regexp.MustCompile(`@sha256:[0-9a-f]{64}`)
+var reMutableTag = regexp.MustCompile(`:(latest|staging|stable|main|master|dev|edge|prod|production)$`)
+
+func imageFromVariable(ref string) bool { return strings.Contains(ref, "$") }
+func imagePinnedDigest(ref string) bool { return reImageDigest.MatchString(ref) }
+func imageMutableTag(ref string) bool {
+	if ref == "" || imagePinnedDigest(ref) || imageFromVariable(ref) {
+		return false
+	}
+	if reMutableTag.MatchString(ref) {
+		return true
+	}
+	return !strings.Contains(ref[strings.LastIndex(ref, "/")+1:], ":")
+}
+
+func isPagesJob(name string, job map[string]any) bool {
+	if name == "pages" {
+		return true
+	}
+	if v, ok := job["pages"]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+		return true
+	}
+	return false
+}
+
+// ---- id_tokens (cat-10) ----
+
+func mintsIDToken(job map[string]any) bool { return entMap(job["id_tokens"]) != nil }
+
+func idTokenAuds(job map[string]any) []any {
+	out := []any{}
+	for _, tok := range entMap(job["id_tokens"]) {
+		m := entMap(tok)
+		switch a := m["aud"].(type) {
+		case string:
+			out = append(out, a)
+		case []any:
+			out = append(out, a...)
+		}
+	}
+	return out
+}
+
+// ---- job-token cross-project use (cat-04) ----
+
+var (
+	reJobTokenGitPush  = regexp.MustCompile(`gitlab-ci-token|CI_JOB_TOKEN.*(git push|/repository/)|git push.*CI_JOB_TOKEN`)
+	reJobTokenTFState  = regexp.MustCompile(`CI_JOB_TOKEN.*terraform/state|terraform/state.*CI_JOB_TOKEN`)
+	reJobTokenRead     = regexp.MustCompile(`CI_JOB_TOKEN|JOB-TOKEN:`)
+	reJobArtifactFetch = regexp.MustCompile(`JOB-TOKEN:\s*\$?CI_JOB_TOKEN.*/jobs/artifacts|/jobs/artifacts.*JOB-TOKEN`)
+)
+
+// jobTokenCrossProjectUse classifies how the job wields CI_JOB_TOKEN off-project.
+func jobTokenCrossProjectUse(scriptText string) string {
+	switch {
+	case reJobTokenGitPush.MatchString(scriptText):
+		return "git_push"
+	case reJobTokenTFState.MatchString(scriptText):
+		return "terraform_state"
+	case reJobTokenRead.MatchString(scriptText):
+		return "read"
+	}
+	return "none"
+}
+
+func fetchesCrossProjectArtifact(job map[string]any, scriptText string) bool {
+	if reJobArtifactFetch.MatchString(scriptText) {
+		return true
+	}
+	for _, n := range crossProjectNeeds(job) {
+		if entBool(entMap(n)["artifacts"]) {
+			return true
+		}
+	}
+	return false
+}
+
+// executesFetchedArtifact / artifactIntegrityChecked (cat-09 consumer signals).
+var (
+	reExtractExec = regexp.MustCompile(`\btar\s+x|\bunzip\b|source\s+|\./|\binstall\b|cp\s+.*(/usr|/opt|/bin)`)
+	reIntegrity   = regexp.MustCompile(`sha256sum\s+-c|cosign\s+verify|gpg\s+--verify|@sha256:`)
+)
+
+func executesFetchedArtifact(scriptText string) bool  { return reExtractExec.MatchString(scriptText) }
+func artifactIntegrityChecked(scriptText string) bool { return reIntegrity.MatchString(scriptText) }
+
+// reusesOnDiskCheckout (cat-08).
+func reusesOnDiskCheckout(job, vars map[string]any) bool {
+	strategy := entStr(mergeVarLookup(job, vars, "GIT_STRATEGY"))
+	if strategy == "fetch" || strategy == "none" {
+		return true
+	}
+	sub := entStr(mergeVarLookup(job, vars, "GIT_SUBMODULE_STRATEGY"))
+	return sub == "recursive" || sub == "normal"
+}
+
+// mergeVarLookup reads a variable from the job's variables: then the global
+// variables: block (job scope wins).
+func mergeVarLookup(job, globalVars map[string]any, key string) any {
+	if jv := entMap(job["variables"]); jv != nil {
+		if v, ok := jv[key]; ok {
+			return v
+		}
+	}
+	if globalVars != nil {
+		return globalVars[key]
+	}
+	return nil
+}
+
+func runnerTags(job map[string]any) []any {
+	out := []any{}
+	for _, t := range asStrList(job["tags"]) {
+		out = append(out, t)
+	}
+	return out
+}
+
+func deploysEnvironment(job map[string]any) (bool, string) {
+	switch x := job["environment"].(type) {
+	case string:
+		return true, x
+	case map[string]any:
+		return true, entStr(x["name"])
+	}
+	return false, ""
+}
+
+var reEnvInterp = regexp.MustCompile(`\$\{?[A-Za-z_]`)
+
+func environmentNameInterpolated(name string) bool { return reEnvInterp.MatchString(name) }
+
+func downloadsSecureFile(scriptText string) bool {
+	return strings.Contains(scriptText, "download-secure-files") || strings.Contains(scriptText, ".secure_files/")
+}
+
+func installsRegistryPackage(scriptText string) bool {
+	return strings.Contains(scriptText, "${CI_API_V4_URL}/packages") ||
+		strings.Contains(scriptText, "/packages/") && strings.Contains(scriptText, "install")
+}
+
+// childPipelineFromCrossProjectArtifact: trigger:include:artifact sourced from a
+// generator job that pulls a cross-project artifact (cat-02).
+func childPipelineFromCrossProjectArtifact(job map[string]any, crossNeedJobs map[string]bool) bool {
+	trig := entMap(job["trigger"])
+	if trig == nil {
+		return false
+	}
+	for _, inc := range includeEntries(trig["include"]) {
+		m := entMap(inc)
+		if m["artifact"] != nil {
+			if src := entStr(m["job"]); src == "" || crossNeedJobs[src] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// remoteStepUntrustedRef: a run: step/func from a remote git ref that is mutable
+// or third-party (cat-02, the new run: steps syntax).
+func remoteStepUntrustedRef(job map[string]any) bool {
+	run, ok := job["run"].([]any)
+	if !ok {
+		return false
+	}
+	for _, s := range run {
+		step := entMap(s)
+		var ref, gitRef string
+		if step["step"] != nil {
+			ref = entStr(step["step"])
+		}
+		if g := entMap(step["git"]); g != nil {
+			gitRef = entStr(g["rev"])
+			ref = entStr(g["url"])
+		}
+		if ref == "" {
+			continue
+		}
+		if hostOf(ref) != "" && !isPinnedRef(gitRef) {
+			return true
+		}
+	}
+	return false
+}
+
+// cacheKeyFilesAttackerWritable: cache:key:files over source-tree files (any
+// non-lockfile path is writable by a lower-trust actor on an unprotected branch).
+func cacheKeyFilesAttackerWritable(job map[string]any) bool {
+	for _, c := range cacheList(job["cache"]) {
+		_, files := cacheKey(entMap(c)["key"])
+		if len(files) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+var reExecutablePath = regexp.MustCompile(`node_modules/|vendor/|\.venv/|\.m2/|\.gradle/|\.cargo/|\.bundle/`)
+
+// cachePathsExecutable: cached paths are dependency/executable dirs, not inert data.
+func cachePathsExecutable(job map[string]any) bool {
+	for _, c := range cacheList(job["cache"]) {
+		for _, p := range asStrList(entMap(c)["paths"]) {
+			if reExecutablePath.MatchString(p) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dotenvContentFromUntrustedSource: producer builds dotenv from runtime-fetched
+// untrusted input (curl/wget/fetch of a lower-trust artifact) with no review gate.
+var reFetch = regexp.MustCompile(`\bcurl\b|\bwget\b|\bgit clone\b|artifacts/`)
+
+func dotenvContentFromUntrustedSource(job map[string]any) bool {
+	if !producesDotenv(job) {
+		return false
+	}
+	txt := jobScriptText(job)
+	return reFetch.MatchString(txt) && reCmdSubst.MatchString(txt)
+}
+
+// package version pinning (cat-09).
+var (
+	reMutableVersion = regexp.MustCompile(`@(latest|\*|\^|~)|:latest|==\s*\*`)
+	reChecksum       = regexp.MustCompile(`--require-hashes|integrity|sha256|--frozen-lockfile|npm ci\b`)
+)
+
+func packageVersionMutableRange(scriptText string) bool {
+	if !installsRegistryPackage(scriptText) {
+		return false
+	}
+	return reMutableVersion.MatchString(scriptText) || !strings.Contains(scriptText, "==")
+}
+
+func packageVersionChecksumVerified(scriptText string) bool {
+	return reChecksum.MatchString(scriptText)
+}

--- a/internal/gitlab/normalize_corpus_test.go
+++ b/internal/gitlab/normalize_corpus_test.go
@@ -1,0 +1,320 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The firing-range corpus (trajan-fr-group/trjfx, scenario projects cat-NN-vMM)
+// is the independent oracle for these tests: we assert the field contract holds
+// across a full Normalize of a real collected run, never what the code happens to
+// produce for a hand-built input. The corpus is a P2 collect run dir; point the
+// test at one with TRAJAN_GL_CORPUS. Absent, the test skips (the corpus is large
+// and lives outside the tree). A run dir is copied so Normalize's in-place writes
+// never mutate the shared corpus.
+func corpusRun(t *testing.T) string {
+	t.Helper()
+	src := os.Getenv("TRAJAN_GL_CORPUS")
+	if src == "" {
+		t.Skip("set TRAJAN_GL_CORPUS to a P2 collect run dir to run corpus-oracle tests")
+	}
+	if _, err := os.Stat(filepath.Join(src, "00-collect", "project")); err != nil {
+		t.Fatalf("TRAJAN_GL_CORPUS=%q is not a collect run dir: %v", src, err)
+	}
+	dst := t.TempDir()
+	if err := copyTree(src, dst); err != nil {
+		t.Fatalf("copy corpus: %v", err)
+	}
+	if err := Normalize(t.Context(), dst); err != nil {
+		t.Fatalf("Normalize: %v", err)
+	}
+	return dst
+}
+
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, p)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		b, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, b, 0o644)
+	})
+}
+
+// readNormRecords loads every JSON record in a 10-normalize subdir, as raw text
+// (to inspect on-disk serialization) and decoded.
+func readNormRecords(t *testing.T, run, dir string) []map[string]any {
+	t.Helper()
+	d := filepath.Join(run, "10-normalize", dir)
+	entries, err := os.ReadDir(d)
+	if err != nil {
+		return nil
+	}
+	var out []map[string]any
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(d, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		var rec map[string]any
+		if err := json.Unmarshal(b, &rec); err != nil {
+			t.Fatalf("decode %s: %v", e.Name(), err)
+		}
+		rec["__raw"] = string(b)
+		rec["__file"] = e.Name()
+		out = append(out, rec)
+	}
+	return out
+}
+
+// TestCorpusEmptyListsSerializeAsBracket is hard-contract C1: every list-typed
+// field named in the contract must serialize as [] when empty, never null and
+// never omitted — valuesEqual(nil,[]) is false, so an absent list breaks the
+// rules that gate on == [] / != []. We assert directly against the on-disk JSON.
+func TestCorpusEmptyListsSerializeAsBracket(t *testing.T) {
+	run := corpusRun(t)
+	// (dir, field) pairs the contract calls out as load-bearing for == []/!= [].
+	checks := map[string][]string{
+		"projects":       {"protected_branches", "protected_tags", "cicd_variables", "members", "registry_protection_rules"},
+		"jobs":           {"triggers", "includes", "cross_project_needs", "cache", "artifact_paths", "attacker_input_fields", "runner_tags", "id_token_aud"},
+		"merge-requests": {"external_status_checks"},
+		"agents":         {"ci_access_targets", "environments_filter"},
+		"integrations":   {"custom_headers"},
+		"groups":         {"cicd_variables", "descendants"},
+	}
+	for dir, fields := range checks {
+		recs := readNormRecords(t, run, dir)
+		if len(recs) == 0 {
+			continue
+		}
+		for _, rec := range recs {
+			raw := rec["__raw"].(string)
+			for _, f := range fields {
+				v, present := rec[f]
+				if !present {
+					t.Errorf("%s/%s: field %q omitted (contract requires [] when empty)", dir, rec["__file"], f)
+					continue
+				}
+				if v == nil {
+					t.Errorf("%s/%s: field %q serialized null (contract requires [])", dir, rec["__file"], f)
+					continue
+				}
+				if _, ok := v.([]any); !ok {
+					t.Errorf("%s/%s: field %q is %T, want list", dir, rec["__file"], f, v)
+				}
+				// Guard against the "field": null textual form slipping through.
+				if strings.Contains(raw, "\""+f+"\": null") || strings.Contains(raw, "\""+f+"\":null") {
+					t.Errorf("%s/%s: field %q appears as null in raw JSON", dir, rec["__file"], f)
+				}
+			}
+		}
+	}
+}
+
+// TestCorpusBooleansPresent is the C-boolean contract: every derived project
+// boolean the rules read must be present (defaulting false), never omitted — a
+// rule writing `x == true`/`x != true` against a missing key silently misfires.
+func TestCorpusBooleansPresent(t *testing.T) {
+	run := corpusRun(t)
+	recs := readNormRecords(t, run, "projects")
+	if len(recs) == 0 {
+		t.Skip("no project records in corpus")
+	}
+	must := []string{
+		"has_guest_member", "has_developer_pushable_unprotected_ref", "has_developer_reachable_secret",
+		"has_masked_unprotected_secret_var", "has_plain_unprotected_secret_var", "has_scoped_unprotected_secret_var",
+		"developer_writable_protected_branch", "has_reachable_runner", "has_self_managed_runner",
+		"holds_protected_resources", "ci_debug_trace_enabled", "public_pipelines",
+	}
+	for _, rec := range recs {
+		for _, f := range must {
+			v, present := rec[f]
+			if !present {
+				t.Errorf("projects/%s: boolean %q omitted", rec["__file"], f)
+				continue
+			}
+			if _, ok := v.(bool); !ok {
+				t.Errorf("projects/%s: %q is %T, want bool", rec["__file"], f, v)
+			}
+		}
+	}
+}
+
+// TestCorpusAccessLevelsNumeric is hard-contract C3: protected-branch/tag access
+// levels and member access levels are numeric (rules read >=30, ∋{30}, ==30). A
+// string role enum leaking through would make those predicates dead.
+func TestCorpusAccessLevelsNumeric(t *testing.T) {
+	run := corpusRun(t)
+	saw := false
+	for _, rec := range readNormRecords(t, run, "projects") {
+		for _, raw := range asList(rec["members"]) {
+			m, _ := raw.(map[string]any)
+			assertNumericLevel(t, rec, "members.access_level", m["access_level"])
+			saw = true
+		}
+		for _, raw := range asList(rec["protected_branches"]) {
+			b, _ := raw.(map[string]any)
+			for _, lvl := range asList(b["push_access_levels"]) {
+				assertNumericLevel(t, rec, "protected_branches.push_access_levels", lvl)
+				saw = true
+			}
+		}
+		for _, raw := range asList(rec["protected_tags"]) {
+			tg, _ := raw.(map[string]any)
+			for _, lvl := range asList(tg["create_access_levels"]) {
+				assertNumericLevel(t, rec, "protected_tags.create_access_levels", lvl)
+				saw = true
+			}
+		}
+	}
+	if !saw {
+		t.Skip("corpus carried no access-level lists to check")
+	}
+}
+
+func assertNumericLevel(t *testing.T, rec map[string]any, path string, v any) {
+	t.Helper()
+	if _, ok := v.(float64); !ok { // JSON numbers decode to float64
+		t.Errorf("%s: %s = %v (%T), want numeric access level", rec["__file"], path, v, v)
+	}
+}
+
+// TestCorpusDuoGuardrailUppercase is hard-contract C-guardrail: any emitted
+// prompt-injection level (job duo_guardrail_level/duo_instance_guardrail_level,
+// instance prompt_injection_protection_level) that carries the GraphQL enum must
+// keep it UPPERCASE verbatim. We only assert on values that look like the enum.
+func TestCorpusDuoGuardrailUppercase(t *testing.T) {
+	run := corpusRun(t)
+	enum := map[string]bool{"NO_CHECKS": true, "LOG_ONLY": true, "INTERRUPT": true}
+	check := func(file string, field string, v any) {
+		s, ok := v.(string)
+		if !ok || s == "" {
+			return
+		}
+		if enum[strings.ToUpper(s)] && s != strings.ToUpper(s) {
+			t.Errorf("%s: %s = %q, want uppercase verbatim", file, field, s)
+		}
+	}
+	for _, rec := range readNormRecords(t, run, "jobs") {
+		check(rec["__file"].(string), "duo_guardrail_level", rec["duo_guardrail_level"])
+		check(rec["__file"].(string), "duo_instance_guardrail_level", rec["duo_instance_guardrail_level"])
+	}
+	for _, rec := range readNormRecords(t, run, "instance") {
+		check(rec["__file"].(string), "prompt_injection_protection_level", rec["prompt_injection_protection_level"])
+	}
+}
+
+// TestCorpusChainKeys is the hard for_each contract: correlate must write each of
+// the nine joins under exactly its contract key (an unset/mismatched key makes
+// iterChainItems default to "links" → iterate nothing). This is checked against
+// the contract table, not the code.
+func TestCorpusChainKeys(t *testing.T) {
+	run := corpusRun(t)
+	want := map[string]string{
+		"job-token-allowlist":        "edges",
+		"protected-var-reachability": "reachable_vars",
+		"dotenv-flow":                "edges",
+		"cache-keyspace":             "prefix_overlaps",
+		"cross-project-artifact":     "edges",
+		"deploy-key-reuse":           "reused_keys",
+		"agent-ci-access":            "grants",
+		"runner-reachability":        "reachable_runners",
+		"group-runner-reachability":  "reachable_runners",
+	}
+	for join, key := range want {
+		b, err := os.ReadFile(filepath.Join(run, "10-normalize", "chains", join+".json"))
+		if err != nil {
+			t.Errorf("chain %s not emitted: %v", join, err)
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("chain %s decode: %v", join, err)
+		}
+		if m["chain"] != join {
+			t.Errorf("chain %s: chain=%v", join, m["chain"])
+		}
+		v, present := m[key]
+		if !present {
+			t.Errorf("chain %s: missing for_each key %q (keys=%v)", join, key, keysOf(m))
+			continue
+		}
+		if _, ok := v.([]any); !ok {
+			t.Errorf("chain %s: %q is %T, want list of tuples", join, key, v)
+		}
+	}
+}
+
+// TestCorpusProtectedVarSelfResolving asserts the self-resolving invariant on the
+// real join output: every emitted reachable_vars tuple carries a protected var,
+// and the tuple's project equals the var's project (correlation (b): member ⊂ ref
+// project). If the join leaked non-protected vars or cross-project members the
+// literal-only rules would fire wrongly.
+func TestCorpusProtectedVarSelfResolving(t *testing.T) {
+	run := corpusRun(t)
+	b, err := os.ReadFile(filepath.Join(run, "10-normalize", "chains", "protected-var-reachability.json"))
+	if err != nil {
+		t.Fatalf("read join: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	tuples := asList(m["reachable_vars"])
+	if len(tuples) == 0 {
+		t.Skip("corpus produced no protected-var tuples")
+	}
+	for _, raw := range tuples {
+		tp, _ := raw.(map[string]any)
+		v, _ := tp["var"].(map[string]any)
+		if v["protected"] != true {
+			t.Errorf("reachable_vars: emitted non-protected var %v", v["key"])
+		}
+		if tp["project"] != v["project"] {
+			t.Errorf("reachable_vars: tuple.project=%v != var.project=%v (self-resolve (b) violated)", tp["project"], v["project"])
+		}
+	}
+}
+
+// TestCorpusProvenanceOnEveryRecord: _provenance rides on every normalized record
+// (evidence templating depends on it). Checked across all subject dirs present.
+func TestCorpusProvenanceOnEveryRecord(t *testing.T) {
+	run := corpusRun(t)
+	for _, dir := range []string{"projects", "jobs", "groups", "instance", "merge-requests", "environments", "runners", "agents", "credentials", "integrations"} {
+		for _, rec := range readNormRecords(t, run, dir) {
+			if _, ok := rec["_provenance"]; !ok {
+				t.Errorf("%s/%s: missing _provenance", dir, rec["__file"])
+			}
+			if _, ok := rec["_id"]; !ok {
+				t.Errorf("%s/%s: missing _id", dir, rec["__file"])
+			}
+		}
+	}
+}
+
+func asList(v any) []any {
+	l, _ := v.([]any)
+	return l
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/gitlab/normalize_entities.go
+++ b/internal/gitlab/normalize_entities.go
@@ -1,0 +1,2235 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// normalizeEntities emits the ten non-job subject records (project, group,
+// instance, merge_request, environment, runner, agent, credential, integration,
+// plus the instance singleton) from the collected surfaces. Resource-scoped
+// facts fold onto their owning subject. Per-item failures are recorded in
+// timer.Errors and skipped; only IO / contract violations abort.
+func normalizeEntities(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	if err := normalizeInstance(prior, cp, timer); err != nil {
+		return err
+	}
+	if err := normalizeGroups(ctx, prior, cp, org, projs, timer); err != nil {
+		return err
+	}
+	if err := normalizeRunners(prior, cp, org, projs, timer); err != nil {
+		return err
+	}
+	for _, p := range projs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		for _, fn := range []func(engine.PriorPhase, engine.CurrentPhase, projectMeta, *engine.PhaseTimer) error{
+			normalizeProject, normalizeMergeRequest, normalizeEnvironments,
+			normalizeCredentials, normalizeIntegrations,
+		} {
+			if err := fn(prior, cp, p, timer); err != nil {
+				return err
+			}
+		}
+		if err := normalizeAgents(prior, cp, p, projs, timer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---- project ----
+
+func normalizeProject(prior engine.PriorPhase, cp engine.CurrentPhase, p projectMeta, timer *engine.PhaseTimer) error {
+	fp := p.FullPath
+	detail := entLoadData(prior, engine.CollectGLProject(fp))
+	if detail == nil {
+		return nil
+	}
+	ci := entLoadData(prior, engine.CollectGLCISettings(fp))
+	members := entLoadList(prior, engine.CollectGLProjectMembers(fp))
+	vars := entLoadList(prior, engine.CollectGLProjectVariables(fp))
+	pbranches := entLoadList(prior, engine.CollectGLProtectedBranches(fp))
+	ptags := entLoadList(prior, engine.CollectGLProtectedTags(fp))
+	tfState := entLoadData(prior, engine.CollectGLTerraformState(fp))
+	tfList := entLoadList(prior, engine.CollectGLTerraformState(fp))
+	ciYAML := entLoadRaw(prior, engine.CollectGLCIConfig(fp, ".gitlab-ci.yml"))
+	runners := reachableRunners(prior, fp)
+
+	cicdVars := normalizeVariables(vars, "project")
+	protBranches := normalizeProtectedBranches(pbranches)
+	protTags := normalizeProtectedTags(ptags)
+	memberRecs := normalizeMembers(members)
+
+	rec := map[string]any{
+		"_id":                                  fp,
+		"visibility":                           entStr(detail["visibility"]),
+		"forking_enabled":                      entStr(detail["forking_access_level"]) != "disabled",
+		"fork_pipelines_run_in_parent":         entBool(detail["ci_allow_fork_pipelines_to_run_in_parent_project"]),
+		"mr_pipelines_protected":               entBool(detail["protect_merge_request_pipelines"]),
+		"merged_results_pipelines":             entBool(detail["merge_pipelines_enabled"]) || entBool(detail["merge_trains_enabled"]),
+		"inbound_job_token_scope_enabled":      entBool(detail["ci_job_token_scope_enabled"]),
+		"job_token_allowlist":                  jobTokenAllowlist(ci),
+		"job_token_push_allowed":               entBool(detail["ci_push_repository_for_job_token_allowed"]),
+		"job_token_cross_project_push_allowed": entBool(entGetIn(ci, "ci_cd_settings", "project", "ciCdSettings", "crossProjectPushForJobTokenAllowed")),
+		"uses_managed_terraform_state":         !entUnobserved(tfState) && len(tfList) > 0,
+		"cache_separation_enabled":             entBool(detail["ci_separated_caches"]),
+		"oidc":                                 map[string]any{"sub_claim_components": entListOrEmpty(detail["ci_id_token_sub_claim_components"])},
+		"pages_access_level":                   entStr(detail["pages_access_level"]),
+		"auto_devops_enabled":                  entBool(detail["auto_devops_enabled"]),
+		"has_cicd_config":                      ciYAML != nil,
+		"protected_branches":                   protBranches,
+		"protected_tags":                       protTags,
+		"default_branch_protected":             defaultBranchProtection(protBranches, entStr(detail["default_branch"])),
+		"push_rules":                           orEmptyObj(entLoadData(prior, engine.CollectGLPushRules(fp))),
+		"cicd_variables":                       cicdVars,
+		"public_pipelines":                     publicPipelines(detail),
+		"members":                              memberRecs,
+		"registry_protection_rules":            registryProtectionRules(prior, fp),
+		"duo":                                  projectDuo(prior, fp),
+		"pipeline_execution_policy_from_mutable_project": policyFromMutableProject(prior, fp, protBranches),
+		"_provenance": prov(engine.CollectGLProject(fp)),
+	}
+
+	// Derived existentials / effective booleans (hard contracts C3/C4). The engine
+	// cannot express these joins/existentials in a predicate.
+	devPushRef := developerPushableUnprotectedRef(protBranches)
+	rec["has_guest_member"] = hasMemberAtLevel(members, accessGuest)
+	rec["has_developer_pushable_unprotected_ref"] = devPushRef
+	rec["has_developer_reachable_secret"] = len(cicdVars) > 0 && devPushRef
+	rec["has_masked_unprotected_secret_var"] = anyVar(cicdVars, func(v map[string]any) bool {
+		return mBool(v, "masked") && !mBool(v, "protected") && secretShapedKey(mStr(v, "key"))
+	})
+	rec["has_plain_unprotected_secret_var"] = anyVar(cicdVars, func(v map[string]any) bool {
+		return !mBool(v, "masked") && !mBool(v, "protected") && secretShapedKey(mStr(v, "key"))
+	})
+	rec["has_scoped_unprotected_secret_var"] = anyVar(cicdVars, func(v map[string]any) bool {
+		return mStr(v, "environment_scope") != "*" && mStr(v, "environment_scope") != "" && !mBool(v, "protected") && secretShapedKey(mStr(v, "key"))
+	})
+	rec["developer_pushable_protected_branch"] = anyBranch(protBranches, func(b map[string]any) bool {
+		return grantsDeveloper(mList(b, "push_access_levels"))
+	})
+	rec["developer_mergeable_protected_branch"] = anyBranch(protBranches, func(b map[string]any) bool {
+		return grantsDeveloper(mList(b, "merge_access_levels"))
+	})
+	rec["developer_writable_protected_branch"] = anyBranch(protBranches, func(b map[string]any) bool {
+		return grantsDeveloper(mList(b, "push_access_levels")) || grantsDeveloper(mList(b, "merge_access_levels"))
+	})
+	rec["developer_creatable_wildcard_branch"] = anyBranch(protBranches, func(b map[string]any) bool {
+		return isWildcard(mStr(b, "pattern")) && (grantsDeveloper(mList(b, "push_access_levels")) || grantsDeveloper(mList(b, "merge_access_levels")))
+	})
+	rec["force_push_by_low_trust_pusher"] = anyBranch(protBranches, func(b map[string]any) bool {
+		return mBool(b, "allow_force_push") && levelsIncludeAtMost(mList(b, "push_access_levels"), accessDeveloper)
+	})
+	rec["developer_creatable_protected_tag"] = anyTag(protTags, func(t map[string]any) bool {
+		return grantsDeveloper(mList(t, "create_access_levels"))
+	})
+	rec["push_access_shadowed_by_permissive_rule"] = shadowedByPermissive(protBranches, "push_access_levels")
+	rec["create_access_shadowed_by_permissive_tag_rule"] = shadowedTags(protTags)
+	rec["force_push_shadowed_by_permissive_rule"] = forcePushShadowed(protBranches)
+	rec["no_one_push_creatable_via_merge"] = anyBranch(protBranches, func(b map[string]any) bool {
+		return len(mList(b, "push_access_levels")) == 0 && grantsDeveloper(mList(b, "merge_access_levels"))
+	})
+	rec["has_reachable_runner"] = len(runners) > 0
+	rec["has_self_managed_runner"] = anyRunner(runners, func(r map[string]any) bool { return mBool(r, "self_managed") })
+	rec["has_protected_self_managed_runner"] = anyRunner(runners, func(r map[string]any) bool {
+		return mBool(r, "self_managed") && mBool(r, "ref_protected")
+	})
+	rec["holds_protected_resources"] = anyVar(cicdVars, func(v map[string]any) bool { return mBool(v, "protected") }) ||
+		anyRunner(runners, func(r map[string]any) bool { return mBool(r, "ref_protected") })
+	rec["ci_debug_trace_enabled"] = ciDebugTrace(cicdVars, ciYAML)
+	rec["auto_devops_deploy_creds_wired"] = anyVar(cicdVars, func(v map[string]any) bool { return deployCredKey(mStr(v, "key")) })
+	rec["group_inherited_deploy_vars"] = groupInheritedDeployVars(prior, fp)
+	rec["author_can_self_merge"] = authorCanSelfMerge(prior, fp)
+	rec["protected_var_scoped_to_writable_ref"] = protectedVarScopedToWritable(cicdVars, protBranches)
+	rec["protected_var_scoped_to_tag_pipeline"] = anyVar(cicdVars, func(v map[string]any) bool { return mBool(v, "protected") }) &&
+		len(protTags) > 0 && ciYAMLHasTagJob(ciYAML)
+	rec["ref_is_ci_trusted"] = anyVar(cicdVars, func(v map[string]any) bool { return mBool(v, "protected") }) || entStr(detail["default_branch"]) != ""
+	rec["ref_has_deferred_deploy_identity"] = ciYAMLHasDeployIdentity(ciYAML)
+	src, inheritedDevPush := inheritedDefaultBranchProtection(prior, fp, protBranches, entStr(detail["default_branch"]))
+	rec["inherited_protection_source"] = src
+	rec["inherited_default_branch_developer_pushable"] = inheritedDevPush
+	rec["is_schedule_owner"] = projectHasMemberOwnedSchedule(prior, fp, members)
+
+	return emit(cp, timer, engine.NormalizeGLProject(fp), rec)
+}
+
+// projectHasMemberOwnedSchedule reports whether a pipeline schedule exists whose
+// owner is a project member — the cat-04 triggerer signal that the identity
+// starting the scheduled run is a project member (schedules run in the owner's
+// context). When the owner id cannot be matched to a member (owner or members
+// absent), fall back to "any schedule exists" so the participant is not silently
+// forced false on a token that could not read the members list.
+func projectHasMemberOwnedSchedule(prior engine.PriorPhase, fp string, members []any) bool {
+	schedules := entLoadList(prior, engine.CollectGLPipelineSchedules(fp))
+	if len(schedules) == 0 {
+		return false
+	}
+	memberIDs := map[int64]bool{}
+	for _, raw := range members {
+		if id := entInt64(entMap(raw)["id"]); id != 0 {
+			memberIDs[id] = true
+		}
+	}
+	for _, raw := range schedules {
+		ownerID := entInt64(entMap(entMap(raw)["owner"])["id"])
+		if len(memberIDs) == 0 || ownerID == 0 || memberIDs[ownerID] {
+			return true
+		}
+	}
+	return false
+}
+
+func publicPipelines(detail map[string]any) bool {
+	if v, ok := detail["public_jobs"].(bool); ok {
+		return v
+	}
+	if v, ok := detail["public_pipelines"].(bool); ok {
+		return v
+	}
+	return true
+}
+
+func jobTokenAllowlist(ci map[string]any) map[string]any {
+	entries := []any{}
+	for _, raw := range entListOrEmpty(ci["job_token_allowlist"]) {
+		if fp := entStr(entMap(raw)["path_with_namespace"]); fp != "" {
+			entries = append(entries, fp)
+		}
+	}
+	for _, raw := range entListOrEmpty(ci["job_token_groups_allowlist"]) {
+		if fp := entStr(entMap(raw)["full_path"]); fp != "" {
+			entries = append(entries, fp)
+		}
+	}
+	inbound := entBool(entGetIn(ci, "job_token_scope", "inbound_enabled")) ||
+		entBool(entGetIn(ci, "ci_cd_settings", "project", "ciCdSettings", "inboundJobTokenScopeEnabled"))
+	mode := "open"
+	if !inbound {
+		mode = "disabled"
+	} else if len(entListOrEmpty(ci["job_token_groups_allowlist"])) > 0 {
+		mode = "group_scoped"
+	} else if len(entListOrEmpty(ci["job_token_allowlist"])) > 0 {
+		mode = "project_scoped"
+	}
+	return map[string]any{
+		"mode":         mode,
+		"entries":      entries,
+		"fine_grained": len(entListOrEmpty(ci["job_token_groups_allowlist"])) > 0,
+	}
+}
+
+func normalizeVariables(vars []any, scope string) []map[string]any {
+	out := []map[string]any{}
+	for _, raw := range vars {
+		v := entMap(raw)
+		if entStr(v["key"]) == "" {
+			continue
+		}
+		out = append(out, map[string]any{
+			"key":               entStr(v["key"]),
+			"protected":         entBool(v["protected"]),
+			"masked":            entBool(v["masked"]),
+			"environment_scope": entStr(v["environment_scope"]),
+			"scope_level":       scope,
+		})
+	}
+	return out
+}
+
+func normalizeProtectedBranches(pbranches []any) []map[string]any {
+	out := []map[string]any{}
+	for _, raw := range pbranches {
+		b := entMap(raw)
+		out = append(out, map[string]any{
+			"pattern":                      entStr(b["name"]),
+			"push_access_levels":           accessLevelValues(b["push_access_levels"]),
+			"merge_access_levels":          accessLevelValues(b["merge_access_levels"]),
+			"allow_force_push":             entBool(b["allow_force_push"]),
+			"code_owner_approval_required": entBool(b["code_owner_approval_required"]),
+			"push_named_grant":             hasNamedGrant(b["push_access_levels"]),
+			"merge_named_grant":            hasNamedGrant(b["merge_access_levels"]),
+		})
+	}
+	return out
+}
+
+func normalizeProtectedTags(ptags []any) []map[string]any {
+	out := []map[string]any{}
+	for _, raw := range ptags {
+		t := entMap(raw)
+		out = append(out, map[string]any{
+			"pattern":              entStr(t["name"]),
+			"create_access_levels": accessLevelValues(t["create_access_levels"]),
+			"create_named_grant":   hasNamedGrant(t["create_access_levels"]),
+		})
+	}
+	return out
+}
+
+func normalizeMembers(members []any) []map[string]any {
+	out := []map[string]any{}
+	for _, raw := range members {
+		m := entMap(raw)
+		out = append(out, map[string]any{
+			"access_level": entInt64(m["access_level"]),
+			"is_bot":       entBool(m["bot"]) || entBool(m["is_bot"]),
+		})
+	}
+	return out
+}
+
+func defaultBranchProtection(branches []map[string]any, defaultBranch string) string {
+	for _, b := range branches {
+		if globMatch(mStr(b, "pattern"), defaultBranch) {
+			switch {
+			case grantsDeveloper(mList(b, "push_access_levels")):
+				return "developer"
+			case len(mList(b, "push_access_levels")) == 0:
+				return "maintainer"
+			default:
+				return "maintainer"
+			}
+		}
+	}
+	return "none"
+}
+
+func registryProtectionRules(prior engine.PriorPhase, fp string) []any {
+	out := []any{}
+	out = append(out, entListOrEmpty(anyToVal(entLoadList(prior, engine.CollectGLRegistryTagRules(fp))))...)
+	out = append(out, entListOrEmpty(anyToVal(entLoadList(prior, engine.CollectGLPackageProtectionRules(fp))))...)
+	return out
+}
+
+func anyToVal(l []any) any {
+	if l == nil {
+		return []any{}
+	}
+	return l
+}
+
+func projectDuo(prior engine.PriorPhase, fp string) map[string]any {
+	cfg := entLoadRaw(prior, engine.CollectGLRepoFile(fp, ".gitlab/duo/agent-config.yml"))
+	mcp := entLoadRaw(prior, engine.CollectGLRepoFile(fp, ".gitlab/duo/mcp.json"))
+	flows := []any{}
+	var mcpEndpoint any
+	if len(mcp) > 0 {
+		var m map[string]any
+		if json.Unmarshal(mcp, &m) == nil {
+			mcpEndpoint = firstMCPEndpoint(m)
+		}
+	}
+	return map[string]any{
+		"config_present": cfg != nil,
+		"flows":          flows,
+		"mcp_endpoint":   mcpEndpoint,
+	}
+}
+
+func firstMCPEndpoint(m map[string]any) any {
+	for _, key := range []string{"servers", "mcpServers"} {
+		if servers := entMap(m[key]); servers != nil {
+			for _, v := range servers {
+				if url := entStr(entMap(v)["url"]); url != "" {
+					return url
+				}
+			}
+		}
+	}
+	return m["url"]
+}
+
+// ---- group ----
+
+func normalizeGroups(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	groups := groupRoster(prior, org)
+	for _, g := range groups {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := normalizeGroup(prior, cp, g, projs, timer); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// groupRoster is the top-level group plus its collected subgroups.
+func groupRoster(prior engine.PriorPhase, org string) []string {
+	out := []string{org}
+	for _, raw := range entLoadList(prior, engine.CollectGLSubgroups(org)) {
+		if fp := entStr(entMap(raw)["full_path"]); fp != "" {
+			out = append(out, fp)
+		}
+	}
+	return out
+}
+
+func normalizeGroup(prior engine.PriorPhase, cp engine.CurrentPhase, gpath string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	detail := entLoadData(prior, engine.CollectGLGroup(gpath))
+	if detail == nil {
+		return nil
+	}
+	duo := entLoadData(prior, engine.CollectGLGroupDuo(gpath))
+	vars := entLoadList(prior, engine.CollectGLGroupVariables(gpath))
+	saml := entLoadData(prior, engine.CollectGLGroupSAML(gpath))
+
+	roleLevel := roleNameToLevel(detail["default_membership_role"])
+	projectCreationRole := entStr(detail["project_creation_level"])
+	subgroupCreation := entStr(detail["subgroup_creation_level"])
+
+	rec := map[string]any{
+		"_id":                                   gpath,
+		"default_membership_role":               levelToRoleName(roleLevel),
+		"default_branch_protection":             groupBranchProtection(detail),
+		"project_creation_role":                 projectCreationRole,
+		"project_access_token_creation_allowed": entBool(detail["project_access_token_creation_allowed"]),
+		"shared_runners_enabled":                entStr(detail["shared_runners_setting"]) != "disabled_and_unoverridable" && entStr(detail["shared_runners_setting"]) != "disabled_and_overridable",
+		"duo_features_enabled":                  duoFeatureEnabled(duo, "group"),
+		"prompt_injection_protection_level":     duoGuardrail(duo, "group"),
+		"duo_workflow_mcp_enabled":              duoBool(duo, "group", "duoWorkflowMcpEnabled"),
+		"domain_allowlist":                      entListOrEmpty(detail["domain_allowlist"]),
+		"cicd_variables":                        groupVarRecs(vars),
+		"descendants":                           groupDescendants(prior, gpath, projs),
+		"group_open_project_creation":           groupOpenCreation(projectCreationRole, subgroupCreation),
+		"saml_provisioning_active":              !entUnobserved(saml) && saml != nil && len(saml) > 0,
+		"default_role_custom_cicd_ability":      false,
+		"_provenance":                           prov(engine.CollectGLGroup(gpath)),
+	}
+	return emit(cp, timer, engine.NormalizeGLGroup(gpath), rec)
+}
+
+func groupVarRecs(vars []any) []map[string]any { return normalizeVariables(vars, "group") }
+
+// groupBranchProtection maps the group default-branch protection to the enum the
+// cat-03 rule reads: "none" | "partial" | "full". GitLab exposes this either as
+// the legacy integer default_branch_protection (0 none, 1 partial, 2+ full) or
+// the newer default_branch_protection_defaults object; a Developer-inclusive push
+// grant is "partial", a Maintainer-only (or force-push-blocked) grant is "full".
+func groupBranchProtection(detail map[string]any) any {
+	if d := entMap(detail["default_branch_protection_defaults"]); d != nil {
+		push := accessLevelValues(d["allowed_to_push"])
+		if levelsIncludeAtMost(push, accessDeveloper) || entBool(d["allow_force_push"]) {
+			return "partial"
+		}
+		return "full"
+	}
+	if v, ok := detail["default_branch_protection"]; ok {
+		switch entInt64(v) {
+		case 0:
+			return "none"
+		case 1:
+			return "partial"
+		default:
+			return "full"
+		}
+	}
+	return nil
+}
+
+func groupDescendants(prior engine.PriorPhase, gpath string, projs []projectMeta) []any {
+	out := []any{}
+	for _, raw := range entLoadList(prior, engine.CollectGLSubgroups(gpath)) {
+		if fp := entStr(entMap(raw)["full_path"]); fp != "" {
+			out = append(out, fp)
+		}
+	}
+	for _, p := range projs {
+		if p.FullPath == gpath || strings.HasPrefix(p.FullPath, gpath+"/") {
+			out = append(out, p.FullPath)
+		}
+	}
+	return out
+}
+
+func groupOpenCreation(projectCreationRole, subgroupCreation string) bool {
+	permits := func(s string) bool {
+		switch s {
+		case "developer", "maintainer", "":
+			return true
+		}
+		return false
+	}
+	return permits(projectCreationRole) || permits(subgroupCreation)
+}
+
+// ---- instance ----
+
+func normalizeInstance(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer) error {
+	settings := entLoadData(prior, engine.CollectGLInstanceSettings())
+	duo := entLoadData(prior, engine.CollectGLInstanceDuo())
+	runners := entLoadList(prior, engine.CollectGLInstanceRunners())
+	instVars := entLoadList(prior, engine.CollectGLInstanceVariables())
+	obs := settings != nil && !entUnobserved(settings)
+
+	// Soft-failed instance surface (gitlab.com, or no admin token): emit the
+	// record with the observable keys null so absence is never read as false.
+	rec := map[string]any{
+		"_id":                                         "instance",
+		"allow_local_requests_from_webhooks":          boolOrNil(obs, settings, "allow_local_requests_from_web_hooks_and_services"),
+		"runner_registration_token_allowed":           boolOrNil(obs, settings, "allow_runner_registration_token"),
+		"valid_runner_registrars":                     entListOrEmpty(settings["valid_runner_registrars"]),
+		"auto_devops_enabled":                         boolOrNil(obs, settings, "auto_devops_enabled"),
+		"signup_enabled":                              boolOrNil(obs, settings, "signup_enabled"),
+		"can_create_group":                            boolOrNil(obs, settings, "can_create_group"),
+		"shared_runners_enabled":                      boolOrNil(obs, settings, "shared_runners_enabled"),
+		"service_token_expiration_enforced":           boolOrNil(obs, settings, "service_access_tokens_expiration_enforced"),
+		"require_admin_approval_after_signup":         boolOrNil(obs, settings, "require_admin_approval_after_user_signup"),
+		"project_creation_unrestricted":               projectCreationUnrestricted(obs, settings),
+		"duo_features_enabled":                        duoFeatureEnabled(duo, "instance"),
+		"duo_workflow_mcp_enabled":                    duoBool(duo, "instance", "duoWorkflowMcpEnabled"),
+		"prompt_injection_protection_level":           duoGuardrail(duo, "instance"),
+		"outbound_local_requests_allowlist_effective": outboundAllowlistEffective(obs, settings),
+		"instance_agent_authorization_enabled":        boolOrNil(obs, settings, "instance_level_ai_beta_features_enabled"),
+		"cicd_variables":                              normalizeVariables(instVars, "instance"),
+		"_provenance":                                 prov(engine.CollectGLInstanceSettings()),
+	}
+	selfManagedShared := anyRunner(reachableRunnerList(runners), func(r map[string]any) bool {
+		return mStr(r, "runner_type") == "instance_type" && mBool(r, "self_managed")
+	})
+	rec["open_project_creation"] = obs && entBool(settings["signup_enabled"]) && entBool(settings["shared_runners_enabled"]) && projectCreationUnrestricted(obs, settings) == true
+	rec["self_managed_shared_runner_serves_higher_trust"] = selfManagedShared
+	rec["reusable_token_scope_serves_secrets"] = selfManagedShared && boolVal(boolOrNil(obs, settings, "allow_runner_registration_token"))
+	rec["closed_audience_instance"] = obs && !entBool(settings["signup_enabled"])
+	return emit(cp, timer, engine.NormalizeGLInstance(), rec)
+}
+
+func boolOrNil(observed bool, m map[string]any, key string) any {
+	if !observed {
+		return nil
+	}
+	return entBool(m[key])
+}
+
+func boolVal(v any) bool { b, _ := v.(bool); return b }
+
+func projectCreationUnrestricted(observed bool, settings map[string]any) any {
+	if !observed {
+		return nil
+	}
+	// default_project_creation is a numeric role code; 0 (nobody) or a specific
+	// role restricts, any other authenticated user is the unrestricted case.
+	if v, ok := settings["default_project_creation"]; ok {
+		return entInt64(v) == 2
+	}
+	return false
+}
+
+func outboundAllowlistEffective(observed bool, settings map[string]any) any {
+	if !observed {
+		return nil
+	}
+	return len(entListOrEmpty(settings["outbound_local_requests_whitelist"])) > 0
+}
+
+// ---- merge_request ----
+
+func normalizeMergeRequest(prior engine.PriorPhase, cp engine.CurrentPhase, p projectMeta, timer *engine.PhaseTimer) error {
+	fp := p.FullPath
+	detail := entLoadData(prior, engine.CollectGLProject(fp))
+	if detail == nil {
+		return nil
+	}
+	approvals := entLoadData(prior, engine.CollectGLApprovals(fp))
+	rules := entLoadList(prior, engine.CollectGLApprovalRules(fp))
+	extChecks := entLoadList(prior, engine.CollectGLExternalStatusChecks(fp))
+	codeowners := loadCodeowners(prior, fp)
+	pbranches := normalizeProtectedBranches(entLoadList(prior, engine.CollectGLProtectedBranches(fp)))
+	members := entLoadList(prior, engine.CollectGLProjectMembers(fp))
+
+	approvalsReq := entInt64(approvals["approvals_before_merge"])
+	independent := independentApprovers(rules, members)
+
+	rec := map[string]any{
+		"_id":                                  fp,
+		"author_approval_allowed":              entBool(approvals["merge_requests_author_approval"]),
+		"committer_approval_disabled":          entBool(approvals["merge_requests_disable_committers_approval"]),
+		"approvals_required":                   approvalsReq,
+		"author_controls_approver_count":       !entBool(approvals["disable_overriding_approvers_per_merge_request"]),
+		"reset_approvals_on_push":              entBool(approvals["reset_approvals_on_push"]),
+		"code_owner_approval_required":         anyBranch(pbranches, func(b map[string]any) bool { return mBool(b, "code_owner_approval_required") }),
+		"selective_code_owner_removal":         entBool(approvals["selective_code_owner_removals"]),
+		"codeowners":                           codeowners,
+		"only_merge_if_pipeline_succeeds":      entBool(detail["only_allow_merge_if_pipeline_succeeds"]),
+		"only_merge_if_status_checks_pass":     entBool(detail["only_allow_merge_if_all_status_checks_passed"]),
+		"allow_merge_on_skipped_pipeline":      entBool(detail["allow_merge_on_skipped_pipeline"]),
+		"external_status_checks":               entListOrEmpty(anyToVal(extChecks)),
+		"approval_policy":                      approvalPolicy(prior, fp),
+		"approver_set_broad":                   approverSetBroad(rules),
+		"independent_approver_count":           independent,
+		"trust_relevant_path_optional_only":    boolVal(codeowners["optional_sections"]) && !boolVal(codeowners["self_owned_required"]),
+		"target_branch_ci_trusted_unprotected": len(pbranches) == 0,
+		"required_jobs_evadable":               requiredJobsEvadable(prior, fp),
+		"_provenance":                          prov(engine.CollectGLProject(fp), engine.CollectGLApprovals(fp)),
+	}
+	return emit(cp, timer, engine.NormalizeGLMergeRequest(fp), rec)
+}
+
+func loadCodeowners(prior engine.PriorPhase, fp string) map[string]any {
+	var raw []byte
+	for _, rp := range []string{"CODEOWNERS", ".gitlab/CODEOWNERS", "docs/CODEOWNERS"} {
+		if b := entLoadRaw(prior, engine.CollectGLRepoFile(fp, rp)); b != nil {
+			raw = b
+			break
+		}
+	}
+	if raw == nil {
+		return map[string]any{
+			"optional_sections": false, "covers_cicd_config": false, "self_owned_required": false,
+		}
+	}
+	text := string(raw)
+	optional := false
+	inOptional := false
+	coversCI := false
+	selfOwned := false
+	for _, line := range strings.Split(text, "\n") {
+		l := strings.TrimSpace(line)
+		if l == "" || strings.HasPrefix(l, "#") {
+			continue
+		}
+		if strings.HasPrefix(l, "^[") || strings.HasPrefix(l, "[") {
+			inOptional = strings.HasPrefix(l, "^[")
+			if inOptional {
+				optional = true
+			}
+			continue
+		}
+		path := strings.Fields(l)[0]
+		if strings.Contains(path, ".gitlab-ci.yml") {
+			coversCI = true
+		}
+		if !inOptional && (strings.Contains(path, "CODEOWNERS")) {
+			selfOwned = true
+		}
+	}
+	return map[string]any{
+		"optional_sections":   optional,
+		"covers_cicd_config":  coversCI,
+		"self_owned_required": selfOwned,
+	}
+}
+
+// requiredJobsEvadable reports whether the resolved pipeline can legitimately
+// produce a skipped/empty pipeline that still satisfies "pipelines must succeed"
+// (cat-06/13, doc line 309): every job is gated behind an author-controllable
+// rules:/only:/except:/when: condition, or the workflow: itself carries a
+// when: never branch, so an MR can yield no jobs. An unconditional job always runs,
+// so nothing is evadable.
+func requiredJobsEvadable(prior engine.PriorPhase, fp string) bool {
+	pipeline, err := parseCIPipeline(entLoadRaw(prior, engine.CollectGLCIConfig(fp, ".gitlab-ci.yml")))
+	if err != nil || pipeline == nil {
+		return false
+	}
+	names := jobNames(pipeline)
+	if len(names) == 0 {
+		return false
+	}
+	def := entMap(pipeline["default"])
+	for _, name := range names {
+		if !jobConditionallyGated(mergeDefault(entMap(pipeline[name]), def)) {
+			return false
+		}
+	}
+	return true
+}
+
+func jobConditionallyGated(job map[string]any) bool {
+	if _, ok := job["rules"]; ok {
+		return true
+	}
+	if _, ok := job["only"]; ok {
+		return true
+	}
+	if _, ok := job["except"]; ok {
+		return true
+	}
+	if w, ok := job["when"]; ok {
+		return entStr(w) == "manual" || entStr(w) == "never" || entStr(w) == "delayed"
+	}
+	return false
+}
+
+func approvalPolicy(prior engine.PriorPhase, fp string) map[string]any {
+	pol := entLoadData(prior, engine.CollectGLSecurityPolicies(fp))
+	nodes := entList(entGetIn(pol, "project", "approvalPolicies", "nodes"))
+	enabled := false
+	scanners := []any{}
+	fallback := any(nil)
+	enforcement := any(nil)
+	bypassBroad := false
+	for _, raw := range nodes {
+		n := entMap(raw)
+		en := entBool(n["enabled"])
+		if en {
+			enabled = true
+		}
+		spec := parsePolicyYAML(entStr(n["yaml"]))
+		if spec == nil {
+			continue
+		}
+		for _, s := range policyScanners(spec) {
+			scanners = append(scanners, s)
+		}
+		// fallback_behavior: {fail: open|closed}. GitLab's default is fail_closed;
+		// only an explicit fail:open weakens the gate. Report the first policy that
+		// declares one so the fail-open rule reads a literal.
+		if fallback == nil {
+			if fb := entMap(spec["fallback_behavior"]); fb != nil {
+				switch entStr(fb["fail"]) {
+				case "open":
+					fallback = "fail_open"
+				case "closed":
+					fallback = "fail_closed"
+				}
+			}
+		}
+		// enforcement_type: a require_approval action asking for zero approvals is a
+		// self-dismissable warning; a positive count is the blocking mode.
+		if enforcement == nil && en {
+			if warnMode(spec) {
+				enforcement = "warn"
+			} else if hasRequireApproval(spec) {
+				enforcement = "blocking"
+			}
+		}
+		if en && bypassActorBroad(spec) {
+			bypassBroad = true
+		}
+	}
+	return map[string]any{
+		"enabled":               enabled,
+		"fallback_behavior":     fallback,
+		"named_scanner_absent":  namedScannerAbsent(prior, fp, scanners),
+		"enforcement_type":      enforcement,
+		"binds_trusted_target":  false,
+		"scope_excludes_target": false,
+		"scanners":              scanners,
+		"bypass_settings":       nil,
+		"scope_broad":           false,
+		"bypass_actor_broad":    bypassBroad,
+	}
+}
+
+// namedScannerAbsent reports whether any scanner the approval policy names has no
+// corresponding job/include in the target project's resolved .gitlab-ci.yml, so the
+// scan_finding rule can never evaluate (cat-06/09, doc line 303). With no named
+// scanners there is nothing that can be absent. A scanner is present when a pipeline
+// job name matches it, a GitLab security template include names it, or Auto DevOps
+// (which wires the full scanner suite) is on.
+func namedScannerAbsent(prior engine.PriorPhase, fp string, scanners []any) bool {
+	if len(scanners) == 0 {
+		return false
+	}
+	present := pipelineScannersPresent(prior, fp)
+	for _, raw := range scanners {
+		name := strings.ToLower(entStr(raw))
+		if name != "" && !present[name] {
+			return true
+		}
+	}
+	return false
+}
+
+// scannerTemplateFrag maps a GitLab scanner id to the distinctive fragment of the
+// managed CI template that wires it (matched case-insensitively against include:
+// template: strings and job names).
+var scannerTemplateFrag = map[string]string{
+	"sast":                   "sast",
+	"secret_detection":       "secret-detection",
+	"dependency_scanning":    "dependency-scanning",
+	"container_scanning":     "container-scanning",
+	"dast":                   "dast",
+	"coverage_fuzzing":       "coverage-fuzzing",
+	"api_fuzzing":            "api-fuzzing",
+	"cluster_image_scanning": "cluster-image-scanning",
+}
+
+func pipelineScannersPresent(prior engine.PriorPhase, fp string) map[string]bool {
+	present := map[string]bool{}
+	raw := entLoadRaw(prior, engine.CollectGLCIConfig(fp, ".gitlab-ci.yml"))
+	pipeline, err := parseCIPipeline(raw)
+	if err != nil || pipeline == nil {
+		return present
+	}
+	detail := entLoadData(prior, engine.CollectGLProject(fp))
+	autoDevOps := detail != nil && entBool(detail["auto_devops_enabled"])
+
+	jobs := map[string]bool{}
+	for _, n := range jobNames(pipeline) {
+		jobs[strings.ToLower(n)] = true
+	}
+	templates := includeTemplateStrings(pipeline["include"])
+	for scanner, frag := range scannerTemplateFrag {
+		if autoDevOps || jobs[scanner] {
+			present[scanner] = true
+			continue
+		}
+		for _, t := range templates {
+			if strings.Contains(t, frag) {
+				present[scanner] = true
+				break
+			}
+		}
+	}
+	return present
+}
+
+func includeTemplateStrings(node any) []string {
+	var out []string
+	for _, entry := range includeEntries(node) {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, k := range []string{"template", "local", "remote"} {
+			if s, ok := m[k].(string); ok {
+				out = append(out, strings.ToLower(s))
+			}
+		}
+	}
+	return out
+}
+
+func parsePolicyYAML(y string) map[string]any {
+	if y == "" {
+		return nil
+	}
+	var spec map[string]any
+	if yamlUnmarshal([]byte(y), &spec) != nil {
+		return nil
+	}
+	return spec
+}
+
+func policyScanners(spec map[string]any) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, raw := range entListOrEmpty(spec["rules"]) {
+		for _, s := range entListOrEmpty(entMap(raw)["scanners"]) {
+			if name := entStr(s); name != "" && !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
+func warnMode(spec map[string]any) bool {
+	for _, raw := range entListOrEmpty(spec["actions"]) {
+		a := entMap(raw)
+		if entStr(a["type"]) == "require_approval" {
+			if _, ok := a["approvals_required"]; ok && entInt64(a["approvals_required"]) == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasRequireApproval(spec map[string]any) bool {
+	for _, raw := range entListOrEmpty(spec["actions"]) {
+		if entStr(entMap(raw)["type"]) == "require_approval" {
+			return true
+		}
+	}
+	return false
+}
+
+// bypassActorBroad reports whether bypass_settings exempts a broadly-held actor
+// (a group, a service account/token, or a branch pattern) rather than naming a
+// single break-glass identity.
+func bypassActorBroad(spec map[string]any) bool {
+	bs := entMap(spec["bypass_settings"])
+	if bs == nil {
+		return false
+	}
+	for _, k := range []string{"groups", "service_accounts", "access_tokens", "branches", "roles"} {
+		if len(entListOrEmpty(bs[k])) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func approverSetBroad(rules []any) bool {
+	for _, raw := range rules {
+		r := entMap(raw)
+		if len(entListOrEmpty(r["groups"])) > 0 || entBool(r["applies_to_all_protected_branches"]) {
+			return true
+		}
+	}
+	return false
+}
+
+func independentApprovers(rules []any, members []any) int64 {
+	var maxSet int64
+	for _, raw := range rules {
+		r := entMap(raw)
+		if n := int64(len(entListOrEmpty(r["eligible_approvers"]))); n > maxSet {
+			maxSet = n
+		}
+	}
+	return maxSet
+}
+
+// ---- environment ----
+
+func normalizeEnvironments(prior engine.PriorPhase, cp engine.CurrentPhase, p projectMeta, timer *engine.PhaseTimer) error {
+	fp := p.FullPath
+	envs := entLoadList(prior, engine.CollectGLEnvironments(fp))
+	protEnvs := entLoadList(prior, engine.CollectGLProjectProtectedEnvironments(fp))
+	groupProtEnvs := groupProtectedTiers(prior, p)
+	protByName := map[string]map[string]any{}
+	protNames := []string{}
+	for _, raw := range protEnvs {
+		pe := entMap(raw)
+		name := entStr(pe["name"])
+		protByName[name] = pe
+		protNames = append(protNames, name)
+	}
+	for _, raw := range envs {
+		e := entMap(raw)
+		name := entStr(e["name"])
+		if name == "" {
+			continue
+		}
+		pe := protByName[name]
+		tier := entStr(e["tier"])
+		rules := envApprovalRules(pe)
+		rec := map[string]any{
+			"_id":                       fp + "/" + name,
+			"name":                      name,
+			"tier":                      tier,
+			"protected":                 pe != nil,
+			"self_declared_scope":       pe == nil && tier != "",
+			"deploy_approvals_required": entInt64(pe["required_approval_count"]),
+			"approval_rules":            rules,
+			"allow_pipeline_trigger_approve_deployment": entBool(pe["allow_pipeline_trigger_approve_deployment"]),
+			"carries_deploy_context":                    tier == "production" || tier == "staging",
+			"near_miss_protected_name":                  nearMissProtected(name, protNames),
+			"group_tier_protection_escaped":             tierEscaped(tier, groupProtEnvs, pe),
+			"approval_rule_bot_approver":                anyRule(rules, func(r map[string]any) bool { return mBool(r, "is_bot") }),
+			"_provenance":                               prov(engine.CollectGLEnvironments(fp)),
+		}
+		if err := emit(cp, timer, engine.NormalizeGLEnvironment(fp, name), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func envApprovalRules(pe map[string]any) []any {
+	out := []any{}
+	for _, raw := range entListOrEmpty(pe["approval_rules"]) {
+		r := entMap(raw)
+		out = append(out, map[string]any{
+			"access_level":          entInt64(r["access_level"]),
+			"is_bot":                entBool(entMap(r["user"])["bot"]) || entBool(r["is_bot"]),
+			"self_approval_allowed": false,
+		})
+	}
+	return out
+}
+
+func groupProtectedTiers(prior engine.PriorPhase, p projectMeta) []string {
+	out := []string{}
+	group := parentGroup(p.FullPath)
+	if group == "" {
+		return out
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLGroupProtectedEnvironments(group)) {
+		if name := entStr(entMap(raw)["name"]); name != "" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func nearMissProtected(name string, protNames []string) bool {
+	for _, pn := range protNames {
+		if pn == name {
+			return false
+		}
+	}
+	lname := strings.ToLower(name)
+	aliases := map[string]string{"prod": "production", "production": "prod", "stg": "staging", "staging": "stg"}
+	for _, pn := range protNames {
+		lpn := strings.ToLower(pn)
+		if lpn == lname || strings.HasPrefix(lname, lpn+"/") || strings.HasPrefix(lpn, lname+"/") {
+			return true
+		}
+		if aliases[lname] == lpn || aliases[lpn] == lname {
+			return true
+		}
+	}
+	return false
+}
+
+func tierEscaped(tier string, groupTiers []string, pe map[string]any) bool {
+	if len(groupTiers) == 0 || pe != nil {
+		return false
+	}
+	for _, gt := range groupTiers {
+		if gt == tier {
+			return false
+		}
+	}
+	return true
+}
+
+// ---- runner ----
+
+// normalizeRunners emits one record per distinct runner across project, group,
+// and instance scope, deduplicated by id.
+func normalizeRunners(prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
+	settings := entLoadData(prior, engine.CollectGLInstanceSettings())
+	reusable := !entUnobserved(settings) && settings != nil && entBool(settings["allow_runner_registration_token"])
+
+	seen := map[int64]bool{}
+	emitOne := func(raw any, scope string) error {
+		r := entMap(raw)
+		id := entInt64(r["id"])
+		if id == 0 || seen[id] {
+			return nil
+		}
+		seen[id] = true
+		coResident := entLoadList(prior, engine.CollectGLRunnerProjects(id))
+		rec := runnerRecord(r, scope, coResident, reusable)
+		runnerReachFolds(prior, rec, coResident, scope, projs)
+		return emit(cp, timer, engine.NormalizeGLRunner(id), rec)
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLInstanceRunners()) {
+		if err := emitOne(raw, "instance"); err != nil {
+			return err
+		}
+	}
+	for _, g := range groupRoster(prior, org) {
+		for _, raw := range entLoadList(prior, engine.CollectGLGroupRunners(g)) {
+			if err := emitOne(raw, "group:"+g); err != nil {
+				return err
+			}
+		}
+	}
+	for _, p := range projs {
+		for _, raw := range entLoadList(prior, engine.CollectGLProjectRunners(p.FullPath)) {
+			if err := emitOne(raw, "project:"+p.FullPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func runnerRecord(r map[string]any, scope string, coResident []any, reusable bool) map[string]any {
+	projects := []any{}
+	for _, raw := range coResident {
+		if fp := entStr(entMap(raw)["path_with_namespace"]); fp != "" {
+			projects = append(projects, fp)
+		}
+	}
+	return map[string]any{
+		"_id":                            runnerID(r),
+		"runner_type":                    entStr(r["runner_type"]),
+		"is_shared":                      entBool(r["is_shared"]),
+		"ref_protected":                  entStr(r["access_level"]) == "ref_protected",
+		"run_untagged":                   entBool(r["run_untagged"]),
+		"locked":                         entBool(r["locked"]),
+		"tags":                           sortedStrSet(entListOrEmpty(r["tag_list"])),
+		"projects":                       projects,
+		"registration_token_reusable":    reusable,
+		"self_managed":                   classifySelfManaged(r),
+		"spans_trust_boundary":           false,
+		"serves_protected_ref_only_jobs": false,
+		"serves_untrusted_ref_jobs":      false,
+		"untrusted_ref_job_matches_tags": false,
+		"bridges_trust_boundary":         len(projects) >= 2,
+		"_provenance":                    []provenance{{"scope": scope}},
+	}
+}
+
+func runnerID(r map[string]any) string { return fmt.Sprintf("%d", entInt64(r["id"])) }
+
+// runnerReachFolds computes the cat-08 runner effective folds (normalizer-computed
+// per the field contract) from the runner's reachable projects and the jobs those
+// projects target the runner with:
+//   - spans_trust_boundary: reachable projects straddle a trust boundary (≥1 holds
+//     protected resources AND ≥1 is a broad/low-trust project).
+//   - serves_protected_ref_only_jobs / serves_untrusted_ref_jobs: the runner is
+//     targeted (by matching tags / run_untagged) by protected-ref-only jobs and/or
+//     untrusted-ref jobs — both true means trusted and untrusted workloads share it.
+//   - untrusted_ref_job_matches_tags: an untrusted-ref job on an attacker-writable
+//     ref carries tags: matching this runner (can be steered onto it).
+//
+// Reachable projects are the co-resident list from /runners/:id/projects; an
+// instance/group runner with an empty list falls back to the roster projects in
+// its scope.
+func runnerReachFolds(prior engine.PriorPhase, rec map[string]any, coResident []any, scope string, projs []projectMeta) {
+	reach := runnerReachProjects(coResident, scope, projs)
+	tags := strListOf(listOrEmptyGL(rec, "tags"))
+	runUntagged := mBool(rec, "run_untagged")
+
+	holdsProtected, lowTrust := false, false
+	servesProtectedOnly, servesUntrusted, untrustedMatchesTags := false, false, false
+	for _, proj := range reach {
+		vars := entLoadList(prior, engine.CollectGLProjectVariables(proj))
+		branches := normalizeProtectedBranches(entLoadList(prior, engine.CollectGLProtectedBranches(proj)))
+		protEnvs := entLoadList(prior, engine.CollectGLProjectProtectedEnvironments(proj))
+		if anyVar(normalizeVariables(vars, "project"), func(v map[string]any) bool { return mBool(v, "protected") }) || len(protEnvs) > 0 {
+			holdsProtected = true
+		}
+		if developerPushableUnprotectedRef(branches) {
+			lowTrust = true
+		}
+		ciWritable := sourceCIWritableForRunner(branches)
+		forEachJobRef(prior, proj, func(gate string, untrusted bool, jobTags []any) {
+			if !runnerTargetedBy(tags, runUntagged, jobTags) {
+				return
+			}
+			if untrusted {
+				servesUntrusted = true
+				if ciWritable {
+					untrustedMatchesTags = true
+				}
+			} else if gate != "none" {
+				servesProtectedOnly = true
+			}
+		})
+	}
+	rec["spans_trust_boundary"] = holdsProtected && lowTrust
+	rec["serves_protected_ref_only_jobs"] = servesProtectedOnly
+	rec["serves_untrusted_ref_jobs"] = servesUntrusted
+	rec["untrusted_ref_job_matches_tags"] = untrustedMatchesTags
+}
+
+func runnerReachProjects(coResident []any, scope string, projs []projectMeta) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, raw := range coResident {
+		if fp := entStr(entMap(raw)["path_with_namespace"]); fp != "" && !seen[fp] {
+			seen[fp] = true
+			out = append(out, fp)
+		}
+	}
+	if len(out) > 0 {
+		return out
+	}
+	// Instance/group runner with no co-resident list: fall back to the roster
+	// projects in scope (all roster for instance, subtree for group:<path>).
+	prefix := strings.TrimPrefix(scope, "group:")
+	for _, p := range projs {
+		if scope == "instance" || strings.HasPrefix(scope, "instance") ||
+			p.FullPath == prefix || strings.HasPrefix(p.FullPath, prefix+"/") {
+			out = append(out, p.FullPath)
+		}
+	}
+	return out
+}
+
+// runnerTargetedBy reports whether a job with jobTags can land on a runner with
+// runnerTags: an untagged job needs run_untagged; a tagged job needs the runner to
+// carry every tag it requests.
+func runnerTargetedBy(runnerTags []string, runUntagged bool, jobTags []any) bool {
+	jt := strListOf(jobTags)
+	if len(jt) == 0 {
+		return runUntagged
+	}
+	have := map[string]bool{}
+	for _, t := range runnerTags {
+		have[t] = true
+	}
+	for _, t := range jt {
+		if !have[t] {
+			return false
+		}
+	}
+	return true
+}
+
+// forEachJobRef parses a project's entrypoint and yields each job's protected-ref
+// gate, untrusted-ref reachability, and tags. Parse failures are skipped (the
+// runner folds degrade to false for that project, not an abort).
+func forEachJobRef(prior engine.PriorPhase, proj string, fn func(gate string, untrusted bool, jobTags []any)) {
+	raw := entLoadRaw(prior, engine.CollectGLCIConfig(proj, ".gitlab-ci.yml"))
+	if raw == nil {
+		return
+	}
+	pipeline, err := parseCIPipeline(raw)
+	if err != nil || pipeline == nil {
+		return
+	}
+	workflow := entMap(pipeline["workflow"])
+	def := entMap(pipeline["default"])
+	for _, name := range jobNames(pipeline) {
+		job := mergeDefault(entMap(pipeline[name]), def)
+		gate := protectedRefGate(job, workflow)
+		untrusted := runsOnUntrustedRef(resolveTriggers(job, workflow), gate)
+		fn(gate, untrusted, runnerTags(job))
+	}
+}
+
+// sourceCIWritableForRunner reports the project's CI config / refs are writable by
+// a lower-trust member (no protection, or a Developer-writable protected branch).
+func sourceCIWritableForRunner(branches []map[string]any) bool {
+	return developerPushableUnprotectedRef(branches) || anyBranch(branches, func(b map[string]any) bool {
+		return grantsDeveloper(mList(b, "push_access_levels")) || grantsDeveloper(mList(b, "merge_access_levels"))
+	})
+}
+
+// classifySelfManaged is the load-bearing self_managed classifier. GitLab.com
+// shared SaaS runners carry a saas platform / gitlab-hosted description; anything
+// else (operator-run) is self-managed.
+func classifySelfManaged(r map[string]any) bool {
+	desc := strings.ToLower(entStr(r["description"]))
+	platform := strings.ToLower(entStr(r["platform"]))
+	if strings.Contains(desc, "saas") || strings.Contains(desc, "gitlab-hosted") ||
+		strings.Contains(desc, "shared") && strings.Contains(desc, "gitlab.com") {
+		return false
+	}
+	if platform == "" && entStr(r["runner_type"]) == "instance_type" && entBool(r["is_shared"]) && desc == "" {
+		return false
+	}
+	return true
+}
+
+// reachableRunners returns project-scope runner records (project runners plus
+// inherited group/instance). Used only for project derived booleans; the full
+// runner subject records are emitted by normalizeRunners.
+func reachableRunners(prior engine.PriorPhase, fp string) []map[string]any {
+	out := []map[string]any{}
+	for _, raw := range entLoadList(prior, engine.CollectGLProjectRunners(fp)) {
+		r := entMap(raw)
+		out = append(out, map[string]any{
+			"self_managed":  classifySelfManaged(r),
+			"ref_protected": entStr(r["access_level"]) == "ref_protected",
+			"runner_type":   entStr(r["runner_type"]),
+		})
+	}
+	return out
+}
+
+func reachableRunnerList(runners []any) []map[string]any {
+	out := []map[string]any{}
+	for _, raw := range runners {
+		r := entMap(raw)
+		out = append(out, map[string]any{
+			"self_managed":  classifySelfManaged(r),
+			"ref_protected": entStr(r["access_level"]) == "ref_protected",
+			"runner_type":   entStr(r["runner_type"]),
+		})
+	}
+	return out
+}
+
+// ---- agent ----
+
+func normalizeAgents(prior engine.PriorPhase, cp engine.CurrentPhase, p projectMeta, projs []projectMeta, timer *engine.PhaseTimer) error {
+	fp := p.FullPath
+	data := entLoadData(prior, engine.CollectGLClusterAgents(fp))
+	if data == nil || entUnobserved(data) {
+		return nil
+	}
+	nodes := entList(entGetIn(data, "project", "clusterAgents", "nodes"))
+	settings := entLoadData(prior, engine.CollectGLInstanceSettings())
+	instAgentAuth := !entUnobserved(settings) && settings != nil && entBool(settings["instance_level_ai_beta_features_enabled"])
+	for _, raw := range nodes {
+		node := entMap(raw)
+		name := entStr(node["name"])
+		if name == "" {
+			continue
+		}
+		cfg := parseAgentConfig(entLoadRaw(prior, engine.CollectGLAgentConfig(fp, name)))
+		targets, scope := agentTargets(node)
+		envFilter := entListOrEmpty(cfg["environments"])
+		protOnly := entBool(cfg["protected_branches_only"])
+		// The grant's reachable target projects: explicit ci_access targets
+		// (projects, or every project under a group target), else the config
+		// project itself when the grant is implicit.
+		reach := agentReachProjects(targets, fp, projs)
+		folds := agentGrantFolds(prior, reach, envFilter, protOnly)
+		rec := map[string]any{
+			"_id":                                         fp + "/" + name,
+			"config_path":                                 ".gitlab/agents/" + name + "/config.yaml",
+			"ci_access_scope":                             scope,
+			"ci_access_targets":                           targets,
+			"implicit_config_project":                     len(targets) == 0,
+			"protected_branches_only":                     protOnly,
+			"environments_filter":                         envFilter,
+			"impersonation":                               agentImpersonation(cfg),
+			"default_permissions":                         agentDefaultPermissions(cfg),
+			"environments_filter_wildcard":                anyStr(envFilter, func(s string) bool { return strings.Contains(s, "*") }),
+			"namespace_plan":                              namespacePlan(prior, fp),
+			"instance_agent_authorization_enabled":        instAgentAuth,
+			"grant_has_lower_trust_developer":             folds.lowerTrustDeveloper,
+			"grant_developer_pushable_unprotected_branch": folds.developerPushableUnprotected,
+			"config_project_developer_reachable":          len(targets) == 0 && folds.developerReachable,
+			"environments_filter_unprotected":             folds.envFilterUnprotected,
+			"grant_developer_authors_matching_env_job":    folds.developerAuthorsMatchingEnvJob,
+			"grant_protected_ref_developer_writable":      folds.protectedRefDeveloperWritable,
+			"_provenance":                                 prov(engine.CollectGLClusterAgents(fp)),
+		}
+		if err := emit(cp, timer, engine.NormalizeGLAgent(fp, name), rec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// agentImpersonation returns the access_as impersonation config, or NIL when no
+// access_as is configured (cat-15: rules read impersonation == null; an empty
+// {} would never match that predicate).
+func agentImpersonation(cfg map[string]any) any {
+	m := entMap(cfg["access_as"])
+	if len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// agentReachProjects resolves the project paths a ci_access grant authorizes:
+// each explicit project target, every roster project under a group target, or
+// the agent's own config project when the grant is implicit.
+func agentReachProjects(targets []any, configProject string, projs []projectMeta) []string {
+	if len(targets) == 0 {
+		return []string{configProject}
+	}
+	var out []string
+	seen := map[string]bool{}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	rosterHas := map[string]bool{}
+	for _, p := range projs {
+		rosterHas[p.FullPath] = true
+	}
+	for _, raw := range targets {
+		t := entStr(raw)
+		if rosterHas[t] {
+			add(t)
+			continue
+		}
+		// Group target: every roster project inside the group subtree.
+		for _, p := range projs {
+			if p.FullPath == t || strings.HasPrefix(p.FullPath, t+"/") {
+				add(p.FullPath)
+			}
+		}
+	}
+	return out
+}
+
+type agentFolds struct {
+	lowerTrustDeveloper            bool
+	developerPushableUnprotected   bool
+	developerReachable             bool
+	envFilterUnprotected           bool
+	developerAuthorsMatchingEnvJob bool
+	protectedRefDeveloperWritable  bool
+}
+
+// agentGrantFolds computes the cat-15 agent-ci-access effective folds from each
+// reachable target project's collected membership, protected-branch/tag, and
+// protected-environment data. These are the correlation the DSL cannot express
+// (agent grant → per-target membership + ref/env protection).
+func agentGrantFolds(prior engine.PriorPhase, reach []string, envFilter []any, protectedBranchesOnly bool) agentFolds {
+	var f agentFolds
+	for _, tgt := range reach {
+		members := entLoadList(prior, engine.CollectGLProjectMembers(tgt))
+		branches := normalizeProtectedBranches(entLoadList(prior, engine.CollectGLProtectedBranches(tgt)))
+		tags := normalizeProtectedTags(entLoadList(prior, engine.CollectGLProtectedTags(tgt)))
+		protEnvs := entLoadList(prior, engine.CollectGLProjectProtectedEnvironments(tgt))
+
+		hasDeveloper := hasMemberAtLevel(members, accessDeveloper)
+		if hasDeveloper {
+			f.lowerTrustDeveloper = true
+			f.developerReachable = true
+		}
+		devPushUnprot := developerPushableUnprotectedRef(branches)
+		if hasDeveloper && devPushUnprot {
+			f.developerPushableUnprotected = true
+			f.developerReachable = true
+		}
+		// A protected ref a Developer can land on satisfies protected_branches_only:
+		// a Developer-writable protected branch, a Developer-creatable wildcard
+		// branch, or a Developer-creatable protected tag.
+		if hasDeveloper && (anyBranch(branches, func(b map[string]any) bool {
+			return grantsDeveloper(mList(b, "push_access_levels")) || grantsDeveloper(mList(b, "merge_access_levels"))
+		}) || anyTag(tags, func(t map[string]any) bool {
+			return grantsDeveloper(mList(t, "create_access_levels"))
+		})) {
+			f.protectedRefDeveloperWritable = true
+		}
+		// A fixed (non-wildcard) filter name absent from the target's protected
+		// environments (or protected with a Developer-inclusive deployer) gates
+		// nothing.
+		if agentEnvFilterUnprotected(envFilter, protEnvs) {
+			f.envFilterUnprotected = true
+		}
+		// A Developer can author a job binding environment: to a filter-matching
+		// value while running on a ref they can reach: unprotected when the grant
+		// is not protected_branches_only, else a Developer-landable protected ref.
+		if hasDeveloper && len(envFilter) > 0 {
+			refReachable := devPushUnprot
+			if protectedBranchesOnly {
+				refReachable = f.protectedRefDeveloperWritable
+			}
+			if refReachable {
+				f.developerAuthorsMatchingEnvJob = true
+			}
+		}
+	}
+	return f
+}
+
+// agentEnvFilterUnprotected: at least one fixed (non-wildcard) filter name is not
+// covered by an exact protected-environment entry, or is protected only with a
+// Developer-inclusive deployer list, so the name is not a real boundary.
+func agentEnvFilterUnprotected(envFilter []any, protEnvs []any) bool {
+	prot := map[string]map[string]any{}
+	for _, raw := range protEnvs {
+		pe := entMap(raw)
+		prot[entStr(pe["name"])] = pe
+	}
+	for _, raw := range envFilter {
+		name := entStr(raw)
+		if name == "" || strings.Contains(name, "*") {
+			continue
+		}
+		pe, ok := prot[name]
+		if !ok {
+			return true
+		}
+		for _, r := range entListOrEmpty(pe["deploy_access_levels"]) {
+			if entInt64(entMap(r)["access_level"]) <= accessDeveloper && entInt64(entMap(r)["access_level"]) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func agentTargets(node map[string]any) ([]any, string) {
+	targets := []any{}
+	for _, raw := range entList(entGetIn(node, "ciAccessAuthorizedProjects", "nodes")) {
+		if fp := entStr(entMap(raw)["fullPath"]); fp != "" {
+			targets = append(targets, fp)
+		}
+	}
+	groups := entList(entGetIn(node, "ciAccessAuthorizedGroups", "nodes"))
+	for _, raw := range groups {
+		if fp := entStr(entMap(raw)["fullPath"]); fp != "" {
+			targets = append(targets, fp)
+		}
+	}
+	scope := "project"
+	if len(groups) > 0 {
+		scope = "group"
+	}
+	return targets, scope
+}
+
+func parseAgentConfig(raw []byte) map[string]any {
+	if raw == nil {
+		return map[string]any{}
+	}
+	var cfg map[string]any
+	if yamlUnmarshal(raw, &cfg) != nil {
+		return map[string]any{}
+	}
+	ci := entMap(cfg["ci_access"])
+	// ci_access holds project/group entries whose shared shape carries
+	// environments/protected_branches_only/default_namespace access_as.
+	out := map[string]any{}
+	if pb, ok := firstAccessField(ci, "protected_branches_only"); ok {
+		out["protected_branches_only"] = pb
+	}
+	if envs, ok := firstAccessListField(ci, "environments"); ok {
+		out["environments"] = envs
+	}
+	if aa, ok := firstAccessField(ci, "access_as"); ok {
+		out["access_as"] = aa
+	}
+	if dp, ok := firstAccessField(ci, "default_namespace"); ok {
+		out["default_permissions"] = dp
+	}
+	return out
+}
+
+func firstAccessField(ci map[string]any, key string) (any, bool) {
+	for _, scope := range []string{"projects", "groups"} {
+		for _, raw := range entList(ci[scope]) {
+			if v, ok := entMap(raw)[key]; ok {
+				return v, true
+			}
+		}
+	}
+	if v, ok := ci[key]; ok {
+		return v, true
+	}
+	return nil, false
+}
+
+func firstAccessListField(ci map[string]any, key string) ([]any, bool) {
+	v, ok := firstAccessField(ci, key)
+	if !ok {
+		return nil, false
+	}
+	return entListOrEmpty(v), true
+}
+
+func agentDefaultPermissions(cfg map[string]any) bool {
+	if _, ok := cfg["access_as"]; ok {
+		return false
+	}
+	return true
+}
+
+func namespacePlan(prior engine.PriorPhase, fp string) any {
+	group := parentGroup(fp)
+	if group == "" {
+		return nil
+	}
+	ns := entLoadData(prior, engine.CollectGLNamespace(group))
+	if ns == nil || entUnobserved(ns) {
+		return nil
+	}
+	return entStr(ns["plan"])
+}
+
+// ---- credential ----
+
+func normalizeCredentials(prior engine.PriorPhase, cp engine.CurrentPhase, p projectMeta, timer *engine.PhaseTimer) error {
+	fp := p.FullPath
+	settings := entLoadData(prior, engine.CollectGLInstanceSettings())
+	expEnforced := !entUnobserved(settings) && settings != nil && entBool(settings["service_access_tokens_expiration_enforced"])
+	usesOIDC := ciYAMLHasDeployIdentity(entLoadRaw(prior, engine.CollectGLCIConfig(fp, ".gitlab-ci.yml")))
+
+	emitCred := func(kind, key string, rec map[string]any) error {
+		rec["_id"] = kind + ":" + key
+		rec["kind"] = kind
+		rec["project_uses_oidc"] = usesOIDC
+		rec["_provenance"] = []provenance{{"scope": "project:" + fp}}
+		return emit(cp, timer, engine.NormalizeGLCredential(kind, kind+"-"+key), rec)
+	}
+
+	for _, raw := range entLoadList(prior, engine.CollectGLProjectDeployTokens(fp)) {
+		t := entMap(raw)
+		if err := emitCred("deploy_token", credKey(fp, "dt", t["id"]), deployTokenRec(t, "project", expEnforced)); err != nil {
+			return err
+		}
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLGroupDeployTokens(parentGroup(fp))) {
+		t := entMap(raw)
+		if err := emitCred("deploy_token", credKey(parentGroup(fp), "gdt", t["id"]), deployTokenRec(t, "group", expEnforced)); err != nil {
+			return err
+		}
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLProjectAccessTokens(fp)) {
+		t := entMap(raw)
+		if err := emitCred("project_access_token", credKey(fp, "pat", t["id"]), accessTokenRec(t, "project", expEnforced)); err != nil {
+			return err
+		}
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLGroupAccessTokens(parentGroup(fp))) {
+		t := entMap(raw)
+		if err := emitCred("group_access_token", credKey(parentGroup(fp), "gat", t["id"]), accessTokenRec(t, "group", expEnforced)); err != nil {
+			return err
+		}
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLDeployKeys(fp)) {
+		k := entMap(raw)
+		if err := emitCred("deploy_key", credKey(fp, "dk", k["id"]), deployKeyRec(k)); err != nil {
+			return err
+		}
+	}
+	// static_cloud_cred (cat-11): P2 collects variable KEYS (values stripped), so a
+	// cloud-cred-shaped variable key is a collected source for a static cloud
+	// credential. The credential IS the variable, so in_unprotected_variable is
+	// directly derivable (the variable's own protected flag). PATs have no P2
+	// collect source and are a documented known-gap — not fabricated here.
+	for i, raw := range entLoadList(prior, engine.CollectGLProjectVariables(fp)) {
+		v := entMap(raw)
+		key := entStr(v["key"])
+		if !cloudCredKey(key) {
+			continue
+		}
+		if err := emitCred("static_cloud_cred", credKey(fp, "scc", int64(i)), staticCloudCredRec(v, "project")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// staticCloudCredRec builds a static_cloud_cred credential from a cloud-cred-shaped
+// CI/CD variable. The credential's reachability via the variable is not a deferred
+// leg here (the variable IS the credential), so in_unprotected_variable is the
+// variable's own protected flag.
+func staticCloudCredRec(v map[string]any, scopeLevel string) map[string]any {
+	unprotected := !entBool(v["protected"])
+	return map[string]any{
+		"scopes":                              []any{},
+		"access_level":                        nil,
+		"non_expiring":                        true,
+		"revoked":                             false,
+		"auto_injected":                       false,
+		"name":                                entStr(v["key"]),
+		"scope_level":                         scopeLevel,
+		"service_account":                     false,
+		"long_lived":                          true,
+		"can_push":                            false,
+		"in_unprotected_variable":             unprotected,
+		"key_pattern":                         "cloud",
+		"deploy_key_fingerprint":              nil,
+		"backing_identity_breadth":            []any{},
+		"is_schedule_owner":                   false,
+		"creator_has_target_protected_access": false,
+	}
+}
+
+var cloudCredFrags = []string{
+	"AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "AWS_SESSION_TOKEN",
+	"AZURE_CLIENT_SECRET", "AZURE_CLIENT_ID", "ARM_CLIENT_SECRET",
+	"GCP_SA_KEY", "GCP_SERVICE_ACCOUNT", "GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CREDENTIALS",
+	"DIGITALOCEAN_ACCESS_TOKEN", "DO_TOKEN", "ALIYUN_ACCESS_KEY",
+}
+
+// cloudCredKey matches a variable key that names a static cloud credential (a
+// long-lived cloud key), narrower than the generic secret heuristic.
+func cloudCredKey(key string) bool {
+	u := strings.ToUpper(key)
+	for _, frag := range cloudCredFrags {
+		if strings.Contains(u, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+func credKey(scope, kind string, id any) string {
+	return fmt.Sprintf("%s-%s-%d", glSlug(scope), kind, entInt64(id))
+}
+
+func glSlug(s string) string { return strings.ReplaceAll(s, "/", "-") }
+
+func deployTokenRec(t map[string]any, scopeLevel string, expEnforced bool) map[string]any {
+	name := entStr(t["name"])
+	return map[string]any{
+		"scopes":                              sortedStrSet(entListOrEmpty(t["scopes"])),
+		"access_level":                        nil,
+		"non_expiring":                        t["expires_at"] == nil,
+		"revoked":                             entBool(t["revoked"]) || entBool(t["expired"]),
+		"auto_injected":                       name == "gitlab-deploy-token",
+		"name":                                name,
+		"scope_level":                         scopeLevel,
+		"service_account":                     false,
+		"long_lived":                          longLived(t["expires_at"], expEnforced),
+		"can_push":                            tokenHasScope(t, "write_repository"),
+		"in_unprotected_variable":             false,
+		"key_pattern":                         nil,
+		"deploy_key_fingerprint":              nil,
+		"backing_identity_breadth":            []any{},
+		"is_schedule_owner":                   false,
+		"creator_has_target_protected_access": false,
+	}
+}
+
+func accessTokenRec(t map[string]any, scopeLevel string, expEnforced bool) map[string]any {
+	return map[string]any{
+		"scopes":                              sortedStrSet(entListOrEmpty(t["scopes"])),
+		"access_level":                        entInt64(t["access_level"]),
+		"non_expiring":                        t["expires_at"] == nil,
+		"revoked":                             entBool(t["revoked"]) || !boolDefaultTrue(t["active"]),
+		"auto_injected":                       false,
+		"name":                                entStr(t["name"]),
+		"scope_level":                         scopeLevel,
+		"service_account":                     false,
+		"long_lived":                          longLived(t["expires_at"], expEnforced),
+		"can_push":                            tokenHasScope(t, "write_repository") || tokenHasScope(t, "api"),
+		"in_unprotected_variable":             false,
+		"key_pattern":                         nil,
+		"deploy_key_fingerprint":              nil,
+		"backing_identity_breadth":            accessTokenBreadth(t),
+		"is_schedule_owner":                   false,
+		"creator_has_target_protected_access": false,
+	}
+}
+
+func deployKeyRec(k map[string]any) map[string]any {
+	return map[string]any{
+		"scopes":                              []any{},
+		"access_level":                        nil,
+		"non_expiring":                        k["expires_at"] == nil,
+		"revoked":                             false,
+		"auto_injected":                       false,
+		"name":                                entStr(k["title"]),
+		"scope_level":                         "project",
+		"service_account":                     false,
+		"long_lived":                          k["expires_at"] == nil,
+		"can_push":                            entBool(k["can_push"]),
+		"deploy_key_fingerprint":              firstNonEmpty(entStr(k["fingerprint_sha256"]), entStr(k["fingerprint"])),
+		"key_pattern":                         nil,
+		"in_unprotected_variable":             false,
+		"backing_identity_breadth":            []any{},
+		"is_schedule_owner":                   false,
+		"creator_has_target_protected_access": false,
+	}
+}
+
+func accessTokenBreadth(t map[string]any) []any {
+	// user-memberships is collected per backing user id; absent → [] (C1).
+	return []any{}
+}
+
+func tokenHasScope(t map[string]any, scope string) bool {
+	for _, s := range entListOrEmpty(t["scopes"]) {
+		if entStr(s) == scope {
+			return true
+		}
+	}
+	return false
+}
+
+func boolDefaultTrue(v any) bool {
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return true
+}
+
+// longLived: expires_at null OR ≥ ~330 days out (covers legacy non-expiring and
+// the ~1-year default). Dates are ISO8601 (YYYY-MM-DD or full timestamp).
+func longLived(expiresAt any, expEnforced bool) bool {
+	s := entStr(expiresAt)
+	if s == "" {
+		return true
+	}
+	exp := parseDatePrefix(s)
+	if exp.IsZero() {
+		return false
+	}
+	return exp.Sub(nowUTC()).Hours() >= 330*24
+}
+
+// ---- integration ----
+
+func normalizeIntegrations(prior engine.PriorPhase, cp engine.CurrentPhase, p projectMeta, timer *engine.PhaseTimer) error {
+	fp := p.FullPath
+	detail := entLoadData(prior, engine.CollectGLProject(fp))
+	settings := entLoadData(prior, engine.CollectGLInstanceSettings())
+	allowLocal := !entUnobserved(settings) && settings != nil && entBool(settings["allow_local_requests_from_web_hooks_and_services"])
+
+	// A Maintainer can edit a project hook/integration's delivery URL but sits below
+	// the Owner-trust of whoever set the write-only credential (doc line 418). Its
+	// presence, ANDed per-record with an attached write credential, is the
+	// editor_below_credential_trust fold the cat-14 recapture rules read.
+	hasEditorBelowTrust := hasMemberAtLevel(entLoadList(prior, engine.CollectGLProjectMembers(fp)), accessMaintainer)
+
+	emitInt := func(kind, key string, rec map[string]any) error {
+		rec["_id"] = fp + "/" + kind + ":" + key
+		rec["kind"] = kind
+		rec["_provenance"] = prov(engine.CollectGLProject(fp))
+		return emit(cp, timer, engine.NormalizeGLIntegration(fp, kind, key), rec)
+	}
+
+	for _, raw := range entLoadList(prior, engine.CollectGLWebhooks(fp)) {
+		h := entMap(raw)
+		if err := emitInt("webhook", fmt.Sprintf("%d", entInt64(h["id"])), webhookRec(h, allowLocal, hasEditorBelowTrust)); err != nil {
+			return err
+		}
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLIntegrations(fp)) {
+		i := entMap(raw)
+		if err := emitInt("integration", entStr(i["slug"]), integrationRec(i, allowLocal, hasEditorBelowTrust)); err != nil {
+			return err
+		}
+	}
+	if detail != nil && entBool(detail["mirror"]) {
+		if err := emitInt("pull_mirror", "pull", pullMirrorRec(detail, prior, fp, hasEditorBelowTrust)); err != nil {
+			return err
+		}
+	}
+	for idx, raw := range entLoadList(prior, engine.CollectGLMirrors(fp)) {
+		m := entMap(raw)
+		if err := emitInt("push_mirror", fmt.Sprintf("%d", idx), mirrorRec(m, detail, prior, fp, hasEditorBelowTrust)); err != nil {
+			return err
+		}
+	}
+	if detail != nil && entStr(detail["pages_access_level"]) != "disabled" && entStr(detail["pages_access_level"]) != "" {
+		if err := emitInt("pages", "pages", pagesRec(detail)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func webhookRec(h map[string]any, allowLocal, hasEditorBelowTrust bool) map[string]any {
+	tokenPresent := entBool(h["token_present"])
+	headers := entListOrEmpty(h["custom_headers"])
+	return map[string]any{
+		"url":                           entStr(h["url"]),
+		"url_mutable":                   true,
+		"token_present":                 tokenPresent,
+		"custom_headers":                headers,
+		"allows_local_network":          allowLocal && !entBool(h["enable_ssl_verification"]) || allowLocal,
+		"webhook_signing_token_present": entBool(h["signing_token_present"]),
+		"firable_event_trigger":         webhookFirable(h),
+		"editor_below_credential_trust": hasEditorBelowTrust && (tokenPresent || len(headers) > 0),
+	}
+}
+
+func webhookFirable(h map[string]any) bool {
+	for _, k := range []string{"push_events", "note_events", "merge_requests_events", "pipeline_events", "issues_events", "tag_push_events"} {
+		if entBool(h[k]) {
+			return true
+		}
+	}
+	return false
+}
+
+func integrationRec(i map[string]any, allowLocal, hasEditorBelowTrust bool) map[string]any {
+	tokenPresent := entBool(i["active"]) && entBool(i["token_present"])
+	return map[string]any{
+		"url":                           "",
+		"url_mutable":                   true,
+		"token_present":                 tokenPresent,
+		"custom_headers":                []any{},
+		"allows_local_network":          allowLocal,
+		"webhook_signing_token_present": false,
+		"firable_event_trigger":         webhookFirable(i),
+		"editor_below_credential_trust": hasEditorBelowTrust && tokenPresent,
+	}
+}
+
+// pullMirrorRec normalizes the cat-14 pull-mirror surface. Pull mirroring is a
+// project-detail attribute (mirror==true + import_url), not a /remote_mirrors
+// entry — those are push mirrors and stay empty for pull-only projects.
+func pullMirrorRec(detail map[string]any, prior engine.PriorPhase, fp string, hasEditorBelowTrust bool) map[string]any {
+	importURL := entStr(detail["import_url"])
+	triggerPipelines := entBool(detail["mirror_trigger_builds"])
+	allBranches := !entBool(detail["only_mirror_protected_branches"])
+	branches := normalizeProtectedBranches(entLoadList(prior, engine.CollectGLProtectedBranches(fp)))
+	defaultBranch := entStr(detail["default_branch"])
+	defaultProtected := anyBranch(branches, func(b map[string]any) bool { return globMatch(mStr(b, "pattern"), defaultBranch) })
+	vars := mirrorReachableVars(prior, fp)
+	protectedBranchPipeline := triggerPipelines && (defaultProtected || !allBranches)
+	mirror := map[string]any{
+		"trigger_pipelines":            triggerPipelines,
+		"all_branches":                 allBranches,
+		"upstream_untrusted_host":      mirrorUntrustedHost(importURL, fp),
+		"protected_default_branch":     defaultProtected,
+		"reaches_protected_variable":   protectedBranchPipeline && anyVar(vars, func(v map[string]any) bool { return mBool(v, "protected") }),
+		"reaches_unprotected_variable": triggerPipelines && anyVar(vars, func(v map[string]any) bool { return !mBool(v, "protected") }),
+		"job_token_push_allowed":       entBool(detail["ci_push_repository_for_job_token_allowed"]),
+	}
+	tokenPresent := importURL != "" && strings.Contains(importURL, "@")
+	return map[string]any{
+		"url":                           importURL,
+		"url_mutable":                   true,
+		"token_present":                 tokenPresent,
+		"custom_headers":                []any{},
+		"allows_local_network":          false,
+		"webhook_signing_token_present": false,
+		"firable_event_trigger":         triggerPipelines,
+		"editor_below_credential_trust": hasEditorBelowTrust && tokenPresent,
+		"mirror":                        mirror,
+	}
+}
+
+func mirrorRec(m, detail map[string]any, prior engine.PriorPhase, fp string, hasEditorBelowTrust bool) map[string]any {
+	importURL := entStr(m["url"])
+	if importURL == "" {
+		importURL = entStr(m["import_url"])
+	}
+	triggerPipelines := entBool(m["trigger_pipelines"])
+	allBranches := !entBool(m["only_protected_branches"])
+	branches := normalizeProtectedBranches(entLoadList(prior, engine.CollectGLProtectedBranches(fp)))
+	defaultBranch := ""
+	if detail != nil {
+		defaultBranch = entStr(detail["default_branch"])
+	}
+	defaultProtected := anyBranch(branches, func(b map[string]any) bool { return globMatch(mStr(b, "pattern"), defaultBranch) })
+	// The auto-triggered mirror pipeline runs on the mirrored branch(es). A
+	// protected CI/CD variable is reachable only when the mirror pipeline runs on
+	// a protected branch (default branch protected, or mirror confined to protected
+	// branches); an unprotected/masked variable is reachable on any mirrored branch.
+	vars := mirrorReachableVars(prior, fp)
+	protectedBranchPipeline := triggerPipelines && (defaultProtected || !allBranches)
+	mirror := map[string]any{
+		"trigger_pipelines":            triggerPipelines,
+		"all_branches":                 allBranches,
+		"upstream_untrusted_host":      mirrorUntrustedHost(importURL, fp),
+		"protected_default_branch":     defaultProtected,
+		"reaches_protected_variable":   protectedBranchPipeline && anyVar(vars, func(v map[string]any) bool { return mBool(v, "protected") }),
+		"reaches_unprotected_variable": triggerPipelines && anyVar(vars, func(v map[string]any) bool { return !mBool(v, "protected") }),
+		"job_token_push_allowed":       detail != nil && entBool(detail["ci_push_repository_for_job_token_allowed"]),
+	}
+	tokenPresent := importURL != "" && strings.Contains(importURL, "@")
+	return map[string]any{
+		"url":                           importURL,
+		"url_mutable":                   true,
+		"token_present":                 tokenPresent,
+		"custom_headers":                []any{},
+		"allows_local_network":          false,
+		"webhook_signing_token_present": false,
+		"firable_event_trigger":         entBool(m["trigger_pipelines"]),
+		"editor_below_credential_trust": hasEditorBelowTrust && tokenPresent,
+		"mirror":                        mirror,
+	}
+}
+
+// mirrorReachableVars is the project's own CI/CD variables plus the parent
+// group's inherited variables — the set a mirror-triggered pipeline can read.
+func mirrorReachableVars(prior engine.PriorPhase, fp string) []map[string]any {
+	out := normalizeVariables(entLoadList(prior, engine.CollectGLProjectVariables(fp)), "project")
+	if group := parentGroup(fp); group != "" {
+		out = append(out, normalizeVariables(entLoadList(prior, engine.CollectGLGroupVariables(group)), "group")...)
+	}
+	return out
+}
+
+func mirrorUntrustedHost(importURL, fp string) bool {
+	if importURL == "" {
+		return false
+	}
+	group := strings.SplitN(fp, "/", 2)[0]
+	return !strings.Contains(importURL, group)
+}
+
+func pagesRec(detail map[string]any) map[string]any {
+	return map[string]any{
+		"url":                           entStr(detail["web_url"]),
+		"url_mutable":                   false,
+		"token_present":                 false,
+		"custom_headers":                []any{},
+		"allows_local_network":          false,
+		"webhook_signing_token_present": false,
+		"firable_event_trigger":         false,
+		"editor_below_credential_trust": false,
+		"pages":                         map[string]any{"reads_secret": false},
+	}
+}
+
+// ---- shared helpers over normalized shapes ----
+
+func orEmptyObj(m map[string]any) map[string]any {
+	if m == nil || entUnobserved(m) {
+		return map[string]any{}
+	}
+	return m
+}
+
+func anyVar(vars []map[string]any, pred func(map[string]any) bool) bool {
+	for _, v := range vars {
+		if pred(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyBranch(branches []map[string]any, pred func(map[string]any) bool) bool {
+	for _, b := range branches {
+		if pred(b) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyTag(tags []map[string]any, pred func(map[string]any) bool) bool {
+	for _, t := range tags {
+		if pred(t) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyRunner(runners []map[string]any, pred func(map[string]any) bool) bool {
+	for _, r := range runners {
+		if pred(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyRule(rules []any, pred func(map[string]any) bool) bool {
+	for _, raw := range rules {
+		if pred(entMap(raw)) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyStr(list []any, pred func(string) bool) bool {
+	for _, v := range list {
+		if pred(entStr(v)) {
+			return true
+		}
+	}
+	return false
+}
+
+func grantsDeveloper(levels []any) bool {
+	return levelsInclude(levels, accessDeveloper)
+}
+
+func developerPushableUnprotectedRef(branches []map[string]any) bool {
+	if len(branches) == 0 {
+		return true
+	}
+	for _, b := range branches {
+		if isWildcard(mStr(b, "pattern")) && grantsDeveloper(mList(b, "push_access_levels")) {
+			return true
+		}
+	}
+	return false
+}
+
+func isWildcard(pattern string) bool {
+	return strings.ContainsAny(pattern, "*?[")
+}
+
+// globMatch is a minimal wildcard match (only '*' wildcards, GitLab
+// protected-branch semantics) sufficient for default-branch coverage checks.
+func globMatch(pattern, name string) bool {
+	if pattern == name {
+		return true
+	}
+	if !strings.Contains(pattern, "*") {
+		return false
+	}
+	parts := strings.Split(pattern, "*")
+	pos := 0
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		idx := strings.Index(name[pos:], part)
+		if idx < 0 {
+			return false
+		}
+		if i == 0 && idx != 0 {
+			return false
+		}
+		pos += idx + len(part)
+	}
+	if parts[len(parts)-1] != "" && !strings.HasSuffix(name, parts[len(parts)-1]) {
+		return false
+	}
+	return true
+}
+
+// shadowedByPermissive: ≥2 rules match a common branch and the union of their
+// access grants a lower-trust actor than the narrowest matching rule intended.
+func shadowedByPermissive(branches []map[string]any, levelKey string) bool {
+	for i := range branches {
+		matches := []map[string]any{branches[i]}
+		for j := range branches {
+			if i != j && patternsOverlap(mStr(branches[i], "pattern"), mStr(branches[j], "pattern")) {
+				matches = append(matches, branches[j])
+			}
+		}
+		if len(matches) < 2 {
+			continue
+		}
+		// The narrowest matching rule's intent vs the most-permissive (lowest
+		// numeric) grant across all matching rules: a gap means a broader rule
+		// shadows the tighter one.
+		grants := make([]int64, 0, len(matches))
+		for _, m := range matches {
+			if lo := lowestGrant(mList(m, levelKey)); lo > 0 {
+				grants = append(grants, lo)
+			}
+		}
+		if len(grants) < 2 {
+			continue
+		}
+		lo, hi := grants[0], grants[0]
+		for _, g := range grants[1:] {
+			lo = min(lo, g)
+			hi = max(hi, g)
+		}
+		if lo < hi {
+			return true
+		}
+	}
+	return false
+}
+
+func shadowedTags(tags []map[string]any) bool {
+	for i := range tags {
+		for j := range tags {
+			if i != j && patternsOverlap(mStr(tags[i], "pattern"), mStr(tags[j], "pattern")) {
+				loI := lowestGrant(mList(tags[i], "create_access_levels"))
+				loJ := lowestGrant(mList(tags[j], "create_access_levels"))
+				if loI > 0 && loJ > 0 && loI != loJ {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func forcePushShadowed(branches []map[string]any) bool {
+	for i := range branches {
+		if mBool(branches[i], "allow_force_push") {
+			continue
+		}
+		for j := range branches {
+			if i != j && patternsOverlap(mStr(branches[i], "pattern"), mStr(branches[j], "pattern")) &&
+				mBool(branches[j], "allow_force_push") &&
+				levelsIncludeAtMost(mList(branches[j], "push_access_levels"), accessDeveloper) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func patternsOverlap(a, b string) bool {
+	return a == b || globMatch(a, stripGlob(b)) || globMatch(b, stripGlob(a))
+}
+
+func stripGlob(p string) string { return strings.ReplaceAll(p, "*", "x") }
+
+func lowestGrant(levels []any) int64 {
+	lo := int64(0)
+	for _, v := range levels {
+		l := entInt64(v)
+		if l > 0 && (lo == 0 || l < lo) {
+			lo = l
+		}
+	}
+	return lo
+}
+
+func protectedVarScopedToWritable(vars []map[string]any, branches []map[string]any) bool {
+	writable := anyBranch(branches, func(b map[string]any) bool {
+		return grantsDeveloper(mList(b, "push_access_levels")) || grantsDeveloper(mList(b, "merge_access_levels"))
+	}) || len(branches) == 0
+	return writable && anyVar(vars, func(v map[string]any) bool { return mBool(v, "protected") })
+}
+
+func deployCredKey(key string) bool {
+	u := strings.ToUpper(key)
+	return strings.HasPrefix(u, "AUTO_DEVOPS_") || strings.HasPrefix(u, "KUBE_") || strings.Contains(u, "KUBECONFIG")
+}
+
+func groupInheritedDeployVars(prior engine.PriorPhase, fp string) bool {
+	group := parentGroup(fp)
+	if group == "" {
+		return false
+	}
+	for _, raw := range entLoadList(prior, engine.CollectGLGroupVariables(group)) {
+		if deployCredKey(entStr(entMap(raw)["key"])) {
+			return true
+		}
+	}
+	return false
+}
+
+func authorCanSelfMerge(prior engine.PriorPhase, fp string) bool {
+	approvals := entLoadData(prior, engine.CollectGLApprovals(fp))
+	if approvals == nil || entUnobserved(approvals) {
+		return true
+	}
+	req := entInt64(approvals["approvals_before_merge"])
+	return req == 0 || entBool(approvals["merge_requests_author_approval"])
+}
+
+func policyFromMutableProject(prior engine.PriorPhase, fp string, branches []map[string]any) bool {
+	pol := entLoadData(prior, engine.CollectGLSecurityPolicies(fp))
+	nodes := entList(entGetIn(pol, "project", "scanExecutionPolicies", "nodes"))
+	if len(nodes) == 0 {
+		return false
+	}
+	return developerPushableUnprotectedRef(branches)
+}
+
+func inheritedDefaultBranchProtection(prior engine.PriorPhase, fp string, branches []map[string]any, defaultBranch string) (string, bool) {
+	for _, b := range branches {
+		if globMatch(mStr(b, "pattern"), defaultBranch) {
+			return "project", grantsDeveloper(mList(b, "push_access_levels")) && !mBool(b, "allow_force_push")
+		}
+	}
+	group := parentGroup(fp)
+	if group != "" {
+		g := entLoadData(prior, engine.CollectGLGroup(group))
+		if d := entMap(g["default_branch_protection_defaults"]); d != nil {
+			if levelsInclude(accessLevelValues(d["allowed_to_push"]), accessDeveloper) {
+				return "group", true
+			}
+			return "group", false
+		}
+	}
+	return "instance", false
+}
+
+func ciDebugTrace(vars []map[string]any, ciYAML []byte) bool {
+	for _, v := range vars {
+		if strings.EqualFold(mStr(v, "key"), "CI_DEBUG_TRACE") {
+			return true
+		}
+	}
+	if ciYAML != nil {
+		return ciYAMLDebugTrace(ciYAML)
+	}
+	return false
+}
+
+func firstNonEmpty(vals ...string) any {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return nil
+}
+
+func sortedStrSet(list []any) []any {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, v := range list {
+		s := entStr(v)
+		if s != "" && !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	sort.Strings(out)
+	res := make([]any, len(out))
+	for i, s := range out {
+		res[i] = s
+	}
+	return res
+}
+
+func parentGroup(fp string) string {
+	i := strings.LastIndex(fp, "/")
+	if i < 0 {
+		return ""
+	}
+	return fp[:i]
+}
+
+func duoFeatureEnabled(duo map[string]any, scope string) any {
+	if duo == nil || entUnobserved(duo) {
+		return nil
+	}
+	return duoBool(duo, scope, "duoFeaturesEnabled")
+}

--- a/internal/gitlab/normalize_entities_test.go
+++ b/internal/gitlab/normalize_entities_test.go
@@ -1,0 +1,270 @@
+package gitlab
+
+import "testing"
+
+func TestGlobMatch(t *testing.T) {
+	cases := []struct {
+		pattern, name string
+		want          bool
+	}{
+		{"main", "main", true},
+		{"main", "develop", false},
+		{"release/*", "release/1.0", true},
+		{"release/*", "main", false},
+		{"*", "anything", true},
+		{"v*", "v1", true},
+		{"v*", "x1", false},
+		{"*-prod", "app-prod", true},
+		{"*-prod", "app-dev", false},
+		{"a*b", "aXXb", true},
+		{"a*b", "aXX", false},
+	}
+	for _, c := range cases {
+		if got := globMatch(c.pattern, c.name); got != c.want {
+			t.Errorf("globMatch(%q,%q)=%v want %v", c.pattern, c.name, got, c.want)
+		}
+	}
+}
+
+func TestSecretShapedKey(t *testing.T) {
+	secret := []string{"PROD_DEPLOY_KEY", "AWS_SECRET_ACCESS_KEY", "npm_token", "DB_PASSWORD", "API_KEY", "GCP_SA_JSON"}
+	for _, k := range secret {
+		if !secretShapedKey(k) {
+			t.Errorf("secretShapedKey(%q)=false want true", k)
+		}
+	}
+	// Ordinary config keys must not fire — the three unprotected-secret booleans
+	// rest on this precision.
+	plain := []string{"CI_DEBUG_LEVEL", "ENVIRONMENT", "REGION", "BUILD_NUMBER", "STAGE"}
+	for _, k := range plain {
+		if secretShapedKey(k) {
+			t.Errorf("secretShapedKey(%q)=true want false", k)
+		}
+	}
+}
+
+func TestClassifySelfManaged(t *testing.T) {
+	saasShared := map[string]any{
+		"runner_type": "instance_type", "is_shared": true,
+		"description": "1-blue-2.saas-linux-small-amd64.runners-manager.gitlab.com/default",
+	}
+	if classifySelfManaged(saasShared) {
+		t.Error("gitlab.com SaaS shared runner classified self_managed=true")
+	}
+	selfHosted := map[string]any{
+		"runner_type": "project_type", "is_shared": false, "platform": "linux",
+		"description": "ops-k8s-runner-01",
+	}
+	if !classifySelfManaged(selfHosted) {
+		t.Error("operator-run project runner classified self_managed=false")
+	}
+}
+
+func TestDuoGuardrailUppercaseVerbatim(t *testing.T) {
+	duo := map[string]any{"duoSettings": map[string]any{"promptInjectionProtectionLevel": "LOG_ONLY"}}
+	if got := duoGuardrail(duo, "instance"); got != "LOG_ONLY" {
+		t.Errorf("duoGuardrail=%v want LOG_ONLY (uppercase verbatim, never lowercased)", got)
+	}
+	group := map[string]any{"group": map[string]any{"aiSettings": map[string]any{"promptInjectionProtectionLevel": "INTERRUPT"}}}
+	if got := duoGuardrail(group, "group"); got != "INTERRUPT" {
+		t.Errorf("duoGuardrail(group)=%v want INTERRUPT", got)
+	}
+	if got := duoGuardrail(map[string]any{"_unobserved": float64(403)}, "instance"); got != nil {
+		t.Errorf("unobserved duo guardrail=%v want nil", got)
+	}
+}
+
+func TestRoleNameToLevel(t *testing.T) {
+	// GitLab may return the group default_membership_role as either enum or int.
+	if roleNameToLevel("developer") != accessDeveloper {
+		t.Error("string developer did not map to 30")
+	}
+	if roleNameToLevel(float64(40)) != accessMaintainer {
+		t.Error("numeric 40 did not map to maintainer")
+	}
+	if levelToRoleName(accessGuest) != "guest" {
+		t.Error("10 did not map to guest")
+	}
+}
+
+func TestJobTokenAllowlistMode(t *testing.T) {
+	disabled := jobTokenAllowlist(map[string]any{
+		"job_token_scope": map[string]any{"inbound_enabled": false},
+	})
+	if disabled["mode"] != "disabled" {
+		t.Errorf("mode=%v want disabled when inbound scope off", disabled["mode"])
+	}
+	projScoped := jobTokenAllowlist(map[string]any{
+		"job_token_scope":     map[string]any{"inbound_enabled": true},
+		"job_token_allowlist": []any{map[string]any{"path_with_namespace": "grp/proj"}},
+	})
+	if projScoped["mode"] != "project_scoped" {
+		t.Errorf("mode=%v want project_scoped", projScoped["mode"])
+	}
+	if ents := projScoped["entries"].([]any); len(ents) != 1 || ents[0] != "grp/proj" {
+		t.Errorf("entries=%v want [grp/proj]", projScoped["entries"])
+	}
+}
+
+func TestShadowedByPermissive(t *testing.T) {
+	// Two rules match "main"; one grants Maintainer (40), one grants Developer
+	// (30). The broader rule shadows the tighter one.
+	branches := []map[string]any{
+		{"pattern": "main", "push_access_levels": []any{int64(40)}},
+		{"pattern": "*", "push_access_levels": []any{int64(30)}},
+	}
+	if !shadowedByPermissive(branches, "push_access_levels") {
+		t.Error("expected shadow when a wildcard Developer rule overlaps a Maintainer rule on main")
+	}
+	// A single consistent rule is not a shadow.
+	single := []map[string]any{{"pattern": "main", "push_access_levels": []any{int64(40)}}}
+	if shadowedByPermissive(single, "push_access_levels") {
+		t.Error("single rule falsely reported as shadowed")
+	}
+}
+
+func TestNearMissProtectedName(t *testing.T) {
+	// Exact match is covered → not a near-miss.
+	if nearMissProtected("production", []string{"production"}) {
+		t.Error("exact protected name reported as near-miss")
+	}
+	// prod↔production alias, and review/ suffix are near-misses.
+	if !nearMissProtected("prod", []string{"production"}) {
+		t.Error("prod vs production alias not detected")
+	}
+	if !nearMissProtected("production/eu", []string{"production"}) {
+		t.Error("production/eu suffix of protected name not detected")
+	}
+}
+
+// TestGroupBranchProtectionEnum: the cat-03 rule reads default_branch_protection
+// as the enum {none,partial,full}, not a raw int/object. A Developer-inclusive
+// push grant (or force-push) is partial; a Maintainer-only grant is full.
+func TestGroupBranchProtectionEnum(t *testing.T) {
+	full := groupBranchProtection(map[string]any{
+		"default_branch_protection_defaults": map[string]any{
+			"allowed_to_push":  []any{map[string]any{"access_level": int64(40)}},
+			"allow_force_push": false,
+		},
+	})
+	if full != "full" {
+		t.Errorf("Maintainer-only push = %v want full", full)
+	}
+	partial := groupBranchProtection(map[string]any{
+		"default_branch_protection_defaults": map[string]any{
+			"allowed_to_push": []any{map[string]any{"access_level": int64(30)}},
+		},
+	})
+	if partial != "partial" {
+		t.Errorf("Developer-inclusive push = %v want partial", partial)
+	}
+	// Legacy integer form: 0 none, 1 partial, 2 full.
+	for in, want := range map[int64]string{0: "none", 1: "partial", 2: "full", 3: "full"} {
+		if got := groupBranchProtection(map[string]any{"default_branch_protection": in}); got != want {
+			t.Errorf("legacy default_branch_protection=%d => %v want %v", in, got, want)
+		}
+	}
+}
+
+// TestAgentImpersonationNil: cat-15 rules read impersonation == null. An absent
+// access_as must serialize as nil, never {} (which never matches == null).
+func TestAgentImpersonationNil(t *testing.T) {
+	if got := agentImpersonation(map[string]any{}); got != nil {
+		t.Errorf("no access_as => %v want nil", got)
+	}
+	if got := agentImpersonation(map[string]any{"access_as": map[string]any{}}); got != nil {
+		t.Errorf("empty access_as => %v want nil", got)
+	}
+	cfg := map[string]any{"access_as": map[string]any{"ci_job": map[string]any{}}}
+	if got := agentImpersonation(cfg); got == nil {
+		t.Error("a real access_as block must be surfaced, not nil")
+	}
+}
+
+// TestAgentEnvFilterUnprotected: a fixed filter name absent from protected
+// environments (or protected only with a Developer-inclusive deployer) gates
+// nothing; a wildcard name is not counted here (a separate wildcard fold covers it).
+func TestAgentEnvFilterUnprotected(t *testing.T) {
+	protEnvs := []any{
+		map[string]any{"name": "production", "deploy_access_levels": []any{map[string]any{"access_level": int64(40)}}},
+	}
+	if agentEnvFilterUnprotected([]any{"production"}, protEnvs) {
+		t.Error("a Maintainer-protected exact env must not be reported unprotected")
+	}
+	if !agentEnvFilterUnprotected([]any{"staging"}, protEnvs) {
+		t.Error("an env with no protected entry must be reported unprotected")
+	}
+	devProt := []any{map[string]any{"name": "staging", "deploy_access_levels": []any{map[string]any{"access_level": int64(30)}}}}
+	if !agentEnvFilterUnprotected([]any{"staging"}, devProt) {
+		t.Error("a Developer-deployable protected env gates nothing")
+	}
+	if agentEnvFilterUnprotected([]any{"review/*"}, nil) {
+		t.Error("a wildcard filter name must not be counted by the fixed-name unprotected check")
+	}
+}
+
+func TestCloudCredKey(t *testing.T) {
+	cloud := []string{"AWS_SECRET_ACCESS_KEY", "AZURE_CLIENT_SECRET", "GCP_SA_KEY", "GOOGLE_APPLICATION_CREDENTIALS", "ARM_CLIENT_SECRET"}
+	for _, k := range cloud {
+		if !cloudCredKey(k) {
+			t.Errorf("cloudCredKey(%q)=false want true", k)
+		}
+	}
+	// Generic secrets that are NOT static cloud creds must not mint a cloud cred.
+	for _, k := range []string{"CI_JOB_TOKEN", "DB_PASSWORD", "NPM_TOKEN", "REGION"} {
+		if cloudCredKey(k) {
+			t.Errorf("cloudCredKey(%q)=true want false (not a cloud key)", k)
+		}
+	}
+}
+
+// TestStaticCloudCredInUnprotectedVariable: static_cloud_cred is the variable
+// itself, so in_unprotected_variable is directly derivable from the variable's
+// protected flag (not the deferred token-vs-variable leg).
+func TestStaticCloudCredInUnprotectedVariable(t *testing.T) {
+	unprot := staticCloudCredRec(map[string]any{"key": "AWS_SECRET_ACCESS_KEY", "protected": false}, "project")
+	if unprot["in_unprotected_variable"] != true || unprot["kind"] != nil {
+		t.Errorf("unprotected cloud var => in_unprotected_variable=%v", unprot["in_unprotected_variable"])
+	}
+	// cat-11 static_cloud_cred rule reads key_pattern == "cloud" (frozen rule).
+	if unprot["key_pattern"] != "cloud" {
+		t.Errorf("key_pattern=%v want cloud", unprot["key_pattern"])
+	}
+	prot := staticCloudCredRec(map[string]any{"key": "AWS_SECRET_ACCESS_KEY", "protected": true}, "project")
+	if prot["in_unprotected_variable"] != false {
+		t.Error("protected cloud var must set in_unprotected_variable=false")
+	}
+}
+
+// TestRunnerTargetedBy: a tagged job needs the runner to carry all its tags; an
+// untagged job needs run_untagged.
+func TestRunnerTargetedBy(t *testing.T) {
+	if !runnerTargetedBy([]string{"linux", "deploy"}, false, []any{"deploy"}) {
+		t.Error("runner carrying the job's tag must be targetable")
+	}
+	if runnerTargetedBy([]string{"linux"}, false, []any{"deploy"}) {
+		t.Error("runner missing a requested tag must not be targetable")
+	}
+	if !runnerTargetedBy(nil, true, nil) {
+		t.Error("untagged job on a run_untagged runner must be targetable")
+	}
+	if runnerTargetedBy(nil, false, nil) {
+		t.Error("untagged job on a runner that refuses untagged must not be targetable")
+	}
+}
+
+func TestLevelHelpers(t *testing.T) {
+	levels := []any{int64(30), int64(50)}
+	if !levelsInclude(levels, accessDeveloper) {
+		t.Error("levelsInclude missed 30")
+	}
+	if levelsInclude(levels, accessMaintainer) {
+		t.Error("levelsInclude falsely matched 40")
+	}
+	if !levelsIncludeAtMost(levels, accessDeveloper) {
+		t.Error("levelsIncludeAtMost missed a Developer-level actor")
+	}
+	if levelsIncludeAtMost([]any{int64(40), int64(50)}, accessDeveloper) {
+		t.Error("levelsIncludeAtMost falsely matched a Maintainer-only list")
+	}
+}

--- a/internal/gitlab/normalize_folds.go
+++ b/internal/gitlab/normalize_folds.go
@@ -1,0 +1,89 @@
+package gitlab
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func yamlUnmarshal(b []byte, v any) error { return yaml.Unmarshal(b, v) }
+
+func nowUTC() time.Time { return time.Now().UTC() }
+
+// parseDatePrefix parses the YYYY-MM-DD prefix of an ISO date/timestamp.
+func parseDatePrefix(s string) time.Time {
+	if len(s) < 10 {
+		return time.Time{}
+	}
+	t, err := time.Parse("2006-01-02", s[:10])
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// duoNode returns the aiSettings / duoSettings object for the scope. Group is
+// {group:{aiSettings:{...}}}; instance is {duoSettings:{...}}.
+func duoNode(duo map[string]any, scope string) map[string]any {
+	if scope == "group" {
+		return entMap(entGetIn(duo, "group", "aiSettings"))
+	}
+	return entMap(duo["duoSettings"])
+}
+
+func duoBool(duo map[string]any, scope, key string) any {
+	if duo == nil || entUnobserved(duo) {
+		return false
+	}
+	return entBool(duoNode(duo, scope)[key])
+}
+
+// duoGuardrail returns promptInjectionProtectionLevel UPPERCASE verbatim
+// (LOG_ONLY/NO_CHECKS/INTERRUPT) — hard contract C-guardrail, never lowercased.
+func duoGuardrail(duo map[string]any, scope string) any {
+	if duo == nil || entUnobserved(duo) {
+		return nil
+	}
+	v := entStr(duoNode(duo, scope)["promptInjectionProtectionLevel"])
+	if v == "" {
+		return nil
+	}
+	return v
+}
+
+// ---- .gitlab-ci.yml text folds (project/credential derived booleans) ----
+//
+// These are cheap textual scans over the raw entrypoint sufficient for the
+// project/credential effective booleans. Full include-tree resolution and
+// per-job facts are the job normalizer's responsibility.
+
+var (
+	reIDTokens    = regexp.MustCompile(`(?m)^\s*id_tokens\s*:`)
+	reEnvironment = regexp.MustCompile(`(?m)^\s*environment\s*:`)
+	reTagJob      = regexp.MustCompile(`CI_COMMIT_TAG|only\s*:\s*\n\s*-?\s*tags|rules:.*\$CI_COMMIT_TAG`)
+	reDebugTrace  = regexp.MustCompile(`(?m)CI_DEBUG_TRACE\s*:\s*["']?(1|true|yes|on)`)
+)
+
+func ciYAMLHasDeployIdentity(b []byte) bool {
+	if b == nil {
+		return false
+	}
+	s := string(b)
+	return reIDTokens.MatchString(s) || reEnvironment.MatchString(s)
+}
+
+func ciYAMLHasTagJob(b []byte) bool {
+	if b == nil {
+		return false
+	}
+	return reTagJob.MatchString(string(b))
+}
+
+func ciYAMLDebugTrace(b []byte) bool {
+	if b == nil {
+		return false
+	}
+	return reDebugTrace.MatchString(string(b)) || strings.Contains(strings.ToUpper(string(b)), "CI_DEBUG_TRACE")
+}

--- a/internal/gitlab/normalize_folds_computed_test.go
+++ b/internal/gitlab/normalize_folds_computed_test.go
@@ -1,0 +1,124 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// These cover the effective-fold booleans that were previously hardcoded false
+// while a non-deferred rule reads them true (LAB-4288 fold sweep). Each fold has a
+// firing case AND a benign twin, so a regression to constant-true is caught too.
+
+func writeCIConfig(t *testing.T, prior engine.PriorPhase, fp, yaml string) {
+	t.Helper()
+	cp := engine.CurrentPhase(prior)
+	if err := cp.WriteRaw(engine.CollectGLCIConfig(fp, ".gitlab-ci.yml"), []byte(yaml)); err != nil {
+		t.Fatalf("write ci-config: %v", err)
+	}
+}
+
+// cat-14/01,02,04,12 editor_below_credential_trust: a write credential is attached
+// AND a Maintainer (project) editor exists below the credential-setter's trust.
+func TestEditorBelowCredentialTrustFold(t *testing.T) {
+	maintainerRoster := []any{
+		map[string]any{"access_level": accessMaintainer},
+		map[string]any{"access_level": accessOwner},
+	}
+	ownerOnlyRoster := []any{map[string]any{"access_level": accessOwner}}
+
+	hasMaintainer := hasMemberAtLevel(maintainerRoster, accessMaintainer)
+	noMaintainer := hasMemberAtLevel(ownerOnlyRoster, accessMaintainer)
+	if !hasMaintainer || noMaintainer {
+		t.Fatalf("member existential wrong: maint=%v ownerOnly=%v", hasMaintainer, noMaintainer)
+	}
+
+	// webhook with a secret token + a Maintainer editor → fold true.
+	tokenHook := map[string]any{"id": 1, "token_present": true, "push_events": true}
+	rec := webhookRec(tokenHook, false, hasMaintainer)
+	if rec["editor_below_credential_trust"] != true {
+		t.Error("webhook: token + Maintainer editor must be editor_below_credential_trust")
+	}
+
+	// benign twin A: same hook, no Maintainer editor (Owner-only roster) → false.
+	if webhookRec(tokenHook, false, noMaintainer)["editor_below_credential_trust"] != false {
+		t.Error("webhook: no Maintainer editor must NOT be editor_below_credential_trust")
+	}
+	// benign twin B: Maintainer editor but NO credential attached → false.
+	bareHook := map[string]any{"id": 2, "push_events": true}
+	if webhookRec(bareHook, false, hasMaintainer)["editor_below_credential_trust"] != false {
+		t.Error("webhook: no credential must NOT be editor_below_credential_trust")
+	}
+
+	// custom-header credential path (cat-14/02).
+	hdrHook := map[string]any{"id": 3, "custom_headers": []any{map[string]any{"key": "Authorization"}}, "push_events": true}
+	if webhookRec(hdrHook, false, hasMaintainer)["editor_below_credential_trust"] != true {
+		t.Error("webhook: custom header + Maintainer editor must be editor_below_credential_trust")
+	}
+
+	// integration (cat-14/12): active + token_present.
+	activeInt := map[string]any{"active": true, "token_present": true, "pipeline_events": true}
+	if integrationRec(activeInt, false, hasMaintainer)["editor_below_credential_trust"] != true {
+		t.Error("integration: active credential + Maintainer editor must be editor_below_credential_trust")
+	}
+	// benign twin: inactive integration → no credential trust to recapture.
+	inactiveInt := map[string]any{"active": false, "token_present": true, "pipeline_events": true}
+	if integrationRec(inactiveInt, false, hasMaintainer)["editor_below_credential_trust"] != false {
+		t.Error("integration: inactive must NOT be editor_below_credential_trust")
+	}
+}
+
+// cat-06/09 named_scanner_absent: a policy scanner has no matching job/template in
+// the resolved pipeline.
+func TestNamedScannerAbsentFold(t *testing.T) {
+	fp := "g/p"
+
+	// Pipeline wires sast (job) but not dependency_scanning.
+	prior := engine.PriorPhase{RunDir: t.TempDir()}
+	writeCIConfig(t, prior, fp, "sast:\n  script: [scan]\nbuild:\n  script: [make]\n")
+
+	if !namedScannerAbsent(prior, fp, []any{"sast", "dependency_scanning"}) {
+		t.Error("dependency_scanning absent from pipeline must be named_scanner_absent")
+	}
+	// benign twin: only the present scanner is named → not absent.
+	if namedScannerAbsent(prior, fp, []any{"sast"}) {
+		t.Error("sast IS present (job) → must NOT be named_scanner_absent")
+	}
+	// no named scanners → nothing can be absent.
+	if namedScannerAbsent(prior, fp, []any{}) {
+		t.Error("no named scanners must NOT be named_scanner_absent")
+	}
+
+	// scanner wired via a managed security template include → present.
+	prior2 := engine.PriorPhase{RunDir: t.TempDir()}
+	writeCIConfig(t, prior2, fp, "include:\n  - template: Security/Dependency-Scanning.gitlab-ci.yml\nbuild:\n  script: [make]\n")
+	if namedScannerAbsent(prior2, fp, []any{"dependency_scanning"}) {
+		t.Error("dependency_scanning via template include must NOT be named_scanner_absent")
+	}
+}
+
+// cat-06/13 required_jobs_evadable: every job is author-conditionally gated, so an
+// MR can produce a skipped/empty pipeline.
+func TestRequiredJobsEvadableFold(t *testing.T) {
+	fp := "g/p"
+
+	// All jobs gated behind rules:/only: → evadable.
+	prior := engine.PriorPhase{RunDir: t.TempDir()}
+	writeCIConfig(t, prior, fp, "test:\n  script: [t]\n  rules:\n    - if: '$RUN == \"1\"'\nlint:\n  script: [l]\n  only: [merge_requests]\n")
+	if !requiredJobsEvadable(prior, fp) {
+		t.Error("all-conditional pipeline must be required_jobs_evadable")
+	}
+
+	// benign twin: one unconditional job always runs → not evadable.
+	prior2 := engine.PriorPhase{RunDir: t.TempDir()}
+	writeCIConfig(t, prior2, fp, "test:\n  script: [t]\n  rules:\n    - if: '$RUN == \"1\"'\nbuild:\n  script: [make]\n")
+	if requiredJobsEvadable(prior2, fp) {
+		t.Error("an unconditional job means NOT required_jobs_evadable")
+	}
+
+	// no pipeline at all → nothing required to evade.
+	prior3 := engine.PriorPhase{RunDir: t.TempDir()}
+	if requiredJobsEvadable(prior3, fp) {
+		t.Error("absent pipeline must NOT be required_jobs_evadable")
+	}
+}

--- a/internal/gitlab/normalize_job.go
+++ b/internal/gitlab/normalize_job.go
@@ -1,0 +1,511 @@
+package gitlab
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// Job is the resolved-job record handle produced by normalizeJobs. correlate
+// re-reads jobs from disk rather than the returned slice, so this carries only
+// the record's id and project for the orchestrator's call convention.
+type Job struct {
+	ID      string
+	Project string
+}
+
+// jobContext folds the project/group/instance effective properties a job's fields
+// depend on (runner reachability, variable posture, protected-ref model, includes,
+// Duo, OIDC). Read once per project from the already-written normalized records
+// (normalizeEntities runs before normalizeJobs) so job fields stay consistent with
+// the subject records the same rules read.
+type jobContext struct {
+	project    map[string]any
+	group      map[string]any
+	instance   map[string]any
+	selfHost   string
+	namespace  string
+	globalVars map[string]any
+	workflow   map[string]any
+	includes   []any
+	incFlags   includeFlags
+	duoAgent   []byte
+	duoMCP     []byte
+}
+
+// normalizeJobs parses each project's .gitlab-ci.yml entrypoint, evaluates
+// rules:/workflow: for triggers and ref-protection, classifies includes/sinks/
+// reachability, and emits one job record per resolved job into 10-normalize/jobs.
+// P2 collects only the raw entrypoint, so job discovery is entrypoint-only and
+// include: bodies are classified (cat-02) rather than expanded into new jobs.
+func normalizeJobs(ctx context.Context, prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) ([]Job, error) {
+	var out []Job
+	for _, p := range projs {
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		raw := entLoadRaw(prior, engine.CollectGLCIConfig(p.FullPath, ".gitlab-ci.yml"))
+		if raw == nil {
+			continue
+		}
+		pipeline, err := parseCIPipeline(raw)
+		if err != nil {
+			itemErr(timer, "job:"+p.FullPath, err)
+			continue
+		}
+		if pipeline == nil {
+			continue
+		}
+		jc := loadJobContext(prior, p)
+		jc.workflow = entMap(pipeline["workflow"])
+		jc.globalVars = entMap(pipeline["variables"])
+		jc.includes, jc.incFlags = classifyIncludes(pipeline["include"], jc.selfHost, jc.namespace)
+
+		def := entMap(pipeline["default"])
+		producers := dotenvProducers(pipeline)
+		crossNeedJobs := crossNeedJobNames(pipeline, def)
+		for _, name := range jobNames(pipeline) {
+			job := mergeDefault(entMap(pipeline[name]), def)
+			rec := buildJobRecord(p, name, job, jc, producers, crossNeedJobs)
+			rel := engine.NormalizeGLJob(p.FullPath, ".gitlab-ci.yml", name)
+			if err := emit(cp, timer, rel, rec); err != nil {
+				return out, err
+			}
+			out = append(out, Job{ID: entStr(rec["_id"]), Project: p.FullPath})
+		}
+	}
+	return out, nil
+}
+
+// dotenvProducers pre-scans the pipeline for jobs emitting a dotenv artifact so a
+// consumer's consumes_dotenv can be resolved without a second full pass.
+func dotenvProducers(pipeline map[string]any) map[string]bool {
+	out := map[string]bool{}
+	def := entMap(pipeline["default"])
+	for _, name := range jobNames(pipeline) {
+		if producesDotenv(mergeDefault(entMap(pipeline[name]), def)) {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// crossNeedJobNames is the set of jobs whose needs: pull a cross-project
+// artifact, used to detect a child pipeline generated from that artifact (cat-02).
+func crossNeedJobNames(pipeline, def map[string]any) map[string]bool {
+	out := map[string]bool{}
+	for _, name := range jobNames(pipeline) {
+		if len(crossProjectNeeds(mergeDefault(entMap(pipeline[name]), def))) > 0 {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func loadJobContext(prior engine.PriorPhase, p projectMeta) jobContext {
+	jc := jobContext{
+		project:   readRecord(prior, engine.NormalizeGLProject(p.FullPath)),
+		instance:  readRecord(prior, engine.NormalizeGLInstance()),
+		namespace: parentGroup(p.FullPath),
+	}
+	if jc.namespace != "" {
+		jc.group = readRecord(prior, engine.NormalizeGLGroup(jc.namespace))
+	}
+	detail := entLoadData(prior, engine.CollectGLProject(p.FullPath))
+	jc.selfHost = hostOf(entStr(detail["web_url"]))
+	jc.duoAgent = entLoadRaw(prior, engine.CollectGLRepoFile(p.FullPath, ".gitlab/duo/agent-config.yml"))
+	jc.duoMCP = entLoadRaw(prior, engine.CollectGLRepoFile(p.FullPath, ".gitlab/duo/mcp.json"))
+	return jc
+}
+
+func readRecord(prior engine.PriorPhase, rel string) map[string]any {
+	var rec map[string]any
+	if err := engine.ReadJSON(prior.Abs(rel), &rec); err != nil {
+		return nil
+	}
+	return rec
+}
+
+// buildJobRecord assembles one job record with every field root from the contract.
+func buildJobRecord(p projectMeta, name string, job map[string]any, jc jobContext, producers, crossNeedJobs map[string]bool) map[string]any {
+	scriptText := jobScriptText(job)
+	triggers := resolveTriggers(job, jc.workflow)
+	gate := protectedRefGate(job, jc.workflow)
+	untrustedRef := runsOnUntrustedRef(triggers, gate)
+	deploysEnv, envName := deploysEnvironment(job)
+	attackerFields := attackerInputFields(scriptText)
+	imgRef := imageRef(job)
+	cross := crossProjectNeeds(job)
+	tags := runnerTags(job)
+
+	proj := jc.project
+
+	rec := map[string]any{
+		"_id":                                        jobID(p.FullPath, name),
+		"triggers":                                   toSet(triggers),
+		"runs_on_untrusted_ref":                      untrustedRef,
+		"runs_fork_mr_in_parent":                     hasMergeRequestTrigger(triggers) && mBool(proj, "fork_pipelines_run_in_parent"),
+		"reads_cicd_variable":                        referencesAnyVariable(scriptText, job) || len(mList(proj, "cicd_variables")) > 0 && scriptText != "",
+		"reads_protected_variable":                   jobReadsProtectedVar(proj, scriptText, job),
+		"mints_id_token":                             mintsIDToken(job),
+		"id_token_aud":                               idTokenAuds(job),
+		"deploys_environment":                        deploysEnv,
+		"environment_name":                           strOrNil(envName),
+		"attacker_input_fields":                      toSet(attackerFields),
+		"script_uses_untrusted_input":                len(attackerFields) > 0,
+		"includes":                                   jc.includes,
+		"remote_include_untrusted_host":              jc.incFlags.remoteUntrustedHost,
+		"remote_include_cleartext":                   jc.incFlags.remoteCleartext,
+		"mutable_cross_trust_project_include":        jc.incFlags.mutableCrossTrust,
+		"mutable_component_version":                  jc.incFlags.mutableComponent,
+		"include_ref_interpolated":                   jc.incFlags.refInterpolated,
+		"include_bare_ref_shadowable":                jc.incFlags.bareRefShadowable,
+		"cross_project_needs":                        cross,
+		"produces_dotenv":                            producesDotenv(job),
+		"consumes_dotenv":                            consumesDotenv(job, producers),
+		"cache":                                      cacheEntries(job),
+		"artifact_paths":                             artifactPaths(job),
+		"publishes_pages":                            isPagesJob(name, job),
+		"image_ref":                                  strOrNil(imgRef),
+		"image_from_variable":                        imageFromVariable(imgRef),
+		"image_pinned_digest":                        imagePinnedDigest(imgRef),
+		"image_from_registry_mutable_tag":            imageMutableTag(imgRef),
+		"job_token_cross_project_use":                jobTokenCrossProjectUse(scriptText),
+		"runner_tags":                                toSet(strListOf(tags)),
+		"protected_ref_gate":                         gate,
+		"runs_on_protected_ref":                      gate != "none",
+		"mr_pipelines_unprotected":                   !mBool(proj, "mr_pipelines_protected"),
+		"runs_on_merged_result":                      mBool(proj, "merged_results_pipelines"),
+		"consumes_cross_pipeline_artifact":           consumesCrossPipelineArtifact(job),
+		"fetches_cross_project_artifact":             fetchesCrossProjectArtifact(job, scriptText),
+		"dotenv_inheritance_unnarrowed":              dotenvInheritanceUnnarrowed(job),
+		"artifact_source_ref_mutable":                artifactSourceRefMutable(job),
+		"executes_fetched_artifact":                  executesFetchedArtifact(scriptText),
+		"artifact_integrity_checked":                 artifactIntegrityChecked(scriptText),
+		"dotenv_content_attacker_influenced":         dotenvContentAttackerInfluenced(job),
+		"cache_policy_writes":                        cachePolicyWrites(job),
+		"cache_key_static_cross_boundary":            cacheKeyStaticCrossBoundary(job),
+		"cache_separation_enabled":                   mBool(proj, "cache_separation_enabled"),
+		"artifacts_access_unrestricted":              artifactsAccessUnrestricted(job),
+		"reuses_ondisk_checkout":                     reusesOnDiskCheckout(job, jc.globalVars),
+		"downloads_secure_file":                      downloadsSecureFile(scriptText),
+		"artifact_paths_broad":                       artifactPathsBroad(job),
+		"installs_gitlab_registry_package":           installsRegistryPackage(scriptText),
+		"environment_name_interpolated":              deploysEnv && environmentNameInterpolated(envName),
+		"outbound_job_token_broad":                   jobTokenBroad(proj),
+		"child_pipeline_from_cross_project_artifact": childPipelineFromCrossProjectArtifact(job, crossNeedJobs),
+		"remote_step_untrusted_ref":                  remoteStepUntrustedRef(job),
+		"cache_key_files_attacker_writable":          cacheKeyFilesAttackerWritable(job),
+		"cache_paths_executable":                     cachePathsExecutable(job),
+		"dotenv_content_from_untrusted_source":       dotenvContentFromUntrustedSource(job),
+		"package_version_mutable_range":              packageVersionMutableRange(scriptText),
+		"package_version_checksum_verified":          packageVersionChecksumVerified(scriptText),
+		"_provenance":                                jobProvenance(p.FullPath),
+	}
+
+	// Runner reachability folds (cat-01/08): the project's runner posture drives
+	// which runner class this job can land on.
+	rec["targets_self_managed_runner"] = mBool(proj, "has_self_managed_runner")
+	rec["targets_protected_runner"] = mBool(proj, "has_protected_self_managed_runner")
+
+	// Secret / OIDC / Pages / Duo effective folds.
+	rec["env_scoped_secret_reachable"] = deploysEnv && envScopedSecretReachable(proj, envName)
+	rec["sub_claim_omits_ref"] = subClaimOmitsRef(proj)
+	rec["non_member_readable_pipelines"] = nonMemberReadablePipelines(proj)
+	rec["pages_public"] = isPagesJob(name, job) && mStr(proj, "pages_access_level") == "public"
+	rec["pages_references_secret_variable"] = isPagesJob(name, job) && pagesReferencesSecret(job, proj)
+	rec["source_ci_writable_by_lower_trust"] = sourceCIWritable(proj, gate)
+	rec["developer_controls_mr_branches"] = mBool(proj, "developer_writable_protected_branch")
+	rec["runs_on_cross_trust_shared_runner"] = mBool(proj, "has_self_managed_runner") && untrustedRef
+
+	// Cross-project artifact consumer folds (cat-09): the producer-project trust
+	// posture that gates the fetch is resolved by the cross-project-artifact join;
+	// the literal fields the job carries are its own consumer-side signals plus a
+	// conservative default for the source-side (join refines them).
+	rec["on_consumer_job_token_allowlist"] = false
+	rec["source_ref_developer_pushable"] = artifactSourceRefMutable(job)
+	rec["artifact_source_visibility"] = nil
+	rec["upstream_pipeline_untrusted_ref_reachable"] = consumesCrossPipelineArtifact(job)
+
+	// Registry / package protection folds (cat-09): the covering-rule and
+	// default-permission checks the join resolves against the source project;
+	// carried on the job so the rule reads a literal. Absent covering rule / broad
+	// default is the vulnerable state, so these default to the conservative value.
+	rec["registry_tag_protection_covers_consumed_tag"] = registryTagCovers(proj)
+	rec["registry_push_reachable_by_developer"] = mBool(proj, "developer_writable_protected_branch") || mBool(proj, "has_developer_pushable_unprotected_ref")
+	rec["package_protection_covers_consumed_name"] = len(mList(proj, "registry_protection_rules")) > 0
+	rec["package_publish_reachable_by_developer"] = mBool(proj, "has_developer_pushable_unprotected_ref")
+	rec["write_registry_token_reachable_low_trust"] = writeRegistryTokenLowTrust(proj)
+
+	// Consumer inheritance / collision folds (cat-09 dotenv variable shadowing).
+	rec["inherited_var_in_exec_sink"] = inheritedVarInExecSink(job, scriptText, imgRef)
+	declared := declaredVarKeys(job, jc.globalVars)
+	collides, inSink := dotenvCollision(producers, name, job, declared, scriptText, imgRef)
+	rec["dotenv_key_collides_declared_var"] = collides
+	rec["colliding_var_in_exec_sink"] = inSink
+
+	// Duo folds (cat-13): flow context/scope/autonomy + group/instance governance.
+	duoFlow := isDuoFlow(job, jc)
+	rec["is_duo_flow"] = duoFlow
+	rec["duo_flow_context_sources"] = duoFlowContextSources(duoFlow, jc)
+	rec["duo_flow_secrets_in_scope"] = duoFlow && duoFlowSecretsInScope(proj)
+	rec["duo_flow_autonomous_write"] = duoFlow && duoFlowAutonomousWrite(jc.duoAgent)
+	rec["duo_mcp_endpoint_untrusted_host"] = duoMCPUntrustedHost(jc)
+	rec["duo_external_agent_untrusted_host"] = duoExternalAgentUntrustedHost(jc)
+	rec["duo_group_features_enabled"] = mGet(jc.group, "duo_features_enabled")
+	rec["duo_guardrail_level"] = mGet(jc.group, "prompt_injection_protection_level")
+	rec["duo_instance_features_enabled"] = mGet(jc.instance, "duo_features_enabled")
+	rec["duo_instance_guardrail_level"] = mGet(jc.instance, "prompt_injection_protection_level")
+	rec["duo_workflow_mcp_enabled"] = mGet(jc.group, "duo_workflow_mcp_enabled")
+
+	return rec
+}
+
+func jobID(project, name string) string { return project + ":" + name }
+func jobProvenance(project string) []provenance {
+	return []provenance{{"config_file": ".gitlab-ci.yml", "project_path": project}}
+}
+
+// toSet returns a stable, deduplicated slice for a set-typed field, always [] not
+// nil (contract C1).
+func toSet(items []string) []any {
+	seen := map[string]bool{}
+	out := []any{}
+	for _, s := range items {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func strListOf(list []any) []string {
+	out := make([]string, 0, len(list))
+	for _, v := range list {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// referencesAnyVariable reports whether the job references a $VAR or declares
+// variables:, i.e. exposes ≥1 CI/CD variable to its script/env.
+func referencesAnyVariable(scriptText string, job map[string]any) bool {
+	if strings.Contains(scriptText, "$") {
+		return true
+	}
+	return entMap(job["variables"]) != nil
+}
+
+// jobReadsProtectedVar reports a protected variable is reachable by the job: the
+// project has a protected cicd_variable and the job references a variable.
+func jobReadsProtectedVar(proj map[string]any, scriptText string, job map[string]any) bool {
+	if !referencesAnyVariable(scriptText, job) {
+		return false
+	}
+	for _, v := range mList(proj, "cicd_variables") {
+		if mBool(entMap(v), "protected") {
+			return true
+		}
+	}
+	return false
+}
+
+func envScopedSecretReachable(proj map[string]any, envName string) bool {
+	for _, raw := range mList(proj, "cicd_variables") {
+		v := entMap(raw)
+		if mBool(v, "protected") {
+			continue
+		}
+		scope := mStr(v, "environment_scope")
+		if scope == "*" || scope == "" || globMatch(scope, envName) || scope == envName {
+			return true
+		}
+	}
+	return false
+}
+
+func subClaimOmitsRef(proj map[string]any) bool {
+	comps := strListOf(mList(entMap(mGet(proj, "oidc")), "sub_claim_components"))
+	if len(comps) == 0 {
+		return false // default includes ref
+	}
+	for _, c := range comps {
+		if c == "ref" || c == "ref_type" {
+			return false
+		}
+	}
+	return true
+}
+
+func nonMemberReadablePipelines(proj map[string]any) bool {
+	vis := mStr(proj, "visibility")
+	return (vis == "public" || vis == "internal") && mBool(proj, "public_pipelines")
+}
+
+func pagesReferencesSecret(job, proj map[string]any) bool {
+	refs := map[string]bool{}
+	for k := range entMap(job["variables"]) {
+		refs[k] = true
+	}
+	for _, s := range asStrList(entGetIn(job, "secrets")) {
+		refs[s] = true
+	}
+	for _, raw := range mList(proj, "cicd_variables") {
+		v := entMap(raw)
+		if !mBool(v, "protected") && !mBool(v, "masked") {
+			continue
+		}
+		if refs[mStr(v, "key")] {
+			return true
+		}
+	}
+	return false
+}
+
+// sourceCIWritable reports the executed CI config / ref is writable by a
+// lower-trust member: the job is not gated to a protected ref and the project has
+// a developer-pushable unprotected ref (or a developer-writable protected branch).
+func sourceCIWritable(proj map[string]any, gate string) bool {
+	if gate == "strong" {
+		return false
+	}
+	return mBool(proj, "has_developer_pushable_unprotected_ref") || mBool(proj, "developer_writable_protected_branch")
+}
+
+func jobTokenBroad(proj map[string]any) bool {
+	if !mBool(proj, "inbound_job_token_scope_enabled") {
+		return true
+	}
+	allow := mMap(proj, "job_token_allowlist")
+	return mStr(allow, "mode") == "open" || mStr(allow, "mode") == "disabled"
+}
+
+// isDuoFlow reports the job runs a Duo flow/agent in CI: the project has Duo
+// config present (folded onto the project record) and the job wires it.
+func isDuoFlow(job map[string]any, jc jobContext) bool {
+	duo := mMap(jc.project, "duo")
+	if !mBool(duo, "config_present") {
+		return false
+	}
+	scriptText := jobScriptText(job)
+	return strings.Contains(scriptText, "duo") || strings.Contains(scriptText, "glab duo") ||
+		len(mList(duo, "flows")) > 0
+}
+
+func registryTagCovers(proj map[string]any) bool {
+	for _, raw := range mList(proj, "registry_protection_rules") {
+		if entStr(entMap(raw)["tag_name_pattern"]) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeRegistryTokenLowTrust(proj map[string]any) bool {
+	return mBool(proj, "has_developer_reachable_secret")
+}
+
+// inheritedVarInExecSink: the consumer references any $VAR in an execution
+// sink (image:, script command). Without dotenv/global-var provenance on disk the
+// conservative literal is: a variable reaches a sink. The join narrows to the
+// inherited-only case.
+func inheritedVarInExecSink(job map[string]any, scriptText, imgRef string) bool {
+	return imageFromVariable(imgRef) || reCmdSubst.MatchString(scriptText)
+}
+
+// declaredVarKeys returns the union of the job-level and global variables: keys.
+func declaredVarKeys(job, globalVars map[string]any) map[string]bool {
+	out := map[string]bool{}
+	for k := range entMap(job["variables"]) {
+		out[k] = true
+	}
+	for k := range globalVars {
+		out[k] = true
+	}
+	return out
+}
+
+// dotenvCollision reports whether a reachable dotenv producer emits a key that
+// collides with a variable the consumer declares, and whether that colliding key
+// is used in an exec sink.
+func dotenvCollision(producers map[string]bool, name string, job map[string]any, declared map[string]bool, scriptText, imgRef string) (bool, bool) {
+	if len(declared) == 0 || !consumesDotenv(job, producers) {
+		return false, false
+	}
+	// Producer dotenv keys are not resolvable from the entrypoint alone (producer
+	// may be another project); a same-pipeline producer's keys collide when the
+	// consumer declares a key the producer could emit. Conservatively: a collision
+	// exists when the consumer declares a variable AND consumes dotenv.
+	collides := true
+	inSink := false
+	for k := range declared {
+		if strings.Contains(scriptText, "$"+k) || strings.Contains(scriptText, "${"+k+"}") || strings.Contains(imgRef, "$"+k) {
+			inSink = true
+			break
+		}
+	}
+	return collides, inSink
+}
+
+// ---- Duo flow signals (cat-13) ----
+
+func duoFlowContextSources(duoFlow bool, jc jobContext) []any {
+	out := []any{}
+	if !duoFlow {
+		return out
+	}
+	vis := mStr(jc.project, "visibility")
+	if vis == "public" || vis == "internal" || mBool(jc.project, "forking_enabled") {
+		out = append(out, "fork_mr")
+	}
+	out = append(out, "issue_comment")
+	return out
+}
+
+func duoFlowSecretsInScope(proj map[string]any) bool {
+	for _, raw := range mList(proj, "cicd_variables") {
+		if !mBool(entMap(raw), "protected") {
+			return true
+		}
+	}
+	return false
+}
+
+var reDuoWriteAction = regexp.MustCompile(`(?i)post_comment|create_merge_request|push|call_api|write|commit`)
+
+func duoFlowAutonomousWrite(agentCfg []byte) bool {
+	if agentCfg == nil {
+		return false
+	}
+	s := string(agentCfg)
+	if !reDuoWriteAction.MatchString(s) {
+		return false
+	}
+	return !strings.Contains(strings.ToLower(s), "approval") && !strings.Contains(strings.ToLower(s), "human")
+}
+
+func duoMCPUntrustedHost(jc jobContext) bool {
+	endpoint := entStr(mGet(mMap(jc.project, "duo"), "mcp_endpoint"))
+	if endpoint == "" {
+		return false
+	}
+	host := hostOf(endpoint)
+	return host != "" && host != jc.selfHost && !strings.HasSuffix(host, "."+jc.namespace)
+}
+
+var reAgentEndpoint = regexp.MustCompile(`(?i)endpoint\s*:\s*["']?(https?://[^\s"']+)`)
+
+func duoExternalAgentUntrustedHost(jc jobContext) bool {
+	for _, m := range reAgentEndpoint.FindAllStringSubmatch(string(jc.duoAgent), -1) {
+		host := hostOf(m[1])
+		if host != "" && host != jc.selfHost {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gitlab/normalize_job_test.go
+++ b/internal/gitlab/normalize_job_test.go
@@ -1,0 +1,314 @@
+package gitlab
+
+import (
+	"slices"
+	"testing"
+)
+
+func parseJob(t *testing.T, yaml string) map[string]any {
+	t.Helper()
+	p, err := parseCIPipeline([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return p
+}
+
+func TestParseCIPipelineSpecHeader(t *testing.T) {
+	// A spec: header document precedes ---; the pipeline is the second document.
+	p := parseJob(t, "spec:\n  inputs:\n    version:\n      default: latest\n---\ndeploy:\n  script:\n    - ./release.sh $[[ inputs.version ]]\n")
+	names := jobNames(p)
+	if !slices.Equal(names, []string{"deploy"}) {
+		t.Fatalf("jobNames=%v want [deploy]", names)
+	}
+}
+
+func TestParseCIPipelineCommentOnlyIsEmpty(t *testing.T) {
+	p, err := parseCIPipeline([]byte("# only a comment\n"))
+	if err != nil || p != nil {
+		t.Fatalf("comment-only should be (nil,nil); got p=%v err=%v", p, err)
+	}
+}
+
+func TestJobNamesFiltersReservedAndHidden(t *testing.T) {
+	p := parseJob(t, "variables:\n  X: 1\nstages: [build]\n.hidden:\n  script: [x]\nbuild:\n  script: [y]\npages:\n  script: [z]\n")
+	names := jobNames(p)
+	slices.Sort(names)
+	if !slices.Equal(names, []string{"build", "pages"}) {
+		t.Fatalf("jobNames=%v want [build pages] (pages is a real job, .hidden/variables/stages excluded)", names)
+	}
+}
+
+func TestResolveTriggersMergeRequestOnly(t *testing.T) {
+	// A rule pinning $CI_PIPELINE_SOURCE == "merge_request_event" narrows the set.
+	p := parseJob(t, "test:\n  script: [x]\n  rules:\n    - if: '$CI_PIPELINE_SOURCE == \"merge_request_event\"'\n")
+	tr := resolveTriggers(entMap(p["test"]), nil)
+	if !slices.Equal(tr, []string{"merge_request_event"}) {
+		t.Fatalf("triggers=%v want [merge_request_event]", tr)
+	}
+}
+
+func TestResolveTriggersUnconstrainedIsBroad(t *testing.T) {
+	// A ref-name rule does not constrain the pipeline source: broad reachability.
+	p := parseJob(t, "test:\n  script: [x]\n  rules:\n    - if: '$CI_COMMIT_BRANCH == \"main\"'\n")
+	tr := resolveTriggers(entMap(p["test"]), nil)
+	if !hasMergeRequestTrigger(tr) || len(tr) != len(allTriggers) {
+		t.Fatalf("triggers=%v want full set", tr)
+	}
+}
+
+func TestProtectedRefGate(t *testing.T) {
+	cases := []struct {
+		name, yaml, want string
+	}{
+		{"strong", "j:\n  script: [x]\n  rules:\n    - if: '$CI_COMMIT_REF_PROTECTED == \"true\"'\n", "strong"},
+		{"weak-default", "j:\n  script: [x]\n  rules:\n    - if: '$CI_COMMIT_REF_NAME == \"main\"'\n", "weak"},
+		{"weak-tag", "j:\n  script: [x]\n  rules:\n    - if: '$CI_COMMIT_TAG'\n", "weak"},
+		{"none", "j:\n  script: [x]\n", "none"},
+		{"none-feature", "j:\n  script: [x]\n  rules:\n    - if: '$CI_COMMIT_BRANCH =~ /^deploy/'\n", "none"},
+	}
+	for _, c := range cases {
+		p := parseJob(t, c.yaml)
+		if got := protectedRefGate(entMap(p["j"]), nil); got != c.want {
+			t.Errorf("%s: gate=%q want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRunsOnUntrustedRef(t *testing.T) {
+	if runsOnUntrustedRef([]string{"push"}, "strong") {
+		t.Error("strong gate must not be untrusted-ref reachable")
+	}
+	if !runsOnUntrustedRef([]string{"merge_request_event"}, "none") {
+		t.Error("MR-event with no gate must be untrusted-ref reachable")
+	}
+	if runsOnUntrustedRef([]string{"push"}, "weak") {
+		t.Error("weak gate (protected branch pin) is not untrusted")
+	}
+}
+
+func TestClassifyIncludesRemoteUntrusted(t *testing.T) {
+	inc, f := classifyIncludes([]any{
+		map[string]any{"remote": "https://vendor.example.com/build.yml"},
+	}, "gitlab.example.org", "trajan-fr-group")
+	if len(inc) != 1 {
+		t.Fatalf("want 1 include, got %d", len(inc))
+	}
+	tup := inc[0].(map[string]any)
+	if tup["type"] != "remote" || tup["cross_trust"] != true {
+		t.Errorf("remote from foreign host must be cross_trust: %v", tup)
+	}
+	if !f.remoteUntrustedHost {
+		t.Error("unpinned foreign remote must flag remoteUntrustedHost")
+	}
+}
+
+func TestClassifyIncludesRemoteCleartext(t *testing.T) {
+	_, f := classifyIncludes([]any{
+		map[string]any{"remote": "http://vendor.example.com/build.yml"},
+	}, "gitlab.example.org", "ns")
+	if !f.remoteCleartext {
+		t.Error("http:// remote with no integrity must flag cleartext")
+	}
+}
+
+func TestClassifyIncludesProjectMutableCrossTrust(t *testing.T) {
+	// A project include at a branch ref (main) in a different namespace is mutable
+	// cross-trust; a pinned SHA is not.
+	_, mutable := classifyIncludes([]any{
+		map[string]any{"project": "shared/ci-templates", "ref": "main", "file": "/x.yml"},
+	}, "gitlab.example.org", "trajan-fr-group")
+	if !mutable.mutableCrossTrust {
+		t.Error("branch ref in foreign namespace must flag mutableCrossTrust")
+	}
+	_, pinned := classifyIncludes([]any{
+		map[string]any{"project": "shared/ci-templates", "ref": "0123456789abcdef0123456789abcdef01234567", "file": "/x.yml"},
+	}, "gitlab.example.org", "trajan-fr-group")
+	if pinned.mutableCrossTrust {
+		t.Error("40-hex SHA ref must not be mutable")
+	}
+}
+
+func TestIsPinnedRef(t *testing.T) {
+	if !isPinnedRef("0123456789abcdef0123456789abcdef01234567") {
+		t.Error("40-hex is pinned")
+	}
+	if !isPinnedRef("v1.2.3") {
+		t.Error("semver tag is pinned")
+	}
+	if isPinnedRef("main") || isPinnedRef("~latest") || isPinnedRef("") {
+		t.Error("branch/moving/empty ref is mutable")
+	}
+}
+
+func TestDotenvProducerAndContent(t *testing.T) {
+	p := parseJob(t, "build_env:\n  script:\n    - echo \"API_TOKEN=$(get-token)\" > deploy.env\n  artifacts:\n    reports:\n      dotenv: deploy.env\n")
+	job := entMap(p["build_env"])
+	if !producesDotenv(job) {
+		t.Error("artifacts:reports:dotenv must produce dotenv")
+	}
+	if !dotenvContentAttackerInfluenced(job) {
+		t.Error("command substitution into .env is attacker-influenced")
+	}
+}
+
+func TestConsumesDotenv(t *testing.T) {
+	p := parseJob(t, "producer:\n  script: [x]\n  artifacts: {reports: {dotenv: a.env}}\nconsumer:\n  needs: [producer]\n  script: [y]\n")
+	producers := dotenvProducers(p)
+	if !consumesDotenv(entMap(p["consumer"]), producers) {
+		t.Error("needs: a dotenv producer must consume dotenv")
+	}
+	if consumesDotenv(entMap(p["producer"]), producers) {
+		t.Error("producer with no needs does not consume")
+	}
+}
+
+func TestDotenvInheritanceNarrowing(t *testing.T) {
+	p := parseJob(t, "a:\n  needs: [x]\n  dependencies: []\n  script: [y]\nb:\n  needs: [x]\n  script: [y]\n")
+	if dotenvInheritanceUnnarrowed(entMap(p["a"])) {
+		t.Error("dependencies: [] narrows inheritance")
+	}
+	if !dotenvInheritanceUnnarrowed(entMap(p["b"])) {
+		t.Error("no narrowing directive is unnarrowed")
+	}
+}
+
+func TestCacheKeyStaticCrossBoundary(t *testing.T) {
+	static := parseJob(t, "j:\n  cache:\n    key: global-cache\n    paths: [node_modules/]\n  script: [x]\n")
+	if !cacheKeyStaticCrossBoundary(entMap(static["j"])) {
+		t.Error("a static literal key collides across the boundary")
+	}
+	scoped := parseJob(t, "j:\n  cache:\n    key: $CI_COMMIT_REF_SLUG\n    paths: [node_modules/]\n  script: [x]\n")
+	if cacheKeyStaticCrossBoundary(entMap(scoped["j"])) {
+		t.Error("a ref-slug key is per-ref, not cross-boundary")
+	}
+	files := parseJob(t, "j:\n  cache:\n    key: {files: [package-lock.json]}\n    paths: [node_modules/]\n  script: [x]\n")
+	if cacheKeyStaticCrossBoundary(entMap(files["j"])) {
+		t.Error("a content-addressed key is not the static case")
+	}
+}
+
+func TestImageMutableTag(t *testing.T) {
+	if !imageMutableTag("node:latest") {
+		t.Error("latest is mutable")
+	}
+	if !imageMutableTag("registry/app") {
+		t.Error("no tag defaults to latest (mutable)")
+	}
+	if imageMutableTag("node@sha256:" + repeat("a", 64)) {
+		t.Error("digest-pinned is immutable")
+	}
+	if imageMutableTag("$IMAGE") {
+		t.Error("variable image is classified by image_from_variable, not mutable-tag")
+	}
+	if imageMutableTag("node:20.1.0") {
+		t.Error("a fixed semantic version tag is not mutable")
+	}
+}
+
+func repeat(s string, n int) string {
+	out := ""
+	for range n {
+		out += s
+	}
+	return out
+}
+
+func TestJobTokenCrossProjectUse(t *testing.T) {
+	cases := map[string]string{
+		"git push https://gitlab-ci-token:$CI_JOB_TOKEN@host/repo.git":      "git_push",
+		"curl --header \"JOB-TOKEN: $CI_JOB_TOKEN\" $URL/terraform/state/x": "terraform_state",
+		"curl --header \"JOB-TOKEN: $CI_JOB_TOKEN\" $URL/packages":          "read",
+		"echo hello": "none",
+	}
+	for script, want := range cases {
+		if got := jobTokenCrossProjectUse(script); got != want {
+			t.Errorf("script %q: use=%q want %q", script, got, want)
+		}
+	}
+}
+
+func TestAttackerInputFields(t *testing.T) {
+	got := attackerInputFields("echo $CI_MERGE_REQUEST_TITLE; git checkout $CI_COMMIT_REF_NAME; run $[[ inputs.x ]]")
+	slices.Sort(got)
+	want := []string{"component_input", "mr_metadata", "ref_name"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("attacker fields=%v want %v", got, want)
+	}
+	if len(attackerInputFields("echo hello")) != 0 {
+		t.Error("constant script has no attacker input")
+	}
+}
+
+func TestCrossProjectNeeds(t *testing.T) {
+	p := parseJob(t, "generate:\n  needs:\n    - {project: shared/manifests, job: publish, ref: main, artifacts: true}\n    - build\n  script: [x]\n")
+	cross := crossProjectNeeds(entMap(p["generate"]))
+	if len(cross) != 1 {
+		t.Fatalf("want 1 cross-project need (bare 'build' excluded), got %d", len(cross))
+	}
+	n := cross[0].(map[string]any)
+	if n["project"] != "shared/manifests" || n["artifacts"] != true {
+		t.Errorf("cross need=%v", n)
+	}
+	if !artifactSourceRefMutable(entMap(p["generate"])) {
+		t.Error("ref: main is a mutable branch")
+	}
+}
+
+func TestReusesOnDiskCheckout(t *testing.T) {
+	p := parseJob(t, "j:\n  variables:\n    GIT_STRATEGY: fetch\n  script: [x]\n")
+	if !reusesOnDiskCheckout(entMap(p["j"]), nil) {
+		t.Error("GIT_STRATEGY: fetch reuses on-disk state")
+	}
+	clean := parseJob(t, "j:\n  script: [x]\n")
+	if reusesOnDiskCheckout(entMap(clean["j"]), nil) {
+		t.Error("default clone is a clean checkout")
+	}
+}
+
+func TestChildPipelineFromCrossProjectArtifact(t *testing.T) {
+	p := parseJob(t, "generate:\n  needs:\n    - {project: shared/x, job: publish, ref: main, artifacts: true}\n  artifacts: {paths: [out.yml]}\n  script: [x]\nrun-children:\n  trigger:\n    include:\n      - {artifact: out.yml, job: generate}\n")
+	crossJobs := crossNeedJobNames(p, nil)
+	if !childPipelineFromCrossProjectArtifact(entMap(p["run-children"]), crossJobs) {
+		t.Error("trigger:include:artifact from a cross-project-needs generator must fire")
+	}
+	if childPipelineFromCrossProjectArtifact(entMap(p["generate"]), crossJobs) {
+		t.Error("the generator itself does not trigger a child pipeline")
+	}
+}
+
+func TestCachePathsExecutable(t *testing.T) {
+	exec := parseJob(t, "j:\n  cache: {paths: [node_modules/], key: k}\n  script: [x]\n")
+	if !cachePathsExecutable(entMap(exec["j"])) {
+		t.Error("node_modules/ is an executable dependency dir")
+	}
+	inert := parseJob(t, "j:\n  cache: {paths: [reports/], key: k}\n  script: [x]\n")
+	if cachePathsExecutable(entMap(inert["j"])) {
+		t.Error("reports/ is inert data")
+	}
+}
+
+func TestDuoFlowAutonomousWrite(t *testing.T) {
+	if !duoFlowAutonomousWrite([]byte("tools:\n  - post_comment\n  - push\n")) {
+		t.Error("write tools with no approval gate is autonomous")
+	}
+	if duoFlowAutonomousWrite([]byte("tools:\n  - post_comment\napproval: required\n")) {
+		t.Error("an approval gate is not autonomous")
+	}
+	if duoFlowAutonomousWrite(nil) {
+		t.Error("absent config is not autonomous")
+	}
+}
+
+func TestMergeDefault(t *testing.T) {
+	// default: image applies to a job that does not set image; job image wins.
+	def := map[string]any{"image": "default:1", "tags": []any{"shared"}}
+	job := map[string]any{"image": "override:1", "script": []any{"x"}}
+	m := mergeDefault(job, def)
+	if imageRef(m) != "override:1" {
+		t.Errorf("job image must override default, got %q", imageRef(m))
+	}
+	if len(runnerTags(m)) != 1 {
+		t.Error("default tags must apply when the job sets none")
+	}
+}

--- a/internal/gitlab/normalize_mirror_test.go
+++ b/internal/gitlab/normalize_mirror_test.go
@@ -1,0 +1,125 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+// Pull mirroring is a project-detail attribute (mirror==true + import_url), not a
+// /remote_mirrors entry. The firing range's pull-only cat-14 fixtures have an
+// empty remote_mirrors surface, so a normalizer that keyed off it emitted no
+// pull_mirror record and the whole cat-14 mirror.* fold surface went missing.
+// Fixture inputs below are the ground-truth cat-14-v05/v07 scenarios.
+func TestPullMirrorRec(t *testing.T) {
+	writeEnv := func(t *testing.T, prior engine.PriorPhase, rel string, data any) {
+		t.Helper()
+		if err := engine.WriteJSON(prior.Abs(rel), map[string]any{"data": data}); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	protectedMain := []any{map[string]any{"name": "main"}}
+
+	cases := []struct {
+		name        string
+		fp          string
+		detail      map[string]any
+		protected   []any
+		projectVars []any
+		want        map[string]any
+	}{
+		{
+			// cat-14-v05: mirror confined to protected branches, default branch
+			// protected, one protected project variable.
+			name: "protected-only reaches protected var",
+			fp:   "trajan-fr-group/trjfx/c14/cat-14-v05",
+			detail: map[string]any{
+				"default_branch":                 "main",
+				"mirror":                         true,
+				"import_url":                     "https://github.com/octocat/Hello-World.git",
+				"mirror_trigger_builds":          true,
+				"only_mirror_protected_branches": true,
+				"ci_push_repository_for_job_token_allowed": false,
+			},
+			protected:   protectedMain,
+			projectVars: []any{map[string]any{"key": "PROD_DEPLOY_SECRET", "protected": true}},
+			want: map[string]any{
+				"trigger_pipelines":            true,
+				"all_branches":                 false,
+				"upstream_untrusted_host":      true,
+				"protected_default_branch":     true,
+				"reaches_protected_variable":   true,
+				"reaches_unprotected_variable": false,
+				"job_token_push_allowed":       false,
+			},
+		},
+		{
+			// cat-14-v07: mirror pulls all branches, one unprotected variable.
+			name: "all-branches reaches unprotected var",
+			fp:   "trajan-fr-group/trjfx/c14/cat-14-v07",
+			detail: map[string]any{
+				"default_branch":                 "main",
+				"mirror":                         true,
+				"import_url":                     "https://github.com/octocat/Hello-World.git",
+				"mirror_trigger_builds":          true,
+				"only_mirror_protected_branches": false,
+				"ci_push_repository_for_job_token_allowed": false,
+			},
+			protected:   protectedMain,
+			projectVars: []any{map[string]any{"key": "API_KEY", "protected": false}},
+			want: map[string]any{
+				"trigger_pipelines":            true,
+				"all_branches":                 true,
+				"upstream_untrusted_host":      true,
+				"protected_default_branch":     true,
+				"reaches_protected_variable":   false,
+				"reaches_unprotected_variable": true,
+				"job_token_push_allowed":       false,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			prior := engine.PriorPhase{RunDir: t.TempDir()}
+			writeEnv(t, prior, engine.CollectGLProtectedBranches(c.fp), c.protected)
+			writeEnv(t, prior, engine.CollectGLProjectVariables(c.fp), c.projectVars)
+
+			rec := pullMirrorRec(c.detail, prior, c.fp, false)
+
+			if got := rec["url"]; got != c.detail["import_url"] {
+				t.Errorf("url = %v, want %v", got, c.detail["import_url"])
+			}
+			m, ok := rec["mirror"].(map[string]any)
+			if !ok {
+				t.Fatalf("mirror field missing/wrong type: %T", rec["mirror"])
+			}
+			for k, want := range c.want {
+				if got := m[k]; got != want {
+					t.Errorf("mirror.%s = %v, want %v", k, got, want)
+				}
+			}
+			// C1: list field must serialize as [] not null.
+			if hdrs, ok := rec["custom_headers"].([]any); !ok || hdrs == nil {
+				t.Errorf("custom_headers = %#v, want empty non-nil list", rec["custom_headers"])
+			}
+		})
+	}
+}
+
+func TestMirrorUntrustedHost(t *testing.T) {
+	cases := []struct {
+		importURL, fp string
+		want          bool
+	}{
+		{"https://github.com/octocat/Hello-World.git", "trajan-fr-group/trjfx/c14/cat-14-v05", true},
+		{"https://gitlab.com/trajan-fr-group/upstream.git", "trajan-fr-group/trjfx/x", false},
+		{"", "trajan-fr-group/x", false},
+	}
+	for _, c := range cases {
+		if got := mirrorUntrustedHost(c.importURL, c.fp); got != c.want {
+			t.Errorf("mirrorUntrustedHost(%q,%q) = %v, want %v", c.importURL, c.fp, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Implements phase P3 (normalize) of the GitLab re-architecture. Flips the `Normalize` stub to real: reads the raw `00-collect` surfaces and emits per-subject fact records plus cross-entity chain joins under `10-normalize`, matching the binding field contract in `docs/gitlab/gitlab-normalized-fields.md` (the forward contract for the 141 rules). Mirrors the ADO/GitHub normalizer split; per-item failures route to `timer.Errors` and never abort the phase.

## Subject records (eleven types)

`jobs`, `projects`, `groups`, `instance`, `merge-requests`, `environments`, `runners`, `agents`, `credentials`, `integrations`. Each record carries `_id`, `_provenance`, and typed fields per the doc. Job records resolve `.gitlab-ci.yml` (includes expanded, `rules:`/`workflow:` evaluated) into per-job facts: triggers, attacker-input surface, sink classification, and variable/runner reachability — the GitLab analog of the GitHub job normalizer.

## Correlation joins (nine) — exact `for_each` keys

| Join | `for_each` key | Rules |
|---|---|---|
| `job-token-allowlist` | `edges` | x6 (heaviest) |
| `protected-var-reachability` | `reachable_vars` | x4 (self-resolving) |
| `dotenv-flow` | `edges` | x3 |
| `cache-keyspace` | `prefix_overlaps` | x2 |
| `cross-project-artifact` | `edges` | x1 |
| `deploy-key-reuse` | `reused_keys` | x1 |
| `agent-ci-access` | `grants` | x1 |
| `runner-reachability` | `reachable_runners` | x1 |
| `group-runner-reachability` | `reachable_runners` | x1 |

`protected-var-reachability` self-resolves: it emits only tuples where the ref/member project is in the variable's inheritance scope and the member belongs to the ref's project, so the rules stay literal-only.

## Hard-contract compliance

- **Empty lists serialize as `[]`, never null/omitted** (`valuesEqual(nil, [])` is false). Verified live: `external_status_checks` 41/41 list, `artifact_paths` 13/13, `custom_headers` 47/47, `backing_identity_breadth` 1/1 — zero nulls on any load-bearing field.
- **Numeric access levels** (Guest 10 / Reporter 20 / Developer 30 / Maintainer 40 / Owner 50); `default_membership_role` reconciled between the string enum and numeric level.
- **Duo guardrail levels** (`duo_guardrail_level` / `duo_instance_guardrail_level`) carry the GraphQL `promptInjectionProtectionLevel` UPPERCASE verbatim (`LOG_ONLY`/`NO_CHECKS`/`INTERRUPT`), not lowercased.
- **Existential member booleans** (`has_guest_member` and siblings) precomputed from member maps, since the engine's `∋` cannot express existentials.

Also promotes `docs/gitlab/gitlab-normalized-fields.md` to a git-tracked artifact under `docs/` (via a scoped `.gitignore` re-include).

## Live-CLI validation (SaaS `trajan-fr-group/trjfx`, gitlab.com)

`gitlab collect` then `gitlab normalize` end-to-end (collect soft-failed several surfaces under gitlab.com 429 rate-limiting, as designed). Normalize emitted:

```
jobs 13  projects 41  groups 1  instance 1  merge-requests 41
environments 3  runners 127  agents 0  credentials 1  integrations 47
```

All eleven subject dirs and all nine `chains/*.json` present, each carrying its exact `for_each` list key. (`agents 0` reflects the agent surfaces being 429-degraded during collect, not a normalize gap.)

## Self-hosted status

Live self-hosted validation (`trjfx` @ `3.136.153.111`, `--insecure`) is **PENDING host availability** — the host was unreachable (connection timeout) at ship time. The normalizer is host-agnostic: it reads on-disk `00-collect` output identically regardless of source, so SaaS validation exercises the same code paths.

---

Stacks on P2 collect (LAB-4287). Part of the GitLab parity re-arch.



Closes LAB-4288
