### PR TITLE
feat: add GitHub Action scanner

### DIFF
--- a/.github/GITHUB_ACTION.md
+++ b/.github/GITHUB_ACTION.md
@@ -1,0 +1,100 @@
+# Trajan GitHub Action
+
+Trajan can run as a composite GitHub Action. It scans the selected GitHub
+repository, renders HTML, Markdown, and JSONL reports, writes a concise job
+summary, and uploads the reports as a workflow artifact.
+
+The initial implementation builds the Trajan source pinned by the Action ref and
+supports Linux runners.
+
+## Use the Action
+
+```yaml
+name: Trajan
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  trajan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan CI/CD configuration
+        uses: praetorian-inc/trajan@feat/github-action
+        with:
+          fail-on-severity: none
+```
+
+No checkout step is required in the consumer repository. Trajan reads the
+target through GitHub's APIs.
+
+During development, the value after `@` can be a branch. For a released Action,
+use a full commit SHA for the strongest immutable pin, a fixed version such as
+`v1.1.0`, or the moving compatible `v1` tag.
+
+## Expanded coverage
+
+The built-in `${{ github.token }}` covers repository source and workflows, but
+not Trajan's complete settings and organization collection. The Action marks
+`degraded=true` when Trajan records unavailable collection operations.
+
+For expanded coverage, store a fine-grained PAT as an Actions secret and pass it
+explicitly:
+
+```yaml
+      - uses: praetorian-inc/trajan@feat/github-action
+        with:
+          token: ${{ secrets.TRAJAN_TOKEN }}
+          fail-on-severity: high
+```
+
+Do not use the PAT configuration for fork-originated pull requests. GitHub does
+not expose repository secrets to those runs.
+
+## Inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `token` | `github.token` | Token used by the Trajan collector |
+| `scope` | `github.repository` | Repository (`owner/name`) or organization to scan |
+| `artifact-name` | `trajan-report` | Uploaded artifact name |
+| `retention-days` | `14` | Artifact retention period |
+| `fail-on-severity` | `none` | Fail after upload for `info`, `low`, `medium`, `high`, or `critical` findings |
+| `force-rest` | `true` | Avoid the current git transport's token-in-process-argument behavior, with reduced all-branch collection |
+
+The Action exposes report paths, artifact URL, finding count, and degraded state
+as outputs.
+
+## Testing a branch
+
+You do not need to merge the Action to `main` before testing it.
+
+From another repository, reference the branch directly:
+
+```yaml
+uses: praetorian-inc/trajan@feat/github-action
+```
+
+To test inside this repository, the `Test GitHub Action` workflow checks out the
+selected branch and invokes `uses: ./`. Open the Actions tab, select that
+workflow, choose **Run workflow**, and select the feature branch.
+
+A successful test has all of the following:
+
+1. The source build completes.
+2. Collect, normalize, and scan complete, with unavailable permissions reported
+   as degraded rather than hidden.
+3. The job summary contains severity counts.
+4. The `trajan-report` artifact contains `findings.html`, `findings.md`, and
+   `findings.jsonl`.
+5. The output step prints the finding count, degraded state, and artifact URL.
+
+The Action defaults to report-only behavior. Set `fail-on-severity: high`, for
+example, only after validating expected results; the failure is applied after
+the report artifact is uploaded.

