### PR TITLE
ci: onboard leaderboard backfill replay caller (ENG-5992)

### DIFF
--- a/.github/workflows/leaderboard-backfill-caller.yml
+++ b/.github/workflows/leaderboard-backfill-caller.yml
@@ -1,0 +1,49 @@
+# Operator-dispatched REPLAY path for leaderboard metrics. The live caller
+# (leaderboard-metrics.yml) fires only on a real `pull_request_target: closed`
+# event and never retries, so PRs that merged before this repo was onboarded
+# have no metrics at all. The 2026-08-09 fleet audit (ENG-5973) found 2 PRs
+# in trajan with no delivery run at all (#136, #137).
+#
+# ⚠ The `uses:` pin is COUPLED TO PROD IAM: the LeaderboardMetricsRole trust
+# list names the CALLED reusable at this exact SHA, so bumping it alone fails
+# closed at AssumeRole with no local signal. A bump needs the matching
+# guard-core backend/template.yml entry deployed FIRST (ENG-4164 runbook).
+#
+# This repo has NO .github/dependabot.yml, so Dependabot version updates are
+# off and the pin above is not currently at risk of an automated bump. If a
+# dependabot.yml is ever added here with a `github-actions` ecosystem, it MUST
+# carry ignore entries for BOTH leaderboard reusables, or this pin gets bumped
+# and delivery fails closed and silently — the ENG-5687 incident exactly.
+#
+# `capability_map` is omitted DELIBERATELY — unset means "derive it from this
+# repo's own live leaderboard-metrics.yml on the default branch", so a replay
+# attributes capabilities exactly as live runs do; passing a value is what
+# would drift.
+#
+# Replay is idempotent ONLY while author resolution is unchanged: the consumer
+# upserts CodeCommit on `#code_commit#<repo>#<pr_number>#<author>`, so
+# re-running a PR overwrites its own row — a changed ENGINEER_EMAIL_MAP keys a
+# second row and double-counts (ENG-5693).
+#
+# Sole repo prerequisite: the `leaderboard` GitHub environment (present). NEVER
+# apply the Actions OIDC sub-claim customization (see leaderboard-metrics.yml).
+name: Leaderboard Backfill
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: "PR numbers to replay (comma- or space-separated)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+
+jobs:
+  backfill:
+    uses: praetorian-inc/public-workflows/.github/workflows/leaderboard-backfill.yml@6c715ccf351a09bfcb916aede4c542e437e5f31d # v2.17.0
+    with:
+      pr_numbers: ${{ inputs.pr_numbers }}


### PR DESCRIPTION
## Summary

Onboards the operator-dispatched leaderboard backfill replay caller (ENG-5992, part of the ENG-5973 fleet-audit follow-up):

- **`.github/workflows/leaderboard-backfill-caller.yml`** (new) — dispatch-only (`workflow_dispatch`) caller of the `leaderboard-backfill.yml` reusable, replicated from the template already merged in `nerva` and `caeruleus`. Merging this enables replay; it never runs automatically, and no dispatch happens as part of this PR.

This repo has no `.github/dependabot.yml`, so no dependabot change is needed; the workflow header documents the ignore requirement should one ever be added.

## Why

The 2026-08-09 fleet audit found 2 replay-eligible PRs in this repo with no delivery run at all (#136, #137 — merged before onboarding). Replaying them requires this caller.

## Do not bump the pin

`uses: …leaderboard-backfill.yml@6c715ccf351a09bfcb916aede4c542e437e5f31d # v2.17.0` is the exact SHA on the IAM trust list. Bumping it alone fails closed at AssumeRole with no local signal — a bump follows the ENG-4164 runbook (trust updated and deployed first).

## Gates

- **Premise gate: SKIP recorded** — template replication of an already-merged mechanism; no non-trivial machinery (size-and-behavior condition).
- **Shell review-after gate: passed pre-PR** — shell-reviewer verdict REVIEW_APPROVED; everything from `name:` down verified byte-identical (sha256) to the live nerva/caeruleus canonical; actionlint clean; this repo's `verify-pins.yml` passes on the SHA-pinned `uses:`.
- **Provenance:** the workflow file is entirely new.

Ticket: ENG-5992 (blocks the ENG-5690 replay work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
