### PR TITLE
feat: rebuild WASM browser scanner on YAML detections

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,7 @@ project_name: trajan
 before:
   hooks:
     - go mod tidy
+    - make wasm-dist
 
 builds:
   - id: trajan
@@ -68,3 +69,5 @@ release:
   draft: false
   prerelease: auto
   name_template: "Trajan v{{.Version}}"
+  extra_files:
+    - glob: browser/trajan-standalone.html

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,17 @@ GOBUILD := CGO_ENABLED=0 $(GO) build
 # Directories
 BIN_DIR := bin
 CMD_DIR := cmd/trajan
+WASM_DIR := browser
+WASM_SRC := cmd/trajan-wasm
+
+# WASM build
+WASM_EXEC := $(shell test -f "$$(go env GOROOT)/lib/wasm/wasm_exec.js" && echo "$$(go env GOROOT)/lib/wasm/wasm_exec.js" || echo "$$(go env GOROOT)/misc/wasm/wasm_exec.js")
+WASM_LDFLAGS := -s -w -X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT) -X main.BuildTime=$(BUILD_DATE)
 
 # Safety: delete partial outputs on error
 .DELETE_ON_ERROR:
 
-.PHONY: all build test test-short test-coverage clean fmt vet lint deps help
+.PHONY: all build test test-short test-coverage clean fmt vet lint deps help wasm wasm-dist wasm-serve wasm-smoke
 
 all: build
 
@@ -41,10 +47,55 @@ test-coverage:
 	$(GOTEST) -v -race -coverprofile=coverage.out ./...
 	$(GO) tool cover -html=coverage.out -o coverage.html
 
+## wasm: Compile Go to WASM and refresh browser assets
+wasm:
+	@mkdir -p $(WASM_DIR)
+	@echo "Compiling Go to WASM..."
+	GOWORK=off GOOS=js GOARCH=wasm $(GO) build -trimpath -ldflags "$(WASM_LDFLAGS)" -o $(WASM_DIR)/trajan.wasm ./$(WASM_SRC)
+	@echo "WASM binary: $$(du -h $(WASM_DIR)/trajan.wasm | cut -f1)"
+	@test -f "$(WASM_EXEC)" || (echo "Error: wasm_exec.js not found at $(WASM_EXEC)" && exit 1)
+	cp -f "$(WASM_EXEC)" $(WASM_DIR)/wasm_exec.js
+	cp -f internal/report/assets/report.css $(WASM_DIR)/report.css
+
+## wasm-dist: Build standalone single-file HTML
+wasm-dist: wasm
+	@echo "Building standalone distribution..."
+	@cd $(WASM_DIR) && python3 -c "\
+	import base64, os; \
+	html = open('index.html').read(); \
+	report_css = open('report.css').read(); \
+	shell_css = open('shell.css').read(); \
+	css = report_css + '\n' + shell_css; \
+	wasmjs = open('wasm_exec.js').read(); \
+	fsshim = open('fs-shim.js').read(); \
+	bridgejs = open('bridge.js').read(); \
+	appjs = open('app.js').read(); \
+	wasm = base64.b64encode(open('trajan.wasm','rb').read()).decode(); \
+	html = html.replace('<link rel=\"stylesheet\" href=\"report.css\">\n<link rel=\"stylesheet\" href=\"shell.css\">', '<style>' + css + '</style>'); \
+	html = html.replace('<script src=\"fs-shim.js\"></script>', '<script>' + fsshim + '</script>'); \
+	html = html.replace('<script src=\"wasm_exec.js\"></script>', '<script>' + wasmjs + '</script>'); \
+	html = html.replace('<script src=\"bridge.js\"></script>', '<script>' + bridgejs + '</script>'); \
+	html = html.replace('<script src=\"app.js\"></script>', '<script>function _wasmDataUrl(){return \"data:application/wasm;base64,' + wasm + '\";}</script><script>' + appjs + '</script>'); \
+	open('trajan-standalone.html','w').write(html); \
+	print(f'Standalone: {os.path.getsize(\"trajan-standalone.html\") / 1048576:.1f}MB')"
+	@echo "Output: $(WASM_DIR)/trajan-standalone.html"
+
+## wasm-serve: Start local WASM dev server
+wasm-serve: wasm
+	@echo "Starting dev server at http://localhost:8080"
+	@cd $(WASM_DIR) && $(GO) run server.go
+
+## wasm-smoke: Exercise fs shim + WASM init + fixture scan/report
+wasm-smoke: wasm
+	node $(WASM_DIR)/smoke-fs.mjs
+	node $(WASM_DIR)/smoke-wasm.mjs
+	node $(WASM_DIR)/smoke-pipeline.mjs
+
 ## clean: Remove build artifacts
 clean:
 	rm -rf $(BIN_DIR)
 	rm -f coverage.out coverage.html