--- a/.github/workflows/test-github-action.yml
+++ b/.github/workflows/test-github-action.yml
@@ -1,0 +1,38 @@
+name: Test GitHub Action
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - action.yml
+      - scripts/github-action/**
+      - .github/workflows/test-github-action.yml
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the Action source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Run the local Trajan Action
+        id: trajan
+        uses: ./
+        with:
+          fail-on-severity: none
+
+      - name: Show Action outputs
+        if: always()
+        shell: bash
+        env:
+          FINDING_COUNT: ${{ steps.trajan.outputs.finding-count }}
+          DEGRADED: ${{ steps.trajan.outputs.degraded }}
+          ARTIFACT_URL: ${{ steps.trajan.outputs.artifact-url }}
+        run: |
+          echo "finding-count=$FINDING_COUNT"
+          echo "degraded=$DEGRADED"
+          echo "artifact-url=$ARTIFACT_URL"

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ trajan github scan --repo owner/repo -o json > results.json
 
 For detailed usage and detection explanations, see the [Wiki](https://github.com/praetorian-inc/trajan/wiki).
 
+## GitHub Action
+
+Trajan can scan a repository from a GitHub Actions workflow and upload HTML,
+Markdown, and JSONL reports. See the [GitHub Action guide](.github/GITHUB_ACTION.md)
+for permissions, branch testing, expanded token coverage, and CI gating.
+
 ## Platform coverage
 
 | Platform | Detections | Enumerate |
@@ -227,4 +233,3 @@ Built on research from [Gato](https://github.com/praetorian-inc/gato), [Glato](h
 ## License
 
 Apache 2.0. See [LICENSE](LICENSE).
-

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,115 @@
+name: Trajan CI/CD Security Scan
+description: Scan GitHub Actions configuration with Trajan and publish HTML, Markdown, and JSONL reports.
+author: Praetorian
+
+branding:
+  icon: shield
+  color: purple
+
+inputs:
+  token:
+    description: GitHub token used by Trajan. Defaults to the current job's github.token.
+    required: false
+    default: ""
+  scope:
+    description: Repository (owner/name) or organization to scan. Defaults to github.repository.
+    required: false
+    default: ""
+  artifact-name:
+    description: Name of the uploaded report artifact.
+    required: false
+    default: trajan-report
+  retention-days:
+    description: Number of days GitHub retains the report artifact.
+    required: false
+    default: "14"
+  fail-on-severity:
+    description: Fail after report upload when this severity or higher is found (none, info, low, medium, high, critical).
+    required: false
+    default: none
+  force-rest:
+    description: Avoid putting the token in a git child-process argument. This reduces Trajan's all-branches collection.
+    required: false
+    default: "true"
+
+outputs:
+  report-dir:
+    description: Directory containing the generated reports.
+    value: ${{ steps.scan.outputs.report-dir }}
+  html-path:
+    description: Path to the self-contained HTML report.
+    value: ${{ steps.scan.outputs.html-path }}
+  markdown-path:
+    description: Path to the Markdown report.
+    value: ${{ steps.scan.outputs.markdown-path }}
+  jsonl-path:
+    description: Path to the JSONL findings.
+    value: ${{ steps.scan.outputs.jsonl-path }}
+  artifact-url:
+    description: URL of the uploaded report artifact.
+    value: ${{ steps.upload.outputs.artifact-url }}
+  finding-count:
+    description: Total number of reported findings.
+    value: ${{ steps.scan.outputs.finding-count }}
+  degraded:
+    description: Whether Trajan recorded one or more soft collection failures.
+    value: ${{ steps.scan.outputs.degraded }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      with:
+        go-version-file: ${{ github.action_path }}/go.mod
+        cache: false
+
+    - name: Build Trajan
+      shell: bash
+      run: "$GITHUB_ACTION_PATH/scripts/github-action/install.sh"
+
+    - name: Run Trajan
+      id: scan
+      continue-on-error: true
+      shell: bash
+      env:
+        TRAJAN_TOKEN: ${{ inputs.token || github.token }}
+        TRAJAN_SCOPE: ${{ inputs.scope || github.repository }}
+        FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
+        FORCE_REST: ${{ inputs.force-rest }}
+      run: "$GITHUB_ACTION_PATH/scripts/github-action/run.sh"
+
+    - name: Upload Trajan reports
+      id: upload
+      if: always() && steps.scan.outputs.report-ready == 'true'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ steps.scan.outputs.report-dir }}
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}
+
+    - name: Write Trajan job summary
+      if: always()
+      shell: bash
+      env:
+        SCAN_EXIT_CODE: ${{ steps.scan.outputs.scan-exit-code }}
+        FINDING_COUNT: ${{ steps.scan.outputs.finding-count }}
+        CRITICAL_COUNT: ${{ steps.scan.outputs.critical-count }}
+        HIGH_COUNT: ${{ steps.scan.outputs.high-count }}
+        MEDIUM_COUNT: ${{ steps.scan.outputs.medium-count }}
+        LOW_COUNT: ${{ steps.scan.outputs.low-count }}
+        INFO_COUNT: ${{ steps.scan.outputs.info-count }}
+        DEGRADED: ${{ steps.scan.outputs.degraded }}
+        SOFT_ERROR_COUNT: ${{ steps.scan.outputs.soft-error-count }}
+        ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+      run: "$GITHUB_ACTION_PATH/scripts/github-action/summary.sh"
+
+    - name: Apply Trajan failure policy
+      if: always()
+      shell: bash
+      env:
+        SCAN_EXIT_CODE: ${{ steps.scan.outputs.scan-exit-code }}
+        THRESHOLD_HIT: ${{ steps.scan.outputs.threshold-hit }}
+        FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
+      run: "$GITHUB_ACTION_PATH/scripts/github-action/gate.sh"

--- a/scripts/github-action/gate.sh
+++ b/scripts/github-action/gate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${SCAN_EXIT_CODE:-1}" != "0" ]]; then
+  echo "Trajan failed because the scan or report command encountered an operational error." >&2
+  exit 1
+fi
+
+if [[ "${THRESHOLD_HIT:-false}" == "true" ]]; then
+  echo "Trajan found at least one ${FAIL_ON_SEVERITY} or higher severity finding." >&2
+  exit 1
+fi

--- a/scripts/github-action/install.sh
+++ b/scripts/github-action/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${RUNNER_OS:-}" != "Linux" ]]; then
+  echo "The Trajan Action currently supports Linux runners only." >&2
+  exit 1
+fi
+
+install_dir="${RUNNER_TEMP:?RUNNER_TEMP is required}/trajan-bin"
+mkdir -p "$install_dir"
+
+echo "Building Trajan from the pinned Action source"
+(
+  cd "${GITHUB_ACTION_PATH:?GITHUB_ACTION_PATH is required}"
+  GOBIN="$install_dir" go install ./cmd/trajan
+)
+
+"$install_dir/trajan" version
+echo "$install_dir" >> "$GITHUB_PATH"

--- a/scripts/github-action/run.sh
+++ b/scripts/github-action/run.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+write_output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+}
+
+write_defaults() {
+  write_output report-ready false
+  write_output scan-exit-code 1
+  write_output finding-count 0
+  write_output critical-count 0
+  write_output high-count 0
+  write_output medium-count 0
+  write_output low-count 0
+  write_output info-count 0
+  write_output degraded true
+  write_output soft-error-count 0
+  write_output threshold-hit false
+}
+
+write_defaults
+
+if [[ -z "${TRAJAN_TOKEN:-}" ]]; then
+  echo "No GitHub token was provided and github.token was unavailable." >&2
+  exit 1
+fi
+
+case "${FAIL_ON_SEVERITY:-none}" in
+  none|info|low|medium|high|critical) ;;
+  *)
+    echo "fail-on-severity must be one of: none, info, low, medium, high, critical" >&2
+    exit 1
+    ;;
+esac
+
+case "${FORCE_REST:-true}" in
+  true) export TRAJAN_FORCE_REST=1 ;;
+  false) unset TRAJAN_FORCE_REST ;;
+  *)
+    echo "force-rest must be true or false" >&2
+    exit 1
+    ;;
+esac
+
+export GH_TOKEN="$TRAJAN_TOKEN"
+
+run_key="${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-${RANDOM}"
+run_root="${RUNNER_TEMP:?RUNNER_TEMP is required}/trajan-runs-${run_key}"
+report_dir="${RUNNER_TEMP}/trajan-report-${run_key}"
+mkdir -p "$run_root" "$report_dir"
+
+echo "Running Trajan against ${TRAJAN_SCOPE:?scope is required}"
+trajan --no-color github --output-dir "$run_root" run "$TRAJAN_SCOPE"
+operation_code=$?
+
+run_dir=""
+if [[ -d "$run_root" ]]; then
+  run_dir="$(find "$run_root" -mindepth 1 -maxdepth 1 -type d -name '*-gh-*' -print | sort | tail -n 1)"
+fi
+
+if [[ -n "$run_dir" ]]; then
+  write_output run-dir "$run_dir"
+fi
+write_output report-dir "$report_dir"
+write_output html-path "$report_dir/findings.html"
+write_output markdown-path "$report_dir/findings.md"
+write_output jsonl-path "$report_dir/findings.jsonl"
+
+if [[ "$operation_code" -eq 0 && -n "$run_dir" ]]; then
+  trajan --no-color github --output-dir "$run_root" report \
+    --path "$run_dir" \
+    --format all \
+    --out "$report_dir"
+  operation_code=$?
+fi
+
+report_ready=false
+if [[ -s "$report_dir/findings.html" && -f "$report_dir/findings.md" && -f "$report_dir/findings.jsonl" ]]; then
+  report_ready=true
+fi
+
+finding_count=0
+critical_count=0
+high_count=0
+medium_count=0
+low_count=0
+info_count=0
+threshold_hit=false
+
+if [[ -f "$report_dir/findings.jsonl" ]]; then
+  finding_metrics="$run_root/finding-metrics.txt"
+  if python3 - "$report_dir/findings.jsonl" "${FAIL_ON_SEVERITY:-none}" > "$finding_metrics" <<'PY'
+import json
+import sys
+
+path, threshold = sys.argv[1:]
+levels = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+counts = {level: 0 for level in levels}
+total = 0
+hit = False
+
+with open(path, encoding="utf-8") as findings:
+    for line in findings:
+        if not line.strip():
+            continue
+        finding = json.loads(line)
+        severity = str(finding.get("severity", "info")).lower()
+        if severity not in levels:
+            severity = "info"
+        counts[severity] += 1
+        total += 1
+        if threshold != "none" and levels[severity] >= levels[threshold]:
+            hit = True
+
+print(total, counts["critical"], counts["high"], counts["medium"], counts["low"], counts["info"], str(hit).lower())
+PY
+  then
+    read -r finding_count critical_count high_count medium_count low_count info_count threshold_hit < "$finding_metrics"
+  else
+    operation_code=1
+  fi
+fi
+
+degraded=false
+soft_error_count=0
+if [[ -n "$run_dir" && -f "$run_dir/_meta.json" ]]; then
+  meta_metrics="$run_root/meta-metrics.txt"
+  if python3 - "$run_dir/_meta.json" > "$meta_metrics" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as meta_file:
+    meta = json.load(meta_file)
+
+errors = sum(len(phase.get("errors") or []) for phase in meta.get("phases") or [])
+failed = any(bool(phase.get("failed")) for phase in meta.get("phases") or [])
+print(str(failed or errors > 0).lower(), errors)
+PY
+  then
+    read -r degraded soft_error_count < "$meta_metrics"
+  else
+    degraded=true
+    operation_code=1
+  fi
+elif [[ "$operation_code" -ne 0 ]]; then
+  degraded=true
+fi
+
+write_output report-ready "$report_ready"
+write_output scan-exit-code "$operation_code"
+write_output finding-count "$finding_count"
+write_output critical-count "$critical_count"
+write_output high-count "$high_count"
+write_output medium-count "$medium_count"
+write_output low-count "$low_count"
+write_output info-count "$info_count"
+write_output degraded "$degraded"
+write_output soft-error-count "$soft_error_count"
+write_output threshold-hit "$threshold_hit"
+
+if [[ "$degraded" == true ]]; then
+  echo "::warning title=Trajan scan degraded::${soft_error_count} collection or scan operations were unavailable. The report may be incomplete."
+fi
+
+exit "$operation_code"

--- a/scripts/github-action/summary.sh
+++ b/scripts/github-action/summary.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+summary="${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+scan_exit_code="${SCAN_EXIT_CODE:-1}"
+
+{
+  echo "# Trajan CI/CD security scan"
+  echo
+
+  if [[ "$scan_exit_code" == "0" ]]; then
+    echo "Trajan completed with **${FINDING_COUNT:-0} findings**."
+  else
+    echo "Trajan encountered an operational error. Review the job log."
+  fi
+
+  echo
+  echo "| Severity | Findings |"
+  echo "| :-- | --: |"
+  echo "| Critical | ${CRITICAL_COUNT:-0} |"
+  echo "| High | ${HIGH_COUNT:-0} |"
+  echo "| Medium | ${MEDIUM_COUNT:-0} |"
+  echo "| Low | ${LOW_COUNT:-0} |"
+  echo "| Info | ${INFO_COUNT:-0} |"
+  echo
+
+  if [[ "${DEGRADED:-true}" == "true" ]]; then
+    echo "> [!WARNING]"
+    echo "> This scan was degraded: ${SOFT_ERROR_COUNT:-0} operations were unavailable. A clean-looking report may be incomplete."
+    echo
+  fi
+
+  if [[ -n "${ARTIFACT_URL:-}" ]]; then
+    echo "[Download the HTML, Markdown, and JSONL reports](${ARTIFACT_URL})"
+  fi
+} >> "$summary"


### PR DESCRIPTION
## Summary

- add a root composite Action that builds the Trajan source pinned by the Action ref
- run the GitHub collect, normalize, scan, and report pipeline
- upload HTML, Markdown, and JSONL reports as a workflow artifact
- expose finding count, report paths, artifact URL, and degraded coverage state
- support optional post-upload CI failure thresholds
- document branch testing, token coverage, and expanded-token usage
- add a self-test workflow using `uses: ./`

## Security and coverage behavior

- defaults to the job `${{ github.token }}` with repository-scoped coverage
- reports soft collection failures as `degraded=true` instead of presenting a partial scan as complete
- uploads only rendered reports, not the raw collection directory
- defaults `force-rest` to true to avoid the current git transport token-in-process-argument behavior
- pins setup-go, checkout, and upload-artifact to full commit SHAs

## Validation

- shell syntax checks for all Action scripts
- YAML parsing for Action metadata and test workflow
- actionlint v1.7.12 on the new workflow
- source build and CLI command validation
- local end-to-end scan of `praetorian-inc/trajan`: 24 findings, all three reports generated, severity threshold detected, and four unavailable org/runner operations reported as degraded

## Follow-ups

- switch from source build to checksum-verified release binaries after a release containing the new `github run` and `github report` commands
- consider a dedicated `praetorian-inc/trajan-action` repository before Marketplace publication
- add SARIF as a later GitHub Security-tab integration