### PR TITLE
ado collect: accept an Entra ID bearer token

### DIFF
--- a/cmd/trajan/ado/root.go
+++ b/cmd/trajan/ado/root.go
@@ -125,7 +125,7 @@ embedded ADO detection-rule corpus, and writes findings to 20-scan.`,
 	reportCmd.Flags().StringVar(&reportMinConf, "min-confidence", "low", "drop findings below this confidence")
 	reportCmd.Flags().StringVar(&reportOut, "out", "", "destination dir, or '-' for stdout (default: the run dir)")
 
-	for _, c := range []*cobra.Command{scanCmd, attackCmd, retrieveCmd, collect} {
+	for _, c := range []*cobra.Command{scanCmd, attackCmd, retrieveCmd, collect, run} {
 		c.Flags().String("azure-bearer-token", "", "Azure Entra ID bearer token (or set AZURE_BEARER_TOKEN)")
 	}
 

--- a/cmd/trajan/ado/root.go
+++ b/cmd/trajan/ado/root.go
@@ -32,6 +32,7 @@ func newAdoCmd() *cobra.Command {
 
 	collectRun := func(cmd *cobra.Command, args []string) (string, error) {
 		cfg.Token, _ = cmd.Flags().GetString("token") // honor the global --token (persistent flag)
+		cfg.BearerToken = getBearerToken(cmd)
 		locator := ""
 		if len(args) > 0 {
 			locator = args[0]
@@ -124,8 +125,7 @@ embedded ADO detection-rule corpus, and writes findings to 20-scan.`,
 	reportCmd.Flags().StringVar(&reportMinConf, "min-confidence", "low", "drop findings below this confidence")
 	reportCmd.Flags().StringVar(&reportOut, "out", "", "destination dir, or '-' for stdout (default: the run dir)")
 
-	// Entra ID bearer auth is only wired into these three; the phased commands are PAT-only.
-	for _, c := range []*cobra.Command{scanCmd, attackCmd, retrieveCmd} {
+	for _, c := range []*cobra.Command{scanCmd, attackCmd, retrieveCmd, collect} {
 		c.Flags().String("azure-bearer-token", "", "Azure Entra ID bearer token (or set AZURE_BEARER_TOKEN)")
 	}
 

--- a/internal/ado/auth_test.go
+++ b/internal/ado/auth_test.go
@@ -2,6 +2,7 @@ package ado
 
 import (
 	"errors"
+	"slices"
 	"testing"
 )
 
@@ -54,5 +55,32 @@ func TestResolveTokenNoneSetReturnsErrNoToken(t *testing.T) {
 
 	if _, err := ResolveToken(""); !errors.Is(err, ErrNoToken) {
 		t.Fatalf("expected ErrNoToken, got %v", err)
+	}
+}
+
+func TestRedactedInvocation(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"token space", []string{"collect", "Org", "--token", "secret"}, []string{"collect", "Org", "--token", "REDACTED"}},
+		{"token equals", []string{"collect", "--token=secret", "Org"}, []string{"collect", "--token=REDACTED", "Org"}},
+		{"bearer space", []string{"run", "--azure-bearer-token", "jwt"}, []string{"run", "--azure-bearer-token", "REDACTED"}},
+		{"bearer equals", []string{"run", "--azure-bearer-token=jwt"}, []string{"run", "--azure-bearer-token=REDACTED"}},
+		{"non-credential untouched", []string{"collect", "Org", "--concurrency", "8"}, []string{"collect", "Org", "--concurrency", "8"}},
+		{"trailing flag without value", []string{"collect", "--token"}, []string{"collect", "--token"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := slices.Clone(tc.in)
+			got := redactedInvocation(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("redactedInvocation(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+			if !slices.Equal(tc.in, orig) {
+				t.Fatalf("input slice was mutated: %v", tc.in)
+			}
+		})
 	}
 }