+	rm -f $(WASM_DIR)/trajan.wasm $(WASM_DIR)/wasm_exec.js $(WASM_DIR)/trajan-standalone.html
 
 ## fmt: Format Go code
 fmt:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ git clone https://github.com/praetorian-inc/trajan.git
 cd trajan && make build   # writes ./bin/trajan
 ```
 
+### Browser (WASM)
+
+```sh
+make wasm-serve   # http://localhost:8080
+```
+
+Runs collect → normalize → scan in the browser and renders the same HTML report as the CLI. Attack and graph are not included. See [browser/README.md](browser/README.md).
+
 ## Usage
 
 ### Credentials

--- a/browser/README.md
+++ b/browser/README.md
@@ -1,0 +1,60 @@
+# Trajan browser (WASM) scanner
+
+Runs Trajan's YAML detection pipeline (collect → normalize → scan → HTML report)
+entirely in the browser. Attack and graph are not included.
+
+## Build
+
+From the repo root:
+
+```sh
+make wasm          # browser/trajan.wasm + wasm_exec.js + report.css
+make wasm-serve    # http://localhost:8080
+make wasm-dist     # browser/trajan-standalone.html (single file)
+```
+
+## Usage
+
+1. Open the UI.
+2. Choose GitHub, GitLab, or Azure DevOps.
+3. Enter a locator (`org/repo`, group, `org/project`, or HTTPS URL) and a token.
+4. Run scan. Findings render in the same HTML report used by the CLI and GitHub Action.
+
+Tokens stay in memory for the page session. They are not written to `localStorage`.
+
+## CORS
+
+Cloud GitHub, GitLab, and Azure DevOps generally allow browser `Authorization` via CORS
+(verified against all six Azure DevOps `hostBase` hosts: `dev.azure.com`,
+`vsrm`, `feeds`, `extmgmt`, `vssps`, `almsearch`). The default build does **not**
+require a proxy.
+
+If a host blocks you (common for self-hosted GitLab):
+
+```sh
+TRAJAN_WASM_PROXY=1 make wasm-serve
+```
+
+Then point requests through `/azdo-proxy/{host}/...` or `/cors-proxy/{host}/...`
+(see `server.go`). The default build does not require a proxy.
+
+## Layout
+
+| File | Role |
+|------|------|
+| `fs-shim.js` | In-memory `fs` + `path` for Go's js/wasm runtime |
+| `bridge.js` / `app.js` | WASM loader and UI |
+| `report.css` | Copied from `internal/report/assets` on `make wasm` |
+| `shell.css` | Scan form chrome |
+| `server.go` | Dev static server (+ optional CORS proxy) |
+
+## API
+
+```js
+await trajan.initialize({ outputDir: "/run", concurrency: 8, onLog })
+await trajan.whoami({ platform, token, baseUrl, org })
+await trajan.scan({ platform, locator, token, baseUrl, bearerToken, orgOnly })
+await trajan.report({ runDir, format: "html" })
+trajan.cancel()
+trajan.version()
+```

--- a/browser/app.js
+++ b/browser/app.js
@@ -1,0 +1,139 @@
+(() => {
+  const $ = (id) => document.getElementById(id);
+  const form = $("scanForm");
+  const platformEl = $("platform");
+  const progress = $("progress");
+  const status = $("status");
+  const errorEl = $("error");
+  const idle = $("idle");
+  const results = $("results");
+  const frame = $("results-frame");
+  const runBtn = $("runBtn");
+  const cancelBtn = $("cancelBtn");
+  const whoamiBtn = $("whoamiBtn");
+
+  let scanning = false;
+
+  function setPlatformUI() {
+    const p = platformEl.value;
+    $("baseUrlField").hidden = p !== "gitlab";
+    $("bearerField").hidden = p !== "ado";
+    const ph = {
+      github: "org or org/repo",
+      gitlab: "group or group/project",
+      ado: "org or org/project",
+    };
+    $("locator").placeholder = ph[p] || "scope";
+  }
+
+  platformEl.addEventListener("change", setPlatformUI);
+  setPlatformUI();
+
+  function log(line) {
+    const stamp = new Date().toISOString().slice(11, 19);
+    progress.textContent += `[${stamp}] ${line}\n`;
+    progress.scrollTop = progress.scrollHeight;
+  }
+
+  function showError(msg) {
+    errorEl.hidden = !msg;
+    errorEl.textContent = msg || "";
+  }
+
+  function setBusy(busy) {
+    scanning = busy;
+    runBtn.disabled = busy;
+    whoamiBtn.disabled = busy;
+    cancelBtn.disabled = !busy;
+    status.textContent = busy ? "Scanning…" : "Ready";
+  }
+
+  function optsFromForm() {
+    return {
+      platform: platformEl.value,
+      locator: $("locator").value.trim(),
+      token: $("token").value,
+      baseUrl: $("baseUrl").value.trim(),
+      bearerToken: $("bearerToken").value,
+    };
+  }
+
+  async function boot() {
+    try {
+      await window.trajan.initialize({
+        outputDir: "/run",
+        concurrency: 8,
+        onLog(level, msg, attrs) {
+          const extra = attrs && Object.keys(attrs).length
+            ? " " + Object.entries(attrs).map(([k, v]) => `${k}=${v}`).join(" ")
+            : "";
+          log(`${level.toLowerCase()}  ${msg}${extra}`);
+        },
+      });
+      const v = window.trajan.version();
+      $("versionLine").textContent = `Trajan WASM ${v.version} · ${v.gitCommit}`;
+      status.textContent = "Ready";
+      log("WASM ready");
+    } catch (e) {
+      status.textContent = "Failed to load";
+      showError(e.message || String(e));
+    }
+  }
+
+  form.addEventListener("submit", async (ev) => {
+    ev.preventDefault();
+    showError("");
+    progress.textContent = "";
+    results.hidden = true;
+    idle.hidden = true;
+    setBusy(true);
+    const opts = optsFromForm();
+    try {
+      log(`whoami ${opts.platform}`);
+      const id = await window.trajan.whoami(opts);
+      log(`identity ${JSON.stringify(id)}`);
+      log(`scan ${opts.platform} ${opts.locator}`);
+      const summary = await window.trajan.scan(opts);
+      log(`scan complete runDir=${summary.runDir} findings=${summary.total ?? "?"}`);
+      const rep = await window.trajan.report({
+        runDir: summary.runDir,
+        format: "html",
+      });
+      frame.srcdoc = rep.content;
+      results.hidden = false;
+      status.textContent = `Done · ${summary.total ?? 0} findings`;
+    } catch (e) {
+      const msg = (e && e.error) || e.message || String(e);
+      showError(msg);
+      idle.hidden = false;
+      idle.textContent = "Scan failed. See the error above.";
+      status.textContent = "Failed";
+      log("error " + msg);
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  whoamiBtn.addEventListener("click", async () => {
+    showError("");
+    setBusy(true);
+    try {
+      const id = await window.trajan.whoami(optsFromForm());
+      log("whoami " + JSON.stringify(id));
+      status.textContent = "Token ok";
+    } catch (e) {
+      const msg = (e && e.error) || e.message || String(e);
+      showError(msg);
+      status.textContent = "Whoami failed";
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  cancelBtn.addEventListener("click", () => {
+    window.trajan.cancel();
+    log("cancel requested");
+  });
+
+  boot();
+})();

--- a/browser/bridge.js
+++ b/browser/bridge.js
@@ -1,0 +1,85 @@
+/**
+ * Trajan WASM bridge — loads Go, installs the Promise API on window.trajan.
+ * Requires fs-shim.js before wasm_exec.js.
+ */
+class TrajanBridge {
+  constructor() {
+    this.ready = false;
+    this._loading = null;
+  }
+
+  async init(wasmURL = "trajan.wasm") {
+    if (this.ready) return;
+    if (this._loading) return this._loading;
+    this._loading = this._load(wasmURL);
+    await this._loading;
+    this.ready = true;
+  }
+
+  async _load(wasmURL) {
+    if (typeof Go === "undefined") {
+      throw new Error("wasm_exec.js not loaded");
+    }
+    if (typeof globalThis.fs?.open !== "function" || globalThis.fs.constants?.O_CREAT === -1) {
+      throw new Error("fs-shim.js must load before wasm_exec.js");
+    }
+
+      const go = new Go();
+    let result;
+    const url = typeof _wasmDataUrl === "function" ? _wasmDataUrl() : wasmURL;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`failed to fetch ${wasmURL}: ${response.status}`);
+    }
+    const contentType = response.headers.get("Content-Type") || "";
+    if (typeof WebAssembly.instantiateStreaming === "function" && contentType.includes("application/wasm")) {
+      result = await WebAssembly.instantiateStreaming(response, go.importObject);
+    } else {
+      const buffer = await response.arrayBuffer();
+      result = await WebAssembly.instantiate(buffer, go.importObject);
+    }
+    go.run(result.instance);
+    await new Promise((r) => setTimeout(r, 50));
+
+    for (const name of ["trajanInitialize", "trajanScan", "trajanReport", "trajanCancel", "trajanVersion"]) {
+      if (typeof globalThis[name] !== "function") {
+        throw new Error(`${name} not exported from WASM`);
+      }
+    }
+  }
+
+  async initialize(opts = {}) {
+    await this.init(opts.wasmURL);
+    return unwrap(await globalThis.trajanInitialize(opts));
+  }
+
+  async whoami(opts) {
+    return unwrap(await globalThis.trajanWhoAmI(opts));
+  }
+
+  async scan(opts) {
+    return unwrap(await globalThis.trajanScan(opts));
+  }
+
+  async report(opts) {
+    return unwrap(await globalThis.trajanReport(opts));
+  }
+
+  cancel() {
+    return globalThis.trajanCancel();
+  }
+
+  version() {
+    return globalThis.trajanVersion();
+  }
+}
+
+function unwrap(result) {
+  if (result && typeof result === "object" && result.error && !result.ok && result.runDir === undefined && result.content === undefined) {
+    // reject path already throws; some handlers return {error}
+    if (Object.keys(result).length === 1) throw new Error(result.error);
+  }
+  return result;
+}
+
+window.trajan = new TrajanBridge();

--- a/browser/fs-shim.js
+++ b/browser/fs-shim.js
@@ -1,0 +1,426 @@
+/**
+ * In-memory Node-compatible fs + path shims for Go's js/wasm runtime.
+ * Install before wasm_exec.js so Go does not keep the ENOSYS stubs.
+ *
+ * Callbacks match Go's syscall/fs_js.go:
+ *   read/write → (err, n)
+ *   everything else → (err, value)  — never spread arrays
+ */
+(function installTrajanFS(global) {
+  "use strict";
+
+  const S_IFDIR = 0o040000;
+  const S_IFREG = 0o100000;
+
+  const constants = {
+    O_RDONLY: 0,
+    O_WRONLY: 1,
+    O_RDWR: 2,
+    O_CREAT: 0o100,
+    O_EXCL: 0o200,
+    O_TRUNC: 0o1000,
+    O_APPEND: 0o2000,
+    O_DIRECTORY: 0o200000,
+  };
+
+  function err(code, msg) {
+    const e = new Error(msg || code);
+    e.code = code;
+    return e;
+  }
+
+  function normalize(p) {
+    if (!p) return "/";
+    p = String(p).replace(/\\/g, "/");
+    const abs = p.startsWith("/");
+    const parts = [];
+    for (const seg of p.split("/")) {
+      if (!seg || seg === ".") continue;
+      if (seg === "..") {
+        if (parts.length) parts.pop();
+        continue;
+      }
+      parts.push(seg);
+    }
+    const out = (abs ? "/" : "") + parts.join("/");
+    return out || (abs ? "/" : ".");
+  }
+
+  function dirname(p) {
+    p = normalize(p);
+    if (p === "/") return "/";
+    const i = p.lastIndexOf("/");
+    if (i <= 0) return "/";
+    return p.slice(0, i) || "/";
+  }
+
+  function basename(p) {
+    p = normalize(p);
+    if (p === "/") return "/";
+    const i = p.lastIndexOf("/");
+    return i < 0 ? p : p.slice(i + 1);
+  }
+
+  // path → { type: 'dir'|'file', mode, data?: Uint8Array, mtimeMs, ... }
+  const nodes = new Map();
+  nodes.set("/", { type: "dir", mode: 0o755, mtimeMs: Date.now() });
+
+  let nextFD = 3;
+  const fds = new Map(); // fd → { path, flags, pos }
+
+  function get(path) {
+    return nodes.get(normalize(path));
+  }
+
+  function ensureParent(path) {
+    const d = dirname(path);
+    if (!get(d)) throw err("ENOENT", "no such file or directory: " + d);
+    if (get(d).type !== "dir") throw err("ENOTDIR", "not a directory: " + d);
+  }
+
+  function makeStat(node) {
+    const isDir = node.type === "dir";
+    const size = isDir ? 0 : (node.data ? node.data.length : 0);
+    const mode = (isDir ? S_IFDIR : S_IFREG) | (node.mode & 0o777);
+    const now = node.mtimeMs || Date.now();
+    return {
+      dev: 1,
+      ino: 1,
+      mode,
+      nlink: 1,
+      uid: 0,
+      gid: 0,
+      rdev: 0,
+      size,
+      blksize: 4096,
+      blocks: Math.ceil(size / 512) || 0,
+      atimeMs: now,
+      mtimeMs: now,
+      ctimeMs: now,
+      isDirectory() { return isDir; },
+      isFile() { return !isDir; },
+      isSymbolicLink() { return false; },
+    };
+  }
+
+  function listDir(path) {
+    path = normalize(path);
+    const node = get(path);
+    if (!node) throw err("ENOENT", path);
+    if (node.type !== "dir") throw err("ENOTDIR", path);
+    const prefix = path === "/" ? "/" : path + "/";
+    const names = new Set();
+    for (const key of nodes.keys()) {
+      if (key === path || !key.startsWith(prefix)) continue;
+      const rest = key.slice(prefix.length);
+      const slash = rest.indexOf("/");
+      names.add(slash === -1 ? rest : rest.slice(0, slash));
+    }
+    return [...names].sort();
+  }
+
+  function cbify(fn) {
+    return function (...args) {
+      const callback = args[args.length - 1];
+      try {
+        const result = fn(...args.slice(0, -1));
+        callback(null, result);
+      } catch (e) {
+        callback(e);
+      }
+    };
+  }
+
+  const fs = {
+    constants,
+
+    writeSync(fd, buf) {
+      // stdout/stderr: mirror wasm_exec default logging
+      if (fd === 1 || fd === 2) {
+        const text = typeof buf === "string" ? buf : new TextDecoder().decode(buf);
+        const lines = text.split("\n");
+        for (let i = 0; i < lines.length - (text.endsWith("\n") ? 1 : 0); i++) {
+          if (lines[i] !== "") console.log(lines[i]);
+        }
+        if (!text.endsWith("\n") && lines[lines.length - 1]) {
+          // keep partial line buffering simple: just print
+        }
+        return buf.length !== undefined ? buf.length : Buffer.byteLength(text);
+      }
+      throw err("EBADF", "writeSync: bad fd " + fd);
+    },
+
+    write: cbify(function (fd, buf, offset, length, position) {
+      if (fd === 1 || fd === 2) {
+        const slice = buf.subarray(offset, offset + length);
+        fs.writeSync(fd, slice);
+        return length;
+      }
+      const h = fds.get(fd);
+      if (!h) throw err("EBADF", "bad fd");
+      const node = get(h.path);
+      if (!node || node.type !== "file") throw err("EBADF", "not a file");
+      const pos = position == null ? h.pos : position;
+      const src = buf.subarray(offset, offset + length);
+      if (pos + src.length > node.data.length) {
+        const next = new Uint8Array(pos + src.length);
+        next.set(node.data);
+        node.data = next;
+      }
+      node.data.set(src, pos);
+      node.mtimeMs = Date.now();
+      if (position == null) h.pos = pos + src.length;
+      return src.length;
+    }),
+
+    read: cbify(function (fd, buffer, offset, length, position) {
+      const h = fds.get(fd);
+      if (!h) throw err("EBADF", "bad fd");
+      const node = get(h.path);
+      if (!node) throw err("EBADF", "missing");
+      if (node.type === "dir") throw err("EISDIR", h.path);
+      const pos = position == null ? h.pos : position;
+      const available = Math.max(0, node.data.length - pos);
+      const n = Math.min(length, available);
+      buffer.set(node.data.subarray(pos, pos + n), offset);
+      if (position == null) h.pos = pos + n;
+      return n;
+    }),
+
+    open: cbify(function (path, flags, mode) {
+      path = normalize(path);
+      flags = flags | 0;
+      mode = mode || 0o666;
+      let node = get(path);
+      const wantDir = (flags & constants.O_DIRECTORY) !== 0;
+      const creat = (flags & constants.O_CREAT) !== 0;
+      const excl = (flags & constants.O_EXCL) !== 0;
+      const trunc = (flags & constants.O_TRUNC) !== 0;
+      const wr = (flags & constants.O_WRONLY) !== 0 || (flags & constants.O_RDWR) !== 0;
+
+      if (!node) {
+        if (!creat) throw err("ENOENT", path);
+        ensureParent(path);
+        node = { type: "file", mode: mode & 0o777, data: new Uint8Array(0), mtimeMs: Date.now() };
+        nodes.set(path, node);
+      } else if (excl && creat) {
+        throw err("EEXIST", path);
+      }
+
+      if (wantDir && node.type !== "dir") throw err("ENOTDIR", path);
+      if (node.type === "dir" && wr && !wantDir) throw err("EISDIR", path);
+      if (trunc && node.type === "file") {
+        node.data = new Uint8Array(0);
+        node.mtimeMs = Date.now();
+      }
+
+      const fd = nextFD++;
+      let pos = 0;
+      if ((flags & constants.O_APPEND) !== 0 && node.type === "file") pos = node.data.length;
+      fds.set(fd, { path, flags, pos });
+      return fd;
+    }),
+
+    close: cbify(function (fd) {
+      if (fd <= 2) return undefined;
+      if (!fds.has(fd)) throw err("EBADF", "bad fd");
+      fds.delete(fd);
+      return undefined;
+    }),
+
+    fstat: cbify(function (fd) {
+      if (fd <= 2) {
+        return makeStat({ type: "file", mode: 0o666, data: new Uint8Array(0), mtimeMs: Date.now() });
+      }
+      const h = fds.get(fd);
+      if (!h) throw err("EBADF", "bad fd");
+      const node = get(h.path);
+      if (!node) throw err("ENOENT", h.path);
+      return makeStat(node);
+    }),
+
+    lstat: cbify(function (path) {
+      const node = get(path);
+      if (!node) throw err("ENOENT", path);
+      return makeStat(node);
+    }),
+
+    stat: cbify(function (path) {
+      const node = get(path);
+      if (!node) throw err("ENOENT", path);
+      return makeStat(node);
+    }),
+
+    mkdir: cbify(function (path, perm) {
+      path = normalize(path);
+      if (get(path)) throw err("EEXIST", path);
+      ensureParent(path);
+      nodes.set(path, { type: "dir", mode: (perm || 0o755) & 0o777, mtimeMs: Date.now() });
+      return undefined;
+    }),
+
+    readdir: cbify(function (path) {
+      return listDir(path);
+    }),
+
+    rmdir: cbify(function (path) {
+      path = normalize(path);
+      const node = get(path);
+      if (!node) throw err("ENOENT", path);
+      if (node.type !== "dir") throw err("ENOTDIR", path);
+      if (listDir(path).length) throw err("ENOTEMPTY", path);
+      nodes.delete(path);
+      return undefined;
+    }),
+
+    unlink: cbify(function (path) {
+      path = normalize(path);
+      const node = get(path);
+      if (!node) throw err("ENOENT", path);
+      if (node.type === "dir") throw err("EISDIR", path);
+      nodes.delete(path);
+      return undefined;
+    }),
+
+    rename: cbify(function (from, to) {
+      from = normalize(from);
+      to = normalize(to);
+      const node = get(from);
+      if (!node) throw err("ENOENT", from);
+      ensureParent(to);
+      if (get(to)) {
+        // overwrite file; refuse non-empty dir
+        const existing = get(to);
+        if (existing.type === "dir" && listDir(to).length) throw err("ENOTEMPTY", to);
+        nodes.delete(to);
+      }
+      nodes.delete(from);
+      nodes.set(to, node);
+      // move children if directory
+      if (node.type === "dir") {
+        const prefix = from === "/" ? "/" : from + "/";
+        const toPrefix = to === "/" ? "/" : to + "/";
+        const moves = [];
+        for (const key of nodes.keys()) {
+          if (key.startsWith(prefix)) moves.push(key);
+        }
+        for (const key of moves) {
+          const n = nodes.get(key);
+          nodes.delete(key);
+          nodes.set(toPrefix + key.slice(prefix.length), n);
+        }
+      }
+      return undefined;
+    }),
+
+    truncate: cbify(function (path, length) {
+      const node = get(path);
+      if (!node) throw err("ENOENT", path);
+      if (node.type !== "file") throw err("EISDIR", path);
+      const next = new Uint8Array(length);
+      next.set(node.data.subarray(0, Math.min(node.data.length, length)));
+      node.data = next;
+      node.mtimeMs = Date.now();
+      return undefined;
+    }),
+
+    ftruncate: cbify(function (fd, length) {
+      const h = fds.get(fd);
+      if (!h) throw err("EBADF", "bad fd");
+      return fs.truncate.length; // unused; call sync path
+    }),
+
+    fsync: cbify(function () { return undefined; }),
+    chmod: cbify(function () { return undefined; }),
+    fchmod: cbify(function () { return undefined; }),
+    chown: cbify(function () { return undefined; }),
+    fchown: cbify(function () { return undefined; }),
+    lchown: cbify(function () { return undefined; }),
+    utimes: cbify(function (path) {
+      const node = get(path);
+      if (!node) throw err("ENOENT", path);
+      node.mtimeMs = Date.now();
+      return undefined;
+    }),
+    link: cbify(function () { throw err("ENOSYS", "link"); }),
+    symlink: cbify(function () { throw err("ENOSYS", "symlink"); }),
+    readlink: cbify(function () { throw err("EINVAL", "not a symlink"); }),
+  };
+
+  // Fix ftruncate to actually truncate via open handle
+  fs.ftruncate = cbify(function (fd, length) {
+    const h = fds.get(fd);
+    if (!h) throw err("EBADF", "bad fd");
+    const node = get(h.path);
+    if (!node || node.type !== "file") throw err("EINVAL", "not a file");
+    const next = new Uint8Array(length);
+    next.set(node.data.subarray(0, Math.min(node.data.length, length)));
+    node.data = next;
+    node.mtimeMs = Date.now();
+    return undefined;
+  });
+
+  global.fs = fs;
+
+  global.path = {
+    resolve(...segments) {
+      let resolved = "";
+      for (const seg of segments) {
+        if (!seg) continue;
+        const s = String(seg).replace(/\\/g, "/");
+        if (s.startsWith("/")) resolved = s;
+        else resolved = resolved ? resolved.replace(/\/+$/, "") + "/" + s : s;
+      }
+      return normalize(resolved || "/");
+    },
+    dirname,
+    basename,
+    join(...parts) {
+      return normalize(parts.filter(Boolean).join("/"));
+    },
+  };
+
+  if (!global.process) {
+    global.process = {};
+  }
+  Object.assign(global.process, {
+    getuid() { return -1; },
+    getgid() { return -1; },
+    geteuid() { return -1; },
+    getegid() { return -1; },
+    getgroups() { return []; },
+    pid: 1,
+    ppid: 0,
+    umask() { return 0; },
+    cwd() { return "/"; },
+    chdir() { throw err("ENOSYS", "chdir"); },
+  });
+
+  // Helpers for the Go bridge / tests
+  global.__trajanFS = {
+    readFile(path) {
+      const node = get(path);
+      if (!node || node.type !== "file") throw err("ENOENT", path);
+      return new TextDecoder().decode(node.data);
+    },
+    writeFile(path, text) {
+      path = normalize(path);
+      ensureParent(path);
+      nodes.set(path, {
+        type: "file",
+        mode: 0o644,
+        data: new TextEncoder().encode(String(text)),
+        mtimeMs: Date.now(),
+      });
+    },
+    list(path) {
+      return listDir(path || "/");
+    },
+    reset() {
+      nodes.clear();
+      nodes.set("/", { type: "dir", mode: 0o755, mtimeMs: Date.now() });
+      fds.clear();
+      nextFD = 3;
+    },
+  };
+})(typeof globalThis !== "undefined" ? globalThis : window);

--- a/browser/index.html
+++ b/browser/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Trajan — Browser Scanner</title>
+<link rel="stylesheet" href="report.css">
+<link rel="stylesheet" href="shell.css">
+</head>
+<body>
+<div class="shell">
+  <p class="shell-brand">Trajan · Browser</p>
+  <h1>CI/CD security scan</h1>
+  <p class="shell-lead">
+    Runs collect → normalize → scan in your browser with first-party YAML detections.
+    Attack and graph are not included. Tokens stay in memory for this session only.
+  </p>
+
+  <form class="scan-form" id="scanForm">
+    <div class="row">
+      <div class="field">
+        <label for="platform">Platform</label>
+        <select id="platform" name="platform">
+          <option value="github">GitHub</option>
+          <option value="gitlab">GitLab</option>
+          <option value="ado">Azure DevOps</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="locator">Scope / locator</label>
+        <input id="locator" name="locator" type="text" placeholder="org/repo, group, or org/project" autocomplete="off" spellcheck="false" required>
+      </div>
+    </div>
+    <div class="row">
+      <div class="field">
+        <label for="token">Token</label>
+        <input id="token" name="token" type="password" placeholder="PAT or pipeline token" autocomplete="off" required>
+      </div>
+      <div class="field" id="baseUrlField" hidden>
+        <label for="baseUrl">GitLab base URL</label>
+        <input id="baseUrl" name="baseUrl" type="url" placeholder="https://gitlab.com" autocomplete="off" spellcheck="false">
+      </div>
+      <div class="field" id="bearerField" hidden>
+        <label for="bearerToken">Azure bearer (optional)</label>
+        <input id="bearerToken" name="bearerToken" type="password" placeholder="Entra / SYSTEM_ACCESSTOKEN" autocomplete="off">
+      </div>
+    </div>
+    <div class="actions">
+      <button type="submit" class="btn btn-primary" id="runBtn">Run scan</button>
+      <button type="button" class="btn" id="whoamiBtn">Who am I</button>
+      <button type="button" class="btn btn-danger" id="cancelBtn" disabled>Cancel</button>
+      <span class="status" id="status">Loading WASM…</span>
+    </div>
+  </form>
+
+  <div class="error-banner" id="error" hidden></div>
+  <pre class="progress" id="progress" aria-live="polite"></pre>
+  <div class="idle-panel" id="idle">Nothing to report yet. Enter credentials and run a scan.</div>
+  <div id="results" hidden>
+    <iframe id="results-frame" title="Trajan findings report" sandbox="allow-scripts allow-same-origin"></iframe>
+  </div>
+  <p class="shell-foot" id="versionLine"></p>
+</div>
+
+<script src="fs-shim.js"></script>
+<script src="wasm_exec.js"></script>
+<script src="bridge.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/browser/report.css
+++ b/browser/report.css
@@ -1,0 +1,381 @@
+*, *::before, *::after { box-sizing: border-box; }
+[hidden] { display: none !important; }
+
+:root {
+  color-scheme: light dark;
+
+  --paper: #ffffff;
+  --surface: #f4f6f8;
+  --raised: #ffffff;
+  --ink: #11151a;
+  --muted: #5b6673;
+  --faint: #8a94a1;
+  --line: #e1e5ea;
+  --line-strong: #c9d0d8;
+
+  --accent: #5b4bd6;
+  --accent-soft: #eeecfc;
+
+  --crit: #9d1440;  --crit-soft: #fbe9ef;
+  --high: #bd3f0d;  --high-soft: #fdefe6;
+  --med:  #8a6206;  --med-soft:  #faf3e0;
+  --low:  #0d6d7e;  --low-soft:  #e6f4f7;
+  --info: #5b6673;  --info-soft: #eef1f4;
+  --tone-ink: #ffffff;
+
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+/* Dark tokens live in one block, applied by OS preference and by the explicit
+   toggle. Keeping them identical means the toggle can never drift from the
+   automatic theme. */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --paper: #0d1116;
+    --surface: #0d1116;
+    --raised: #161b22;
+    --ink: #e4e9ee;
+    --muted: #99a3af;
+    --faint: #6d7783;
+    --line: #242b34;
+    --line-strong: #343d48;
+
+    --accent: #a695f5;
+    --accent-soft: #221f3d;
+
+    --crit: #f4809f;  --crit-soft: #33101c;
+    --high: #f0975f;  --high-soft: #331c0e;
+    --med:  #d9b552;  --med-soft:  #2e2610;
+    --low:  #5cc0d2;  --low-soft:  #0d2a30;
+    --info: #98a3b0;  --info-soft: #1c222a;
+    --tone-ink: #0d1116;
+  }
+}
+
+:root[data-theme="dark"] {
+  --paper: #0d1116;
+  --surface: #0d1116;
+  --raised: #161b22;
+  --ink: #e4e9ee;
+  --muted: #99a3af;
+  --faint: #6d7783;
+  --line: #242b34;
+  --line-strong: #343d48;
+
+  --accent: #a695f5;
+  --accent-soft: #221f3d;
+
+  --crit: #f4809f;  --crit-soft: #33101c;
+  --high: #f0975f;  --high-soft: #331c0e;
+  --med:  #d9b552;  --med-soft:  #2e2610;
+  --low:  #5cc0d2;  --low-soft:  #0d2a30;
+  --info: #98a3b0;  --info-soft: #1c222a;
+  --tone-ink: #0d1116;
+}
+
+.s-critical { --tone: var(--crit); --tone-soft: var(--crit-soft); }
+.s-high     { --tone: var(--high); --tone-soft: var(--high-soft); }
+.s-medium   { --tone: var(--med);  --tone-soft: var(--med-soft); }
+.s-low      { --tone: var(--low);  --tone-soft: var(--low-soft); }
+.s-info     { --tone: var(--info); --tone-soft: var(--info-soft); }
+
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--surface);
+  color: var(--ink);
+  font: 400 15px/1.55 var(--sans);
+  -webkit-text-size-adjust: 100%;
+}
+
+.wrap { max-width: 1320px; margin: 0 auto; padding: 0 22px 72px; }
+
+:where(a, button, input, summary):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 5px;
+}
+
+/* ---- masthead ---- */
+
+.masthead {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 20px;
+  padding: 32px 0 20px; margin-bottom: 18px; border-bottom: 1px solid var(--line);
+}
+.eyebrow {
+  margin: 0 0 10px; font: 600 11px/1 var(--sans); letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--faint);
+}
+h1 {
+  margin: 0; font-size: 27px; line-height: 1.2; font-weight: 600;
+  letter-spacing: -0.015em; text-wrap: balance; overflow-wrap: anywhere;
+}
+.masthead .meta { margin: 8px 0 0; font-size: 13.5px; color: var(--muted); }
+
+.iconbtn {
+  flex: none; display: grid; place-items: center; width: 36px; height: 36px; cursor: pointer;
+  color: var(--muted); background: var(--raised);
+  border: 1px solid var(--line-strong); border-radius: 9px;
+}
+.iconbtn:hover { color: var(--ink); border-color: var(--muted); }
+/* The icon shows the theme you would switch to, so it tracks the resolved theme
+   rather than the toggle's own state. */
+.i-sun { display: none; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .i-sun { display: block; }
+  :root:not([data-theme="light"]) .i-moon { display: none; }
+}
+:root[data-theme="dark"] .i-sun { display: block; }
+:root[data-theme="dark"] .i-moon { display: none; }
+:root[data-theme="light"] .i-sun { display: none; }
+:root[data-theme="light"] .i-moon { display: block; }
+
+/* ---- severity tiles, which double as the severity filter ---- */
+
+.tiles {
+  display: grid; gap: 8px; margin-bottom: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(122px, 1fr));
+}
+.tile {
+  position: relative; overflow: hidden; text-align: left; font: inherit; color: inherit;
+  background: var(--raised); border: 1px solid var(--line); border-radius: 10px;
+  padding: 13px 15px 12px;
+}
+.tile::before {
+  content: ""; position: absolute; inset: 0 0 auto 0; height: 3px; background: var(--tone, transparent);
+}
+button.tile { cursor: pointer; transition: opacity 0.12s; }
+button.tile[aria-pressed="false"] { opacity: 0.38; }
+button.tile[aria-pressed="false"] .n { color: var(--muted); }
+.tile .n {
+  display: block; font: 600 25px/1 var(--sans);
+  letter-spacing: -0.02em; font-variant-numeric: tabular-nums; color: var(--tone, var(--ink));
+}
+.tile .k {
+  display: block; margin-top: 6px; font: 600 10.5px/1 var(--sans);
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+}
+
+/* ---- two-column shell ---- */
+
+.layout { display: grid; grid-template-columns: 248px minmax(0, 1fr); gap: 26px; align-items: start; }
+.main { min-width: 0; }
+
+.sidebar {
+  position: sticky; top: 18px; max-height: calc(100vh - 36px);
+  overflow-y: auto; overscroll-behavior: contain;
+  display: flex; flex-direction: column; gap: 18px;
+  padding: 14px; background: var(--raised);
+  border: 1px solid var(--line); border-radius: 12px;
+}
+.side-sec { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.side-h {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+  margin: 0 0 6px; padding: 0 6px;
+  font: 600 10.5px/1 var(--sans); letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--faint);
+}
+.side-clear {
+  border: 0; background: none; padding: 0; cursor: pointer; text-transform: none; letter-spacing: 0;
+  font: 500 11px/1 var(--sans); color: var(--accent); text-decoration: underline; text-underline-offset: 2px;
+}
+.side-row {
+  display: flex; align-items: center; gap: 8px; width: 100%; min-width: 0;
+  padding: 6px 8px; cursor: pointer; text-align: left;
+  background: none; border: 0; border-radius: 7px;
+  font: 400 13px/1.35 var(--sans); color: var(--muted);
+}
+.side-row:hover { background: var(--surface); color: var(--ink); }
+.side-label { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.side-n {
+  flex: none; font: 400 11.5px/1 var(--mono);
+  font-variant-numeric: tabular-nums; color: var(--faint);
+}
+.side-row .dot { flex: none; width: 8px; height: 8px; border-radius: 50%; background: var(--tone); }
+/* Confidence starts fully on, so its active state stays neutral. The accent is
+   reserved for a rule you actually picked, which starts empty. */
+.side-row[data-filter="conf"][aria-pressed="true"] { background: var(--surface); color: var(--ink); }
+.side-row[data-filter="conf"][aria-pressed="false"] { opacity: 0.45; }
+.rule-row[aria-pressed="true"] { background: var(--accent-soft); color: var(--ink); font-weight: 500; }
+.rule-row[aria-pressed="true"] .side-n { color: var(--accent); }
+
+.side-input {
+  width: 100%; margin-bottom: 6px; padding: 6px 9px;
+  font: 400 12.5px/1.4 var(--sans); color: var(--ink);
+  background: var(--surface); border: 1px solid var(--line); border-radius: 7px;
+}
+.side-input::placeholder { color: var(--faint); }
+.side-input:focus { border-color: var(--accent); outline: none; }
+
+.rule-group + .rule-group { margin-top: 10px; }
+.rule-cat {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
+  margin: 0 0 3px; padding: 0 8px;
+  font: 500 11px/1.4 var(--mono); color: var(--faint);
+}
+.rule-row .side-label { font: 400 12.2px/1.35 var(--mono); }
+
+/* ---- toolbar ---- */
+
+.toolbar {
+  position: sticky; top: 0; z-index: 5;
+  display: flex; flex-wrap: wrap; align-items: center; gap: 10px 14px;
+  background: var(--raised); border: 1px solid var(--line); border-radius: 10px;
+  padding: 9px 13px; margin-bottom: 14px;
+}
+.search {
+  flex: 1 1 200px; min-width: 150px; display: flex; align-items: center; gap: 8px;
+  padding: 0 10px; background: var(--surface);
+  border: 1px solid var(--line-strong); border-radius: 8px; color: var(--faint);
+}
+.search:focus-within { border-color: var(--accent); color: var(--accent); }
+.search svg { flex: none; }
+.search input {
+  flex: 1; min-width: 0; padding: 7px 0; font: 400 13.5px/1.45 var(--sans);
+  color: var(--ink); background: none; border: 0; outline: none;
+}
+.search input::placeholder { color: var(--faint); }
+
+.linkbtn {
+  border: 0; background: none; padding: 0; cursor: pointer;
+  font: 500 12.5px/1.4 var(--sans); color: var(--muted);
+  text-decoration: underline; text-underline-offset: 2px; white-space: nowrap;
+}
+.linkbtn:hover { color: var(--ink); }
+.tally { margin: 0; font-size: 13px; color: var(--muted); white-space: nowrap; font-variant-numeric: tabular-nums; }
+.tally b { color: var(--ink); font-weight: 600; }
+
+/* ---- finding card ---- */
+
+.finding {
+  position: relative; overflow: hidden; scroll-margin-top: 72px;
+  background: var(--raised); border: 1px solid var(--line); border-radius: 10px;
+  padding: 20px 20px 18px; margin-bottom: 12px;
+}
+.finding::before {
+  content: ""; position: absolute; inset: 0 0 auto 0; height: 6px; background: var(--tone);
+}
+.f-head { display: flex; flex-wrap: wrap; align-items: center; gap: 9px; margin-bottom: 9px; }
+.sev {
+  font: 600 10.5px/1 var(--sans); letter-spacing: 0.09em; text-transform: uppercase;
+  color: var(--tone-ink); background: var(--tone); border-radius: 4px; padding: 5px 9px;
+}
+.fid { font: 500 11.5px/1 var(--mono); color: var(--faint); }
+.conf { font-size: 12.5px; color: var(--muted); }
+
+.finding h2 {
+  margin: 0 0 7px; font-size: 17px; line-height: 1.33; font-weight: 600;
+  letter-spacing: -0.01em; text-wrap: balance;
+}
+.subject { margin: 0; font-size: 13px; line-height: 1.5; color: var(--muted); overflow-wrap: anywhere; }
+.subject + .subject { margin-top: 2px; }
+.subject .loc { font: 400 12.8px/1.5 var(--mono); color: var(--muted); }
+.loc-label {
+  display: inline-block; margin-left: 9px; padding: 2px 7px; border-radius: 4px;
+  font: 600 10px/1.5 var(--sans); letter-spacing: 0.09em;
+  color: var(--muted); background: var(--surface);
+}
+
+.lbl-sec {
+  margin: 15px 0 7px; font: 600 10.5px/1 var(--sans);
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--faint);
+}
+/* A file path is a literal; the label's uppercasing must not reach it. */
+.lbl-sec .path {
+  margin-left: 6px; font: 400 11.5px/1 var(--mono);
+  letter-spacing: 0; text-transform: none; overflow-wrap: anywhere;
+}
+ul.evidence { display: grid; gap: 5px; margin: 0; padding: 0; list-style: none; }
+ul.evidence li { position: relative; padding-left: 16px; font-size: 13.5px; overflow-wrap: anywhere; }
+ul.evidence li::before {
+  content: ""; position: absolute; left: 3px; top: 0.62em;
+  width: 4px; height: 4px; border-radius: 50%; background: var(--line-strong);
+}
+
+pre {
+  margin: 0; padding: 12px 14px; overflow-x: auto;
+  background: var(--surface); border: 1px solid var(--line); border-radius: 8px;
+  font: 400 12.5px/1.55 var(--mono);
+}
+
+.remedy {
+  margin-top: 15px; padding: 11px 14px; font-size: 13.5px;
+  background: var(--surface); border-radius: 8px;
+}
+.remedy + .remedy { margin-top: 8px; }
+.remedy strong { font-weight: 600; }
+
+details.more { margin-top: 15px; padding-top: 11px; border-top: 1px solid var(--line); }
+details.more > summary {
+  display: inline-flex; align-items: center; gap: 7px; cursor: pointer; list-style: none;
+  font: 600 10.5px/1 var(--sans); letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+}
+details.more > summary::-webkit-details-marker { display: none; }
+details.more > summary::before {
+  content: "\25b8"; display: inline-block; font-size: 10px; transition: transform 0.12s;
+}
+details.more[open] > summary::before { transform: rotate(90deg); }
+details.more > summary:hover { color: var(--ink); }
+.desc { margin: 12px 0 0; font-size: 14px; }
+.meta-line { margin: 10px 0 0; font: 400 12px/1.5 var(--mono); overflow-wrap: anywhere; }
+.meta-line .tag { font-family: var(--sans); color: var(--faint); margin-right: 6px; }
+.meta-line a { color: var(--accent); text-decoration: none; }
+.meta-line a:hover { text-decoration: underline; }
+.meta-line code { color: var(--muted); }
+
+table.prov { width: 100%; border-collapse: collapse; margin-top: 13px; font-size: 12.5px; }
+table.prov td { padding: 5px 0; vertical-align: top; border-bottom: 1px solid var(--line); }
+table.prov tr:last-child td { border-bottom: 0; }
+table.prov td.k {
+  width: 1%; padding-right: 22px; white-space: nowrap;
+  font-family: var(--mono); color: var(--muted);
+}
+table.prov td.v { font-family: var(--mono); overflow-wrap: anywhere; }
+
+/* ---- chrome ---- */
+
+.panel {
+  padding: 54px 24px; text-align: center; color: var(--muted);
+  background: var(--raised); border: 1px dashed var(--line-strong); border-radius: 10px;
+}
+
+.totop {
+  position: fixed; right: 22px; bottom: 22px; z-index: 20;
+  display: grid; place-items: center; width: 42px; height: 42px; cursor: pointer;
+  color: var(--paper); background: var(--ink);
+  border: 0; border-radius: 50%; box-shadow: 0 3px 14px rgb(0 0 0 / 0.22);
+}
+.totop:hover { background: var(--accent); }
+
+footer {
+  display: flex; flex-wrap: wrap; gap: 4px 20px;
+  margin-top: 36px; padding-top: 16px; border-top: 1px solid var(--line);
+  font-size: 12px; color: var(--faint);
+}
+footer code { font-family: var(--mono); overflow-wrap: anywhere; }
+
+@media (max-width: 900px) {
+  .layout { grid-template-columns: minmax(0, 1fr); }
+  .sidebar { position: static; max-height: none; }
+}
+
+@media (max-width: 620px) {
+  .wrap { padding: 0 14px 56px; }
+  h1 { font-size: 22px; }
+  .toolbar { position: static; }
+  .f-head { gap: 7px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  * { transition: none !important; }
+}
+
+@media print {
+  .toolbar, .sidebar, .panel, .totop, .iconbtn, .tiles button { display: none !important; }
+  body { background: #fff; }
+  .layout { display: block; }
+  .finding { break-inside: avoid; }
+  details.more > summary { display: none; }
+}

--- a/browser/server.go
+++ b/browser/server.go
@@ -1,0 +1,153 @@
+//go:build ignore
+
+// Local static server for the Trajan browser UI.
+//
+// Serves browser/ on :8080. Optionally proxies Azure DevOps and self-hosted
+// GitLab when CORS blocks direct fetch — enable with TRAJAN_WASM_PROXY=1.
+//
+//	go run server.go
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/azdo-proxy/", handleADOProxy)
+	mux.HandleFunc("/cors-proxy/", handleCORSProxy)
+
+	fs := http.FileServer(http.Dir("."))
+	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".wasm") {
+			w.Header().Set("Content-Type", "application/wasm")
+		}
+		fs.ServeHTTP(w, r)
+	}))
+
+	addr := ":8080"
+	log.Printf("Trajan browser UI at http://localhost%s", addr)
+	if os.Getenv("TRAJAN_WASM_PROXY") == "1" {
+		log.Printf("CORS proxy enabled: /azdo-proxy/ and /cors-proxy/")
+	} else {
+		log.Printf("CORS proxy disabled (cloud GitHub/GitLab/ADO usually work direct). Set TRAJAN_WASM_PROXY=1 if needed.")
+	}
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func proxyEnabled(w http.ResponseWriter) bool {
+	if os.Getenv("TRAJAN_WASM_PROXY") == "1" {
+		return true
+	}
+	http.Error(w, "proxy disabled; set TRAJAN_WASM_PROXY=1", http.StatusServiceUnavailable)
+	return false
+}
+
+func isAllowedADOHost(host string) bool {
+	if host == "dev.azure.com" || strings.HasSuffix(host, ".dev.azure.com") {
+		return true
+	}
+	parts := strings.Split(host, ".")
+	return len(parts) >= 3 && parts[len(parts)-2] == "visualstudio" && parts[len(parts)-1] == "com"
+}
+
+func handleADOProxy(w http.ResponseWriter, r *http.Request) {
+	if !proxyEnabled(w) {
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8080")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	trimmed := strings.TrimPrefix(r.URL.Path, "/azdo-proxy/")
+	idx := strings.Index(trimmed, "/")
+	var host, restPath string
+	if idx == -1 {
+		host, restPath = trimmed, "/"
+	} else {
+		host, restPath = trimmed[:idx], trimmed[idx:]
+	}
+	if host == "" || !isAllowedADOHost(host) {
+		http.Error(w, "host not allowed", http.StatusForbidden)
+		return
+	}
+	forward(w, r, "https", host, restPath)
+}
+
+// /cors-proxy/{host}/{path} — allowlisted self-hosted GitLab fallback.
+func handleCORSProxy(w http.ResponseWriter, r *http.Request) {
+	if !proxyEnabled(w) {
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", "http://localhost:8080")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, PRIVATE-TOKEN")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	trimmed := strings.TrimPrefix(r.URL.Path, "/cors-proxy/")
+	idx := strings.Index(trimmed, "/")
+	var host, restPath string
+	if idx == -1 {
+		host, restPath = trimmed, "/"
+	} else {
+		host, restPath = trimmed[:idx], trimmed[idx:]
+	}
+	if host == "" || host == "169.254.169.254" || strings.HasPrefix(host, "metadata.") {
+		http.Error(w, "host not allowed", http.StatusForbidden)
+		return
+	}
+	scheme := "https"
+	if r.URL.Query().Get("scheme") == "http" {
+		scheme = "http"
+	}
+	forward(w, r, scheme, host, restPath)
+}
+
+func forward(w http.ResponseWriter, r *http.Request, scheme, host, restPath string) {
+	target := &url.URL{Scheme: scheme, Host: host, Path: restPath, RawQuery: r.URL.RawQuery}
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, target.String(), r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	hop := map[string]bool{
+		"Connection": true, "Keep-Alive": true, "Proxy-Connection": true,
+		"Transfer-Encoding": true, "Upgrade": true,
+	}
+	for k, vs := range r.Header {
+		if hop[k] {
+			continue
+		}
+		for _, v := range vs {
+			proxyReq.Header.Add(k, v)
+		}
+	}
+	resp, err := (&http.Client{Timeout: 60 * time.Second}).Do(proxyReq)
+	if err != nil {
+		http.Error(w, "proxy failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	for k, vs := range resp.Header {
+		if hop[k] || k == "Www-Authenticate" {
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}

--- a/browser/shell.css
+++ b/browser/shell.css
@@ -1,0 +1,170 @@
+/* Shell chrome for the WASM scanner. Report look comes from report.css. */
+
+.shell {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 28px 22px 8px;
+}
+
+.shell-brand {
+  margin: 0 0 6px;
+  font: 600 11px/1 var(--sans);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+
+.shell h1 {
+  margin: 0 0 6px;
+  font-size: 27px;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.shell-lead {
+  margin: 0 0 22px;
+  color: var(--muted);
+  font-size: 14.5px;
+  max-width: 62ch;
+}
+
+.scan-form {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  background: var(--raised);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  margin-bottom: 16px;
+}
+
+.scan-form .row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.field label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.field input,
+.field select {
+  font: 400 14px/1.4 var(--sans);
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  padding: 9px 11px;
+  width: 100%;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--line-strong);
+  background: var(--raised);
+  color: var(--ink);
+  font: 600 13.5px/1 var(--sans);
+  padding: 10px 16px;
+  border-radius: 9px;
+  cursor: pointer;
+}
+
+.btn:hover { border-color: var(--muted); }
+.btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--tone-ink, #fff);
+}
+:root[data-theme="dark"] .btn-primary,
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .btn-primary { color: #0d1116; }
+}
+
+.btn-danger {
+  color: var(--crit);
+  border-color: color-mix(in srgb, var(--crit) 35%, var(--line-strong));
+}
+
+.status {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.progress {
+  margin: 0 0 18px;
+  padding: 12px 14px;
+  background: var(--raised);
+  border: 1px dashed var(--line-strong);
+  border-radius: 10px;
+  font: 400 12.5px/1.45 var(--mono);
+  color: var(--muted);
+  max-height: 160px;
+  overflow: auto;
+  white-space: pre-wrap;
+}
+
+.progress:empty { display: none; }
+
+.error-banner {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--crit) 40%, var(--line));
+  background: var(--crit-soft);
+  color: var(--crit);
+  font-size: 14px;
+}
+
+.idle-panel {
+  margin: 8px 0 24px;
+  padding: 36px 20px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 12px;
+  text-align: center;
+  color: var(--muted);
+}
+
+#results {
+  margin-top: 8px;
+}
+
+#results-frame {
+  width: 100%;
+  border: 0;
+  min-height: 70vh;
+  background: var(--paper);
+  border-radius: 12px;
+}
+
+.shell-foot {
+  margin: 28px 0 40px;
+  font-size: 12.5px;
+  color: var(--faint);
+}

--- a/browser/smoke-fs.mjs
+++ b/browser/smoke-fs.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Smoke-test the in-memory fs/path shims against the callback shapes
+ * Go's syscall/fs_js.go expects.
+ */
+import path from "node:path";
+import fsNode from "node:fs";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const shimSrc = fsNode.readFileSync(path.join(__dirname, "fs-shim.js"), "utf8");
+const sandbox = { console, Date, TextEncoder, TextDecoder, Uint8Array, Map, Set, Error };
+sandbox.globalThis = sandbox;
+sandbox.window = sandbox;
+vm.runInNewContext(shimSrc, sandbox);
+
+const { fs, path: jspath, __trajanFS } = sandbox;
+
+function call(fn, ...args) {
+  return new Promise((resolve, reject) => {
+    fn(...args, (err, value) => (err ? reject(err) : resolve(value)));
+  });
+}
+
+try {
+  await call(fs.mkdir, "/run", 0o755);
+  await call(fs.mkdir, "/run/demo", 0o755);
+  const fd = await call(fs.open, "/run/demo/hello.txt", fs.constants.O_CREAT | fs.constants.O_WRONLY | fs.constants.O_TRUNC, 0o644);
+  const payload = new TextEncoder().encode("scan-ok\n");
+  const buf = new Uint8Array(payload);
+  const n = await call(fs.write, fd, buf, 0, buf.length, null);
+  if (n !== buf.length) throw new Error("write length mismatch");
+  await call(fs.close, fd);
+
+  const entries = await call(fs.readdir, "/run/demo");
+  if (!Array.isArray(entries) || !entries.includes("hello.txt")) {
+    throw new Error("readdir failed: " + JSON.stringify(entries));
+  }
+
+  const rfd = await call(fs.open, "/run/demo/hello.txt", fs.constants.O_RDONLY, 0);
+  const out = new Uint8Array(32);
+  const rn = await call(fs.read, rfd, out, 0, 32, null);
+  await call(fs.close, rfd);
+  const text = new TextDecoder().decode(out.subarray(0, rn));
+  if (text !== "scan-ok\n") throw new Error("read mismatch: " + JSON.stringify(text));
+
+  const resolved = jspath.resolve("/run", "demo", "hello.txt");
+  if (resolved !== "/run/demo/hello.txt") throw new Error("path.resolve: " + resolved);
+
+  const st = await call(fs.stat, "/run/demo");
+  if (!st.isDirectory()) throw new Error("stat dir");
+
+  __trajanFS.reset();
+  console.log("fs-shim smoke: ok");
+} catch (e) {
+  console.error("fs-shim smoke: FAIL", e);
+  process.exit(1);
+}

--- a/browser/smoke-pipeline.mjs
+++ b/browser/smoke-pipeline.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Fixture-based Scan + report under WASM + memfs (no network).
+ */
+import path from "node:path";
+import fsNode from "node:fs";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+import { webcrypto } from "node:crypto";
+import { performance } from "node:perf_hooks";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const wasmPath = path.join(__dirname, "trajan.wasm");
+if (!fsNode.existsSync(wasmPath)) {
+  console.error("missing browser/trajan.wasm — run make wasm first");
+  process.exit(1);
+}
+
+const sandbox = {
+  console, Date, TextEncoder, TextDecoder, Uint8Array, Array, Map, Set, Error,
+  Promise, Object, JSON, Math, Number, String, Boolean, parseInt, parseFloat,
+  setTimeout, clearTimeout, setInterval, clearInterval, performance,
+  crypto: webcrypto, fetch: globalThis.fetch, WebAssembly,
+};
+sandbox.globalThis = sandbox;
+sandbox.window = sandbox;
+sandbox.self = sandbox;
+
+vm.runInNewContext(fsNode.readFileSync(path.join(__dirname, "fs-shim.js"), "utf8"), sandbox);
+vm.runInNewContext(fsNode.readFileSync(path.join(__dirname, "wasm_exec.js"), "utf8"), sandbox);
+
+const go = new sandbox.Go();
+const result = await WebAssembly.instantiate(fsNode.readFileSync(wasmPath), go.importObject);
+go.run(result.instance);
+await new Promise((r) => setTimeout(r, 100));
+
+await sandbox.trajanInitialize({ outputDir: "/run", concurrency: 4 });
+
+const runDir = "/run/2026-01-01-0000-gh-fixture";
+const fs = sandbox.fs;
+const call = (fn, ...args) => new Promise((resolve, reject) => {
+  fn(...args, (err, value) => (err ? reject(err) : resolve(value)));
+});
+
+async function mkdirp(p) {
+  const parts = p.split("/").filter(Boolean);
+  let cur = "";
+  for (const part of parts) {
+    cur += "/" + part;
+    try {
+      await call(fs.mkdir, cur, 0o755);
+    } catch (e) {
+      if (e.code !== "EEXIST") throw e;
+    }
+  }
+}
+
+await mkdirp(runDir + "/10-normalize/jobs");
+sandbox.__trajanFS.writeFile(runDir + "/_meta.json", JSON.stringify({
+  run_id: "2026-01-01-0000-gh-fixture",
+  platform: "gh",
+  scope: "fixture/repo",
+  org: "fixture",
+  last_phase: 1,
+  phases: [],
+  started_at: "2026-01-01T00:00:00+00:00",
+  invocation: ["wasm-smoke"],
+}, null, 2));
+
+sandbox.__trajanFS.writeFile(runDir + "/10-normalize/jobs/fr-01__ci__build.json", JSON.stringify({
+  _id: "fr-01__ci__build",
+  triggers: ["pull_request_target"],
+  has_checkout_of_pr_ref: true,
+  executes_checked_out_code: true,
+  if_conditions_summary: { gate_strength: "weak" },
+}, null, 2));
+
+const summary = await sandbox.trajanScan({ platform: "github", runDir });
+if (!summary.runDir) throw new Error("scan missing runDir: " + JSON.stringify(summary));
+
+const rep = await sandbox.trajanReport({ runDir: summary.runDir, format: "html" });
+if (!rep.content || !rep.content.includes("<style>")) {
+  throw new Error("report HTML not self-contained");
+}
+if (!rep.content.includes("Trajan") || !rep.content.includes("finding")) {
+  throw new Error("report HTML missing expected markers");
+}
+
+console.log("pipeline smoke: ok", "findings=" + (summary.total ?? "?"), "html_bytes=" + rep.bytes);

--- a/browser/smoke-wasm.mjs
+++ b/browser/smoke-wasm.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Load trajan.wasm under the fs shim and call initialize().
+ * Validates Go ↔ memfs for MintRunDir / report paths.
+ */
+import path from "node:path";
+import fsNode from "node:fs";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { webcrypto } from "node:crypto";
+import { performance } from "node:perf_hooks";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const wasmPath = path.join(__dirname, "trajan.wasm");
+if (!fsNode.existsSync(wasmPath)) {
+  console.error("missing browser/trajan.wasm — run make wasm first");
+  process.exit(1);
+}
+
+const sandbox = {
+  console,
+  Date,
+  TextEncoder,
+  TextDecoder,
+  Uint8Array,
+  Array,
+  Map,
+  Set,
+  Error,
+  Promise,
+  Object,
+  JSON,
+  Math,
+  Number,
+  String,
+  Boolean,
+  parseInt,
+  parseFloat,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  performance,
+  crypto: webcrypto,
+  fetch: globalThis.fetch,
+  WebAssembly,
+};
+sandbox.globalThis = sandbox;
+sandbox.window = sandbox;
+sandbox.self = sandbox;
+
+vm.runInNewContext(fsNode.readFileSync(path.join(__dirname, "fs-shim.js"), "utf8"), sandbox);
+vm.runInNewContext(fsNode.readFileSync(path.join(__dirname, "wasm_exec.js"), "utf8"), sandbox);
+
+const go = new sandbox.Go();
+const buf = fsNode.readFileSync(wasmPath);
+const result = await WebAssembly.instantiate(buf, go.importObject);
+go.run(result.instance);
+await new Promise((r) => setTimeout(r, 100));
+
+if (typeof sandbox.trajanInitialize !== "function") {
+  throw new Error("trajanInitialize missing");
+}
+
+const init = await sandbox.trajanInitialize({
+  outputDir: "/run",
+  concurrency: 4,
+  onLog(level, msg) {
+    // quiet
+  },
+});
+if (!init || !init.ok) throw new Error("initialize failed: " + JSON.stringify(init));
+
+const listed = sandbox.__trajanFS.list("/");
+if (!listed.includes("run")) throw new Error("/run not created: " + JSON.stringify(listed));
+
+const ver = sandbox.trajanVersion();
+console.log("wasm-init smoke: ok", ver.version, "outputDir=" + init.outputDir);

--- a/cmd/trajan-wasm/api.go
+++ b/cmd/trajan-wasm/api.go
@@ -1,0 +1,600 @@
+//go:build js
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall/js"
+
+	"github.com/praetorian-inc/trajan/internal/ado"
+	"github.com/praetorian-inc/trajan/internal/engine"
+	"github.com/praetorian-inc/trajan/internal/github"
+	"github.com/praetorian-inc/trajan/internal/gitlab"
+	"github.com/praetorian-inc/trajan/internal/report"
+	"github.com/praetorian-inc/trajan/internal/ui"
+)
+
+var (
+	cfg           = &engine.Config{Concurrency: 8, OutputDir: "/run"}
+	activeCancel  context.CancelFunc
+	onLogCallback js.Value
+	initialized   bool
+)
+
+func registerAPI() {
+	js.Global().Set("trajanInitialize", js.FuncOf(promiseOf(initialize)))
+	js.Global().Set("trajanWhoAmI", js.FuncOf(promiseOf(whoami)))
+	js.Global().Set("trajanScan", js.FuncOf(promiseOf(scan)))
+	js.Global().Set("trajanReport", js.FuncOf(promiseOf(reportFn)))
+	js.Global().Set("trajanCancel", js.FuncOf(cancel))
+	js.Global().Set("trajanVersion", js.FuncOf(func(this js.Value, args []js.Value) any {
+		return map[string]any{
+			"version":   Version,
+			"buildTime": BuildTime,
+			"gitCommit": GitCommit,
+		}
+	}))
+}
+
+// promiseOf wraps a Go handler so JS gets a Promise. Work runs in a goroutine;
+// a blocking js.FuncOf would deadlock browser fetch.
+func promiseOf(fn func(js.Value) (any, error)) func(js.Value, []js.Value) any {
+	return func(this js.Value, args []js.Value) any {
+		var opts js.Value
+		if len(args) > 0 {
+			opts = args[0]
+		} else {
+			opts = js.Null()
+		}
+		handler := js.FuncOf(func(this js.Value, args []js.Value) any {
+			resolve := args[0]
+			reject := args[1]
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						reject.Invoke(jsError(fmt.Errorf("panic: %v", r)))
+					}
+				}()
+				out, err := fn(opts)
+				if err != nil {
+					reject.Invoke(jsError(err))
+					return
+				}
+				resolve.Invoke(toJS(out))
+			}()
+			return nil
+		})
+		return js.Global().Get("Promise").New(handler)
+	}
+}
+
+func jsError(err error) map[string]any {
+	return map[string]any{"error": err.Error()}
+}
+
+func toJS(v any) any {
+	if v == nil {
+		return js.Null()
+	}
+	switch x := v.(type) {
+	case map[string]any:
+		return x
+	case string, bool, float64, int, int64:
+		return x
+	default:
+		b, err := json.Marshal(x)
+		if err != nil {
+			return map[string]any{"error": err.Error()}
+		}
+		var m any
+		if err := json.Unmarshal(b, &m); err != nil {
+			return string(b)
+		}
+		return convertJSON(m)
+	}
+}
+
+func convertJSON(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := map[string]any{}
+		for k, val := range x {
+			out[k] = convertJSON(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, val := range x {
+			out[i] = convertJSON(val)
+		}
+		return out
+	case float64, string, bool, nil:
+		return x
+	default:
+		return fmt.Sprint(x)
+	}
+}
+
+func strOpt(opts js.Value, key, fallback string) string {
+	if opts.IsNull() || opts.IsUndefined() {
+		return fallback
+	}
+	v := opts.Get(key)
+	if v.IsUndefined() || v.IsNull() {
+		return fallback
+	}
+	return v.String()
+}
+
+func intOpt(opts js.Value, key string, fallback int) int {
+	if opts.IsNull() || opts.IsUndefined() {
+		return fallback
+	}
+	v := opts.Get(key)
+	if v.IsUndefined() || v.IsNull() {
+		return fallback
+	}
+	n := v.Int()
+	if n <= 0 {
+		return fallback
+	}
+	return n
+}
+
+func boolOpt(opts js.Value, key string) bool {
+	if opts.IsNull() || opts.IsUndefined() {
+		return false
+	}
+	v := opts.Get(key)
+	return !v.IsUndefined() && !v.IsNull() && v.Bool()
+}
+
+type jsLogHandler struct{}
+
+func (h *jsLogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *jsLogHandler) Handle(_ context.Context, r slog.Record) error {
+	if onLogCallback.IsUndefined() || onLogCallback.IsNull() {
+		return nil
+	}
+	attrs := map[string]any{}
+	r.Attrs(func(a slog.Attr) bool {
+		attrs[a.Key] = a.Value.String()
+		return true
+	})
+	onLogCallback.Invoke(r.Level.String(), r.Message, attrs)
+	return nil
+}
+
+func (h *jsLogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *jsLogHandler) WithGroup(string) slog.Handler      { return h }
+
+func initialize(opts js.Value) (any, error) {
+	ui.Init(ui.Human, false)
+	slog.SetDefault(slog.New(&jsLogHandler{}))
+
+	cfg.OutputDir = strOpt(opts, "outputDir", "/run")
+	if !strings.HasPrefix(cfg.OutputDir, "/") {
+		return nil, fmt.Errorf("outputDir must be absolute (browser has no working directory); got %q", cfg.OutputDir)
+	}
+	cfg.Concurrency = intOpt(opts, "concurrency", 8)
+
+	cb := opts.Get("onLog")
+	if !cb.IsUndefined() && !cb.IsNull() && cb.Type() == js.TypeFunction {
+		onLogCallback = cb
+	} else {
+		onLogCallback = js.Undefined()
+	}
+
+	if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir outputDir: %w", err)
+	}
+	initialized = true
+	return map[string]any{
+		"ok":          true,
+		"outputDir":   cfg.OutputDir,
+		"concurrency": cfg.Concurrency,
+		"version":     Version,
+	}, nil
+}
+
+func normalizePlatform(p string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(p)) {
+	case "github", "gh":
+		return "github", nil
+	case "gitlab", "gl":
+		return "gitlab", nil
+	case "ado", "azuredevops", "azure-devops", "azdo":
+		return "ado", nil
+	default:
+		return "", fmt.Errorf("unsupported platform %q (want github|gitlab|ado)", p)
+	}
+}
+
+func applyGitLabBase(baseURL string) error {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		gitlab.FlagURL = "https://gitlab.com"
+		return nil
+	}
+	if err := validateHTTPURL(baseURL); err != nil {
+		return err
+	}
+	gitlab.FlagURL = baseURL
+	return nil
+}
+
+func validateHTTPURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q", u.Scheme)
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "" {
+		return fmt.Errorf("URL must include a hostname")
+	}
+	blocked := []string{"169.254.169.254", "169.254.169.253", "metadata.google.internal", "metadata.azure.com"}
+	for _, b := range blocked {
+		if host == b || strings.Contains(host, b) {
+			return fmt.Errorf("access to cloud metadata service is forbidden")
+		}
+	}
+	return nil
+}
+
+func whoami(opts js.Value) (any, error) {
+	if !initialized {
+		return nil, fmt.Errorf("call initialize first")
+	}
+	platform, err := normalizePlatform(strOpt(opts, "platform", ""))
+	if err != nil {
+		return nil, err
+	}
+	token := strOpt(opts, "token", "")
+	baseURL := strOpt(opts, "baseUrl", "")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	switch platform {
+	case "github":
+		return githubIdentity(ctx, token)
+	case "gitlab":
+		if err := applyGitLabBase(baseURL); err != nil {
+			return nil, err
+		}
+		if gitlab.FlagInsecure {
+			return nil, fmt.Errorf("GitLab insecure TLS is not supported in the browser (fetch ignores InsecureSkipVerify)")
+		}
+		return gitlabIdentity(ctx, token)
+	case "ado":
+		org := strOpt(opts, "org", "")
+		if org == "" {
+			org = strOpt(opts, "locator", "")
+		}
+		bearer := strOpt(opts, "bearerToken", "")
+		return adoIdentity(ctx, org, token, bearer)
+	}
+	return nil, fmt.Errorf("unsupported platform")
+}
+
+func githubIdentity(ctx context.Context, token string) (any, error) {
+	tok, err := github.ResolveToken(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	c := github.NewClient(tok)
+	if raw, hdr, err := c.Get(ctx, "/user", nil, false); err == nil {
+		var user struct {
+			Login string `json:"login"`
+			ID    int64  `json:"id"`
+		}
+		if err := json.Unmarshal(raw, &user); err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"platform": "github",
+			"kind":     "user",
+			"login":    user.Login,
+			"id":       float64(user.ID),
+			"scopes":   hdr.Get("X-OAuth-Scopes"),
+		}, nil
+	}
+	raw, _, err := c.Get(ctx, "/installation/repositories", url.Values{"per_page": []string{"1"}}, false)
+	if err != nil {
+		return nil, fmt.Errorf("token is not a user token and /installation/repositories failed: %w", err)
+	}
+	var inst struct {
+		TotalCount int `json:"total_count"`
+	}
+	if err := json.Unmarshal(raw, &inst); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"platform":               "github",
+		"kind":                   "app",
+		"accessibleRepositories": float64(inst.TotalCount),
+	}, nil
+}
+
+func gitlabIdentity(ctx context.Context, token string) (any, error) {
+	tok, err := gitlab.ResolveToken(token)
+	if err != nil {
+		return nil, err
+	}
+	cl := gitlab.NewClient(gitlab.ResolveBaseURL(gitlab.FlagURL), tok, false, 1)
+	userRaw, _, err := cl.Get(ctx, "/user", nil, false)
+	if err != nil {
+		return nil, err
+	}
+	var user struct {
+		Username string `json:"username"`
+		Name     string `json:"name"`
+		IsAdmin  bool   `json:"is_admin"`
+		Bot      bool   `json:"bot"`
+	}
+	if err := json.Unmarshal(userRaw, &user); err != nil {
+		return nil, err
+	}
+	out := map[string]any{
+		"platform": "gitlab",
+		"username": user.Username,
+		"name":     user.Name,
+		"admin":    user.IsAdmin,
+		"bot":      user.Bot,
+		"baseUrl":  gitlab.ResolveBaseURL(gitlab.FlagURL),
+	}
+	if patRaw, _, perr := cl.Get(ctx, "/personal_access_tokens/self", nil, true); perr == nil && patRaw != nil {
+		var pat struct {
+			Scopes []string `json:"scopes"`
+		}
+		if json.Unmarshal(patRaw, &pat) == nil {
+			scopes := make([]any, len(pat.Scopes))
+			for i, s := range pat.Scopes {
+				scopes[i] = s
+			}
+			out["scopes"] = scopes
+		}
+	}
+	return out, nil
+}
+
+func adoIdentity(ctx context.Context, org, pat, bearer string) (any, error) {
+	if strings.TrimSpace(org) == "" {
+		return nil, fmt.Errorf("ado whoami requires org (or locator)")
+	}
+	scope, err := ado.ParseScope(org)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := ado.ResolveCredential(pat, bearer)
+	if err != nil {
+		return nil, err
+	}
+	var cl *ado.Client
+	if cred.Kind == engine.CredBearer {
+		cl = ado.NewClientBearer(scope.Org, cred.Value)
+	} else {
+		cl = ado.NewClient(scope.Org, cred.Value)
+	}
+	raw, _, err := cl.Get(ctx, "core", ado.APIVersionPreview, "/_apis/connectionData", nil, false)
+	if err != nil {
+		return nil, err
+	}
+	var conn struct {
+		AuthenticatedUser struct {
+			ID                  string `json:"id"`
+			ProviderDisplayName string `json:"providerDisplayName"`
+			Properties          struct {
+				Account struct {
+					Value string `json:"$value"`
+				} `json:"Account"`
+			} `json:"properties"`
+		} `json:"authenticatedUser"`
+		DeploymentType string `json:"deploymentType"`
+	}
+	if err := json.Unmarshal(raw, &conn); err != nil {
+		return nil, err
+	}
+	u := conn.AuthenticatedUser
+	identity := u.ProviderDisplayName
+	if email := u.Properties.Account.Value; email != "" {
+		identity += " <" + email + ">"
+	}
+	return map[string]any{
+		"platform":       "ado",
+		"identity":       identity,
+		"id":             u.ID,
+		"organization":   scope.Org,
+		"deploymentType": conn.DeploymentType,
+	}, nil
+}
+
+func scan(opts js.Value) (any, error) {
+	if !initialized {
+		return nil, fmt.Errorf("call initialize first")
+	}
+	platform, err := normalizePlatform(strOpt(opts, "platform", ""))
+	if err != nil {
+		return nil, err
+	}
+	locator := strings.TrimSpace(strOpt(opts, "locator", ""))
+	existing := strings.TrimSpace(strOpt(opts, "runDir", ""))
+	if locator == "" && existing == "" {
+		return nil, fmt.Errorf("locator is required")
+	}
+	token := strOpt(opts, "token", "")
+	bearer := strOpt(opts, "bearerToken", "")
+	baseURL := strOpt(opts, "baseUrl", "")
+	orgOnly := boolOpt(opts, "orgOnly")
+
+	runCfg := &engine.Config{
+		Concurrency: cfg.Concurrency,
+		OutputDir:   cfg.OutputDir,
+		Token:       token,
+		BearerToken: bearer,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	activeCancel = cancel
+	defer func() {
+		cancel()
+		activeCancel = nil
+	}()
+
+	var runDir string
+	if existing != "" {
+		// Scan-only over an already-normalized runDir (fixture / resume).
+		runDir = existing
+		switch platform {
+		case "github":
+			err = github.Scan(ctx, runDir, github.ScanOptions{OrgOnly: orgOnly})
+		case "gitlab":
+			if err := applyGitLabBase(baseURL); err != nil {
+				return nil, err
+			}
+			err = gitlab.Scan(ctx, runDir, gitlab.ScanOptions{GroupOnly: orgOnly})
+		case "ado":
+			err = ado.Scan(ctx, runDir, ado.ScanOptions{OrgOnly: orgOnly})
+		}
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		switch platform {
+		case "github":
+			runDir, err = github.Collect(ctx, runCfg, locator)
+			if err != nil {
+				return nil, err
+			}
+			if err := github.Normalize(ctx, runDir); err != nil {
+				return nil, err
+			}
+			if err := github.Scan(ctx, runDir, github.ScanOptions{OrgOnly: orgOnly}); err != nil {
+				return nil, err
+			}
+		case "gitlab":
+			if err := applyGitLabBase(baseURL); err != nil {
+				return nil, err
+			}
+			if gitlab.FlagInsecure {
+				return nil, fmt.Errorf("GitLab insecure TLS is not supported in the browser")
+			}
+			runDir, err = gitlab.Collect(ctx, runCfg, locator)
+			if err != nil {
+				return nil, err
+			}
+			if err := gitlab.Normalize(ctx, runDir); err != nil {
+				return nil, err
+			}
+			if err := gitlab.Scan(ctx, runDir, gitlab.ScanOptions{GroupOnly: orgOnly}); err != nil {
+				return nil, err
+			}
+		case "ado":
+			runDir, err = ado.Collect(ctx, runCfg, locator)
+			if err != nil {
+				return nil, err
+			}
+			if err := ado.Normalize(ctx, runDir); err != nil {
+				return nil, err
+			}
+			if err := ado.Scan(ctx, runDir, ado.ScanOptions{OrgOnly: orgOnly}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	summary := map[string]any{
+		"runDir":   runDir,
+		"platform": platform,
+		"locator":  locator,
+	}
+	if b, err := os.ReadFile(filepath.Join(runDir, "20-scan", "_summary.json")); err == nil {
+		var s struct {
+			RulesLoaded   int            `json:"rules_loaded"`
+			TotalFindings int            `json:"total_findings"`
+			RuleFires     map[string]int `json:"rule_fires"`
+		}
+		if json.Unmarshal(b, &s) == nil {
+			summary["rulesLoaded"] = s.RulesLoaded
+			summary["total"] = s.TotalFindings
+			fires := map[string]any{}
+			for k, v := range s.RuleFires {
+				fires[k] = v
+			}
+			summary["ruleFires"] = fires
+		}
+	}
+	if state, err := engine.LoadState(runDir); err == nil {
+		degraded := 0
+		bySev := map[string]any{}
+		for _, p := range state.Phases {
+			degraded += len(p.Errors)
+		}
+		summary["degraded"] = degraded
+		// severity counts come from report meta; leave empty here if unknown
+		summary["bySeverity"] = bySev
+		_ = state
+	}
+	return summary, nil
+}
+
+func reportFn(opts js.Value) (any, error) {
+	if !initialized {
+		return nil, fmt.Errorf("call initialize first")
+	}
+	runDir := strOpt(opts, "runDir", "")
+	if runDir == "" {
+		return nil, fmt.Errorf("runDir is required")
+	}
+	format := strOpt(opts, "format", "html")
+	ctx := context.Background()
+	if err := report.Run(ctx, runDir, report.Options{
+		Format:        format,
+		MinSeverity:   strOpt(opts, "minSeverity", "info"),
+		MinConfidence: strOpt(opts, "minConfidence", "low"),
+	}); err != nil {
+		return nil, err
+	}
+
+	var name string
+	switch format {
+	case "html":
+		name = "findings.html"
+	case "md":
+		name = "findings.md"
+	case "json":
+		name = "findings.json"
+	case "jsonl":
+		name = "findings.jsonl"
+	default:
+		return nil, fmt.Errorf("unsupported format %q", format)
+	}
+	b, err := os.ReadFile(filepath.Join(runDir, name))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"format":  format,
+		"path":    filepath.Join(runDir, name),
+		"content": string(b),
+		"bytes":   len(b),
+	}, nil
+}
+
+func cancel(this js.Value, args []js.Value) any {
+	if activeCancel != nil {
+		activeCancel()
+		return map[string]any{"ok": true}
+	}
+	return map[string]any{"ok": false, "error": "no active scan"}
+}

--- a/cmd/trajan-wasm/main.go
+++ b/cmd/trajan-wasm/main.go
@@ -1,0 +1,28 @@
+//go:build js
+
+package main
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+// Injected via -ldflags from the Makefile.
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildTime = "unknown"
+)
+
+func main() {
+	registerAPI()
+	js.Global().Set("trajanGetVersion", js.FuncOf(func(this js.Value, args []js.Value) any {
+		return map[string]any{
+			"version":   Version,
+			"buildTime": BuildTime,
+			"gitCommit": GitCommit,
+		}
+	}))
+	fmt.Printf("Trajan WASM v%s (commit %s)\n", Version, GitCommit)
+	select {}
+}

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,143 @@
+# WASM Browser Scanner Rebuild
+
+## Goal
+
+Ship a browser-runnable Trajan that runs the current YAML detection pipeline (GitHub, GitLab, Azure DevOps), shows results in the same self-contained HTML report look used by the CLI / GitHub Action, and does **not** include attack or graph.
+
+## Context (what existed and why it died)
+
+- Old stack lived under `browser/` + `cmd/trajan-wasm`, introduced in the initial public release, retired in PR #136 (`da1cf68` / landed on `main` via #135).
+- It used Go plugins (`pkg/detections` + `scanner.DetectionExecutor`), not YAML under `internal/detection-rules`.
+- ADO needed `browser/server.go` `/azdo-proxy/` because browser `fetch` hit CORS; GitHub/GitLab did not.
+- Packaging: `make wasm-dist` inlined CSS/JS/`wasm_exec.js` and base64-embedded `trajan.wasm` into one `trajan-standalone.html`.
+- Broken after attack exports were removed while `bridge.js` still required them — page threw on load.
+
+Do **not** revive that SPA (Validate / Recon / Attack / Shell tabs). Rebuild against `internal/`.
+
+## Product scope
+
+| In | Out |
+|----|-----|
+| Collect → normalize → scan (YAML rules) for GitHub, GitLab, ADO | `internal/attack` |
+| Report HTML (same assets as CLI/Action) | `internal/graph` / Neo4j |
+| Token + platform + scope inputs, run, progress, cancel | Legacy `pkg/scanner` / Go detectors |
+| Self-contained HTML artifact | Persisting PATs in `localStorage` |
+
+Rules stay first-party via existing `//go:embed` in `internal/detection-rules/embed.go` (~301 rules across github/gitlab/ado).
+
+## Architecture
+
+```mermaid
+flowchart LR
+  UI["browser shell\nreport.css + form"]
+  Bridge["JS bridge\nfs path shims"]
+  WASM["cmd/trajan-wasm\nPromise API"]
+  Pipe["Collect Normalize Scan"]
+  Rules["embed.FS YAML rules"]
+  Report["internal/report\nfindings.html"]
+  APIs["GitHub GitLab ADO APIs"]
+
+  UI --> Bridge --> WASM
+  WASM --> Pipe
+  Pipe --> Rules
+  Pipe --> APIs
+  WASM --> Report
+  Report --> UI
+```
+
+**Runtime model (chosen):**
+
+1. In-memory JS `fs` + `path` shims (~150 lines) so the unmodified on-disk `runDir` contract works. Empirically validated: `Scan` + `report.Run(html)` already succeed under browser conditions with this shim; no Go IO rewrite needed.
+2. Absolute `OutputDir` (e.g. `/run`) — browser `os.Getwd` is `ENOSYS`.
+3. WASM `scan` mirrors CLI `run` (thread `runDir` in Go; do not call `ResolveRunDir`).
+4. Results UI: after scan, call `report.Run(..., format: html)`, read `findings.html` from the shim FS, inject into the page (iframe `srcdoc` or replace `#results`). Zero drift from `internal/report/assets/`.
+5. Shell chrome (form + progress) sits **above** that report; copy masthead / tiles / cards / filters / theme from the report assets — do not invent a second visual language.
+6. Exclude attack/graph by not importing them from the WASM `main` (linker drops them). ~21 MB raw / ~5 MB gzip for three platforms + report.
+
+## UI design
+
+Reuse as-is from `internal/report/assets/report.css`, `report.html`, `report.js`:
+
+- CSS variables, severity tiles, sticky sidebar filters, finding cards, light/dark theme, print styles.
+- GitHub Action job summary Markdown is **not** the look — only the HTML report is.
+
+Add above the report mount:
+
+- Platform: `github` | `gitlab` | `ado`
+- Token (password field; memory-only, no `localStorage`)
+- Scope / locator (same strings as CLI: `org/repo`, group, `org/project`, or HTTPS URL)
+- Optional GitLab base URL (self-hosted)
+- Optional ADO org URL when needed
+- Run / Cancel
+- Progress log (phases + soft errors / degraded), wired from `slog` → `onLog`
+
+Idle state: form + empty dashed panel (same empty-run treatment as the report). After scan: inject the full self-contained report document into `#results`.
+
+## JS ↔ Go API (minimal)
+
+Every export returns a `Promise`; work runs in a goroutine (blocking `js.FuncOf` deadlocks fetch).
+
+```javascript
+trajan.initialize({ outputDir: "/run", concurrency, onLog })
+trajan.whoami({ platform, token, baseUrl })   // structured; adapt print-only WhoAmI
+trajan.scan({ platform, locator, token, baseUrl, orgOnly })
+trajan.report({ runDir, format: "html"|"jsonl"|"md", minSeverity, minConfidence })
+trajan.cancel()
+trajan.version()
+```
+
+No `configGet`/`configSet`, no attack, no enumerate/search leftovers from the old bridge.
+
+## Azure DevOps / CORS
+
+Old assumption (“ADO has no ACAO”) looks stale: live OPTIONS probes show `dev.azure.com` and `vssps.dev.azure.com` advertising `ACAO: *` + `authorization`. GitHub and GitLab cloud already work via fetch.
+
+**Plan:** ship **without** a required localhost proxy. Before release, live-test a real ADO PAT across all six `hostBase` hosts in `internal/ado/client.go`. If any host fails CORS or opaque redirect-to-login:
+
+- Reintroduce a thin allowlisted reverse proxy (pattern from deleted `browser/server.go`: host allowlist, strip `Www-Authenticate`, same-origin only).
+- Repoint `hostBase` (already a `var` for tests) rather than re-adding `WithHTTPTransport` to `internal/` clients.
+
+Self-hosted GitLab without CORS is the more likely proxy case; document “cloud works file:// or static host; self-hosted / broken-CORS needs `wasm-serve`.”
+
+## Packaging and build
+
+Restore Makefile targets (names can match history):
+
+- `wasm` — `GOOS=js GOARCH=wasm go build -o browser/trajan.wasm ./cmd/trajan-wasm` + copy GOROOT `wasm_exec.js`
+- `wasm-serve` — static server for multi-file dev (proxy only if ADO/self-hosted verification requires it)
+- `wasm-dist` — single `browser/trajan-standalone.html` (inline CSS/JS/`wasm_exec.js`/`bridge.js`/`app.js`, base64 WASM)
+
+New tree (leaner than the old multi-tab SPA):
+
+- `cmd/trajan-wasm/` — `main.go` + `api.go` (`//go:build js`)
+- `browser/` — `index.html`, `styles` (report.css + thin shell), `app.js`, `bridge.js`, `fs-shim.js`, optional `server.go`
+
+Do not resurrect `pkg/config` / `pkg/storage` IndexedDB token stores.
+
+## Go changes (small)
+
+Prefer zero pipeline changes. Likely touch points:
+
+1. `cmd/trajan-wasm` only imports `internal/{engine,engine/detect,github,gitlab,ado,report,finding,dsl,ui}` — never attack/graph.
+2. Structured `WhoAmI` return for the bridge (CLI today prints).
+3. `slog` / UI writer: bridge logs to `onLog` (call `slog.SetDefault` after `ui.Init`, or widen `ui.Init` if needed).
+4. GitLab insecure TLS: hard-error in WASM (fetch ignores `InsecureSkipVerify`).
+5. Optional later: exported in-memory `report.Render` — start by reading shim FS after `report.Run`.
+
+## Implementation order
+
+1. Write `plan.md` (this document).
+2. JS `fs` + `path` shims + smoke harness (scan/report against fixture or live token).
+3. `cmd/trajan-wasm` Promise API (initialize / whoami / scan / report / cancel / version).
+4. Browser shell: form + progress + inject `findings.html` using report assets.
+5. Live CORS verification for ADO (and document proxy fallback if needed).
+6. `wasm` / `wasm-dist` / optional `wasm-serve`; wire GoReleaser artifact when ready.
+7. Short `browser/README.md` (how to build, token handling, platform notes). Keep root README mention brief.
+
+## Explicit non-goals
+
+- Attack plans / primitives in the browser
+- Graph / Neo4j from the browser
+- Parity with old recon/enumerate/shell/search tabs
+- Storing customer PATs in `localStorage` or IndexedDB
+- Rewriting the phased engine to pure in-memory Go APIs in v1


### PR DESCRIPTION
## Summary
- Rebuild the browser/WASM scanner against the current `internal/` collect → normalize → scan pipeline (GitHub, GitLab, ADO), with first-party YAML rules embedded in the binary
- Reuse the CLI/GitHub Action HTML report look for results; add a thin scan form shell (token, platform, locator). Attack and graph are excluded from the WASM build
- Restore `make wasm` / `wasm-serve` / `wasm-dist` / `wasm-smoke`, optional localhost CORS proxy for self-hosted cases, and GoReleaser standalone HTML attachment. ADO cloud CORS verified across all six `hostBase` hosts (no required proxy)

## Test plan
- [ ] `make wasm-smoke` (fs shim + WASM init + fixture scan/report)
- [ ] `make wasm-serve` → open http://localhost:8080, run a live GitHub/GitLab/ADO scan with a real token
- [ ] Confirm findings render in the same HTML report UI (tiles, filters, theme)
- [ ] Confirm Cancel aborts an in-flight scan
- [ ] `make wasm-dist` produces a usable `browser/trajan-standalone.html`
- [ ] Confirm attack/graph are not reachable from the browser API


Made with [Cursor](https://cursor.com)