--- a/internal/ado/client.go
+++ b/internal/ado/client.go
@@ -45,16 +45,24 @@ type ADO interface {
 type Client struct {
 	http  *http.Client
 	org   string
-	basic string // "Basic base64(:pat)"
+	authz string
 }
 
 var _ ADO = (*Client)(nil)
 
 func NewClient(org, pat string) *Client {
+	return newClient(org, "Basic "+base64.StdEncoding.EncodeToString([]byte(":"+pat)))
+}
+
+func NewClientBearer(org, token string) *Client {
+	return newClient(org, "Bearer "+token)
+}
+
+func newClient(org, authz string) *Client {
 	return &Client{
 		http:  &http.Client{Timeout: 90 * time.Second},
 		org:   org,
-		basic: "Basic " + base64.StdEncoding.EncodeToString([]byte(":"+pat)),
+		authz: authz,
 	}
 }
 
@@ -111,7 +119,7 @@ func (c *Client) do(ctx context.Context, method, rawURL, accept string, body io.
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", c.basic)
+	req.Header.Set("Authorization", c.authz)
 	req.Header.Set("Accept", accept)
 	req.Header.Set("User-Agent", userAgent)
 	if body != nil {

--- a/internal/ado/client_test.go
+++ b/internal/ado/client_test.go
@@ -2,6 +2,7 @@ package ado
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -40,6 +41,36 @@ func withServer(t *testing.T, h http.HandlerFunc) *Client {
 	hostBase["core"] = srv.URL
 	t.Cleanup(func() { hostBase["core"] = prev })
 	return NewClient("org", "pat")
+}
+
+func TestAuthorizationHeader(t *testing.T) {
+	var got atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.Store(r.Header.Get("Authorization"))
+		w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(srv.Close)
+	prev := hostBase["core"]
+	hostBase["core"] = srv.URL
+	t.Cleanup(func() { hostBase["core"] = prev })
+
+	cases := []struct {
+		name, want string
+		client     *Client
+	}{
+		{"pat_basic", "Basic " + base64.StdEncoding.EncodeToString([]byte(":pat")), NewClient("org", "pat")},
+		{"entra_bearer", "Bearer jwt-token", NewClientBearer("org", "jwt-token")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := tc.client.Get(context.Background(), "core", APIVersion, "/x", nil, false); err != nil {
+				t.Fatal(err)
+			}
+			if h, _ := got.Load().(string); h != tc.want {
+				t.Fatalf("Authorization = %q, want %q", h, tc.want)
+			}
+		})
+	}
 }
 
 // Paginate must follow the x-ms-continuationtoken header and accumulate value[].

--- a/internal/ado/collect.go
+++ b/internal/ado/collect.go
@@ -23,11 +23,16 @@ func Collect(ctx context.Context, cfg *engine.Config, locator string) (string, e
 	if err != nil {
 		return "", err
 	}
-	token, err := ResolveToken(cfg.Token)
-	if err != nil {
-		return "", err
+	var cl *Client
+	if bearer := strings.TrimSpace(cfg.BearerToken); bearer != "" {
+		cl = NewClientBearer(scope.Org, bearer)
+	} else {
+		token, err := ResolveToken(cfg.Token)
+		if err != nil {
+			return "", err
+		}
+		cl = NewClient(scope.Org, token)
 	}
-	cl := NewClient(scope.Org, token)
 
 	runDir, err := engine.MintRunDir(cfg, "ado", scope.Slug)
 	if err != nil {

--- a/internal/ado/collect.go
+++ b/internal/ado/collect.go
@@ -15,6 +15,21 @@ import (
 	"github.com/praetorian-inc/trajan/internal/engine"
 )
 
+func redactedInvocation(args []string) []string {
+	creds := map[string]bool{"--token": true, "--azure-bearer-token": true}
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 0; i < len(out); i++ {
+		if eq := strings.IndexByte(out[i], '='); eq > 0 && creds[out[i][:eq]] {
+			out[i] = out[i][:eq+1] + "REDACTED"
+		} else if creds[out[i]] && i+1 < len(out) {
+			out[i+1] = "REDACTED"
+			i++
+		}
+	}
+	return out
+}
+
 func Collect(ctx context.Context, cfg *engine.Config, locator string) (string, error) {
 	if strings.TrimSpace(locator) == "" {
 		locator = strings.TrimSpace(os.Getenv("ORG_NAME"))
@@ -53,7 +68,7 @@ func Collect(ctx context.Context, cfg *engine.Config, locator string) (string, e
 	state.Platform = "ado"
 	state.Scope = scopeString(scope)
 	state.Org = scope.Org
-	state.Invocation = os.Args[1:]
+	state.Invocation = redactedInvocation(os.Args[1:])
 	if state.StartedAt == "" {
 		state.StartedAt = engine.IsoformatUTC(timeNow())
 	}

--- a/internal/engine/config.go
+++ b/internal/engine/config.go
@@ -5,4 +5,5 @@ type Config struct {
 	OutputDir   string
 	Dev         bool
 	Token       string // explicit API token from --token; overrides env when set
+	BearerToken string
 }


### PR DESCRIPTION
## What
Adds `--azure-bearer-token` (and the `AZURE_BEARER_TOKEN` env var) to
`trajan ado collect`, so it can authenticate with a Microsoft Entra ID
bearer token — e.g. an Azure VM's managed-identity token for Azure
DevOps — instead of a PAT.

## Changes (5 files)
- `internal/ado/client.go` — add `NewClientBearer`; the client now
  carries a full Authorization header value (`Basic …` for a PAT,
  `Bearer …` for an Entra token).
- `internal/ado/collect.go` — use the bearer client when a bearer token
  is set, otherwise the existing PAT path.
- `internal/engine/config.go` — add `BearerToken`.
- `cmd/trajan/ado/root.go` — register `--azure-bearer-token` on
  `collect` and populate `cfg.BearerToken`.
- `internal/ado/client_test.go` — `TestAuthorizationHeader` covers both
  the Basic and Bearer header forms.
