### PR TITLE
internal/ado: build an attack graph from normalized Azure DevOps output

### DIFF
--- a/cmd/trajan/ado/root.go
+++ b/cmd/trajan/ado/root.go
@@ -31,6 +31,8 @@ func newAdoCmd() *cobra.Command {
 	var path string
 	var orgDetectionsOnly bool
 	var reportFormat, reportMinSev, reportMinConf, reportOut string
+	var neo4jURL, neo4jUser, neo4jPass string
+	var neo4jReset bool
 
 	collectRun := func(cmd *cobra.Command, args []string) (string, error) {
 		locator := ""
@@ -110,9 +112,37 @@ embedded ADO detection-rule corpus, and writes findings to 20-scan.`,
 			})
 		},
 	}
+	graph := &cobra.Command{
+		Use:   "graph",
+		Short: "Build the property graph from a normalized, scanned run",
+		Long: `Build nodes and edges from a normalized run directory.
+
+Reads the 10-normalize records and 20-scan findings, resolves every edge record to
+typed endpoints, and writes nodes, edges and a summary to 30-graph.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runDir, err := engine.ResolveRunDir(cfg, "ado", path)
+			if err != nil {
+				return err
+			}
+			return adopkg.BuildGraph(cmd.Context(), cfg, runDir)
+		},
+	}
+	push := &cobra.Command{
+		Use:   "push",
+		Short: "Push a built graph into Neo4j",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runDir, err := engine.ResolveRunDir(cfg, "ado", path)
+			if err != nil {
+				return err
+			}
+			return adopkg.PushGraph(cmd.Context(), cfg, runDir, neo4jURL, neo4jUser, neo4jPass, neo4jReset)
+		},
+	}
 	run := &cobra.Command{
 		Use:   "run [locator]",
-		Short: "Wrapper: collect, normalize, scan in one process",
+		Short: "Wrapper: collect, normalize, scan, graph in one process",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runDir, err := collectRun(cmd, args)
@@ -122,13 +152,20 @@ embedded ADO detection-rule corpus, and writes findings to 20-scan.`,
 			if err := adopkg.Normalize(cmd.Context(), runDir); err != nil {
 				return err
 			}
-			return adopkg.Scan(cmd.Context(), runDir, adopkg.ScanOptions{})
+			if err := adopkg.Scan(cmd.Context(), runDir, adopkg.ScanOptions{}); err != nil {
+				return err
+			}
+			return adopkg.BuildGraph(cmd.Context(), cfg, runDir)
 		},
 	}
 
 	scan.Flags().BoolVar(&orgDetectionsOnly, "org-detections-only", false, "evaluate only org-subject (org-level) rules")
+	push.Flags().StringVar(&neo4jURL, "neo4j-url", "bolt://localhost:7687", "Neo4j bolt URL")
+	push.Flags().StringVar(&neo4jUser, "neo4j-user", "neo4j", "Neo4j user")
+	push.Flags().StringVar(&neo4jPass, "neo4j-pass", "", "Neo4j password")
+	push.Flags().BoolVar(&neo4jReset, "reset", false, "delete every node in the database before writing")
 
-	for _, c := range []*cobra.Command{normalize, scan, reportCmd} {
+	for _, c := range []*cobra.Command{normalize, scan, reportCmd, graph, push} {
 		c.Flags().StringVarP(&path, "path", "p", "", "run directory (default: latest)")
 	}
 	reportCmd.Flags().StringVar(&reportFormat, "format", "jsonl", "output format: json|jsonl|md|html|all")
@@ -141,6 +178,6 @@ embedded ADO detection-rule corpus, and writes findings to 20-scan.`,
 		c.Flags().StringVar(&cfg.BearerToken, "azure-bearer-token", "", bearerHelp)
 	}
 
-	ado.AddCommand(whoami, collect, normalize, scan, reportCmd, run)
+	ado.AddCommand(whoami, collect, normalize, scan, reportCmd, graph, push, run)
 	return ado
 }

--- a/cmd/trajan/ado/root.go
+++ b/cmd/trajan/ado/root.go
@@ -1,14 +1,36 @@
 package ado
 
 import (
+	"fmt"
+	"log/slog"
+
 	"github.com/spf13/cobra"
 
 	adopkg "github.com/praetorian-inc/trajan/internal/ado"
 	"github.com/praetorian-inc/trajan/internal/engine"
+	"github.com/praetorian-inc/trajan/internal/engine/detect"
 	"github.com/praetorian-inc/trajan/internal/report"
 )
 
 var AdoCmd = newAdoCmd()
+
+func ruleTargets() (map[string]adopkg.Target, error) {
+	onError := func(e error) { slog.Warn("rule skipped", "err", e) }
+	rules, err := detect.LoadRules("ado", onError)
+	if err != nil {
+		return nil, err
+	}
+	targets := make(map[string]adopkg.Target, len(rules))
+	for _, r := range rules {
+		t, err := adopkg.ParseTarget(r.Graph)
+		if err != nil {
+			onError(fmt.Errorf("%s: %w", r.ID, err))
+			continue
+		}
+		targets[r.ID] = t
+	}
+	return targets, nil
+}
 
 const (
 	tokenHelp  = "PAT (prefer TRAJAN_ADO_TOKEN/ADO_PAT/AZURE_DEVOPS_PAT/AZDO_PAT/AZURE_DEVOPS_EXT_PAT env; this flag is an escape hatch)"
@@ -125,7 +147,11 @@ typed endpoints, and writes nodes, edges and a summary to 30-graph.`,
 			if err != nil {
 				return err
 			}
-			return adopkg.BuildGraph(cmd.Context(), cfg, runDir)
+			targets, err := ruleTargets()
+			if err != nil {
+				return err
+			}
+			return adopkg.BuildGraph(cmd.Context(), cfg, runDir, targets)
 		},
 	}
 	push := &cobra.Command{
@@ -155,7 +181,11 @@ typed endpoints, and writes nodes, edges and a summary to 30-graph.`,
 			if err := adopkg.Scan(cmd.Context(), runDir, adopkg.ScanOptions{}); err != nil {
 				return err
 			}
-			return adopkg.BuildGraph(cmd.Context(), cfg, runDir)
+			targets, err := ruleTargets()
+			if err != nil {
+				return err
+			}
+			return adopkg.BuildGraph(cmd.Context(), cfg, runDir, targets)
 		},
 	}
 

--- a/internal/ado/correlate.go
+++ b/internal/ado/correlate.go
@@ -104,7 +104,7 @@ func deriveRunsAs(cp engine.CurrentPhase, timer *engine.PhaseTimer, pipelines, p
 			"org_provenance":      "unknown",
 		}
 		key := fmt.Sprintf("%s__%d", project, mInt64(pl, "id"))
-		if err := emit(cp, timer, engine.NormalizeADOEdges("runs-as", key), rec); err != nil {
+		if err := emitEdge(cp, timer, "runs-as", key, rec); err != nil {
 			return err
 		}
 	}
@@ -156,7 +156,7 @@ func derivePolicyAttribution(cp engine.CurrentPhase, timer *engine.PhaseTimer, p
 					scopeDisc = "all"
 				}
 				key := fmt.Sprintf("%s__%s__%d__%s__%s__%s", adoSafe(project), adoSafe(mStr(r, "name")), mInt64(pol, "config_id"), adoSafe(refName), adoSafe(matchKind), adoSafe(scopeDisc))
-				if err := emit(cp, timer, engine.NormalizeADOEdges("has-policy", key), rec); err != nil {
+				if err := emitEdge(cp, timer, "has-policy", key, rec); err != nil {
 					return err
 				}
 				if bdID := mInt64(mMap(pol, "settings"), "build_definition_id"); bdID != 0 {
@@ -170,7 +170,7 @@ func derivePolicyAttribution(cp engine.CurrentPhase, timer *engine.PhaseTimer, p
 						"build_definition_id": bdID,
 						"is_blocking":         mBool(pol, "is_blocking"),
 					}
-					if err := emit(cp, timer, engine.NormalizeADOEdges("build-validates", key), bv); err != nil {
+					if err := emitEdge(cp, timer, "build-validates", key, bv); err != nil {
 						return err
 					}
 				}
@@ -244,7 +244,7 @@ func deriveEffectiveRoles(ctx context.Context, prior engine.PriorPhase, cp engin
 						"expanded_members":  expandMembers(graphDesc, memberships),
 					}
 					key := hashKey(src.ns, token, desc)
-					if err := emit(cp, timer, engine.NormalizeADOEdges("has-role", key), rec); err != nil {
+					if err := emitEdge(cp, timer, "has-role", key, rec); err != nil {
 						return err
 					}
 				}
@@ -538,7 +538,7 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 			"variable_group_id": ref.id, "owner_project": ref.owner, "resolved": ref.id != 0,
 		}
 		key := fmt.Sprintf("%s__%d__%s__%s__%s__%s", adoSafe(project), pipelineID, level, adoSafe(stage), adoSafe(job), adoSafe(name))
-		return emit(cp, timer, engine.NormalizeADOEdges("consumes-group", key), rec)
+		return emitEdge(cp, timer, "consumes-group", key, rec)
 	}
 	pipelineRecs, err := loadRecords(prior, "10-normalize/pipelines")
 	if err != nil {
@@ -594,7 +594,7 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 				"input_name":            entStr(um["input_name"]),
 				"resolved":              ref.id != "",
 			}
-			if err := emit(cp, timer, engine.NormalizeADOEdges("uses-connection", jobKey+"__"+adoSafe(name)), rec); err != nil {
+			if err := emitEdge(cp, timer, "uses-connection", jobKey+"__"+adoSafe(name), rec); err != nil {
 				return err
 			}
 		}
@@ -617,7 +617,7 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 				"job":   mStr(j, "job"), "environment": envName, "resource": strOrNull(resource),
 				"environment_ref": env, "environment_id": envID, "resolved": envID != 0,
 			}
-			if err := emit(cp, timer, engine.NormalizeADOEdges("targets", jobKey+"__"+adoSafe(env)), rec); err != nil {
+			if err := emitEdge(cp, timer, "targets", jobKey+"__"+adoSafe(env), rec); err != nil {
 				return err
 			}
 		}
@@ -635,7 +635,7 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 				"project_agent_pool_id": poolID,
 				"resolved":              poolID != 0,
 			}
-			if err := emit(cp, timer, engine.NormalizeADOEdges("runs-on", jobKey), rec); err != nil {
+			if err := emitEdge(cp, timer, "runs-on", jobKey, rec); err != nil {
 				return err
 			}
 		}
@@ -690,7 +690,7 @@ func deriveBranches(cp engine.CurrentPhase, timer *engine.PhaseTimer, pipelines,
 			"repo": repoName, "branch": branch, "yaml_path": mStr(pl, "yaml_path"),
 			"branch_id": project + "/" + repoName + "@" + branch,
 		}
-		if err := emit(cp, timer, engine.NormalizeADOEdges("defined-by", fmt.Sprintf("%s__%d", adoSafe(project), mInt64(pl, "id"))), edge); err != nil {
+		if err := emitEdge(cp, timer, "defined-by", fmt.Sprintf("%s__%d", adoSafe(project), mInt64(pl, "id")), edge); err != nil {
 			return err
 		}
 	}
@@ -777,7 +777,7 @@ func deriveMemberOf(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engi
 	for group, members := range loadMemberships(prior, org) {
 		for _, member := range members {
 			rec := map[string]any{"kind": "MEMBER_OF", "member": member, "group": group, "is_direct": true}
-			if err := emit(cp, timer, engine.NormalizeADOEdges("member-of", hashKey(member, group)), rec); err != nil {
+			if err := emitEdge(cp, timer, "member-of", hashKey(member, group), rec); err != nil {
 				return err
 			}
 		}

--- a/internal/ado/correlate.go
+++ b/internal/ado/correlate.go
@@ -585,6 +585,7 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 				"kind":                  "USES_CONNECTION",
 				"project":               project,
 				"pipeline_id":           mInt64(j, "pipeline_id"),
+				"stage":                 mStr(j, "stage"),
 				"job":                   mStr(j, "job"),
 				"connection_name":       name,
 				"service_connection_id": ref.id,
@@ -612,7 +613,8 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 			}
 			rec := map[string]any{
 				"kind": "TARGETS", "project": project, "pipeline_id": mInt64(j, "pipeline_id"),
-				"job": mStr(j, "job"), "environment": envName, "resource": strOrNull(resource),
+				"stage": mStr(j, "stage"),
+				"job":   mStr(j, "job"), "environment": envName, "resource": strOrNull(resource),
 				"environment_ref": env, "environment_id": envID, "resolved": envID != 0,
 			}
 			if err := emit(cp, timer, engine.NormalizeADOEdges("targets", jobKey+"__"+adoSafe(env)), rec); err != nil {
@@ -625,7 +627,8 @@ func deriveJobResourceEdges(prior engine.PriorPhase, cp engine.CurrentPhase, tim
 			poolID := poolByProjectName[project][name]
 			rec := map[string]any{
 				"kind": "RUNS_ON", "project": project, "pipeline_id": mInt64(j, "pipeline_id"),
-				"job": mStr(j, "job"), "pool_name": name, "vm_image": vmImage,
+				"stage": mStr(j, "stage"),
+				"job":   mStr(j, "job"), "pool_name": name, "vm_image": vmImage,
 				"demands": listOrEmpty(pool, "demands"),
 				// vmImage with no named pool is a Microsoft-hosted image (no node).
 				"is_hosted":             name == "" && vmImage != "",

--- a/internal/ado/correlate_policy.go
+++ b/internal/ado/correlate_policy.go
@@ -168,7 +168,7 @@ func emitBranchEdge(cp engine.CurrentPhase, timer *engine.PhaseTimer, kind, edge
 		"via": via[0], "all_via": toAnyStrings(via),
 		"has_blocking_policy": gov.anyBlocking, "target": mStr(b, "_id"),
 	}
-	return emit(cp, timer, engine.NormalizeADOEdges(kind, hashKey(edgeKind, desc, mStr(b, "_id"))), rec)
+	return emitEdge(cp, timer, kind, hashKey(edgeKind, desc, mStr(b, "_id")), rec)
 }
 
 // One edge per (bypass-holding principal, governed BranchPolicy): the per-policy
@@ -201,7 +201,7 @@ func deriveCanBypass(cp engine.CurrentPhase, timer *engine.PhaseTimer, hasPolicy
 					"branch_policy_id": polID, "config_id": mInt64(e, "config_id"),
 					"policy_type": mStr(e, "policy_type"), "bypass_mode": mode.name, "target": polID,
 				}
-				if err := emit(cp, timer, engine.NormalizeADOEdges("can-bypass", key), rec); err != nil {
+				if err := emitEdge(cp, timer, "can-bypass", key, rec); err != nil {
 					return err
 				}
 			}

--- a/internal/ado/correlate_taint.go
+++ b/internal/ado/correlate_taint.go
@@ -205,7 +205,8 @@ func deriveQueueTimeInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, 
 	emitEdge := func(sinkType, name, via, location, confidence string, ms map[string]any) error {
 		rec := map[string]any{
 			"kind": "QUEUE_TIME_INJECTION", "technique": "queue_time_injection",
-			"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+			"project": project, "pipeline_id": mInt64(j, "pipeline_id"),
+			"stage": mStr(j, "stage"), "job": mStr(j, "job"),
 			"source": "queue_build_principal", "source_permission": "QueueBuilds", "source_principals": sources,
 			"sink_type": sinkType, "macro_name": name, "sink_location": location, "via": via,
 			"step_index":           ms["step_index"],
@@ -294,7 +295,8 @@ func deriveLoggingInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j 
 	emitEdge := func(cmdType, via, effect, source string, echoStep int, consumer map[string]any, confidence string) error {
 		rec := map[string]any{
 			"kind": "LOGGING_COMMAND_INJECTION", "technique": "logging_command_injection",
-			"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+			"project": project, "pipeline_id": mInt64(j, "pipeline_id"),
+			"stage": mStr(j, "stage"), "job": mStr(j, "job"),
 			"command_type": cmdType, "untrusted_source": source, "echo_step": echoStep,
 			"via": via, "effect": effect, "consumer_step": consumer["step_index"],
 			"target_resource": consumer["resource"], "source_principals": sources,
@@ -388,7 +390,8 @@ func deriveAgentInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j ma
 		}
 		rec := map[string]any{
 			"kind": "AGENT_INJECTION", "technique": "prompt_injection",
-			"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+			"project": project, "pipeline_id": mInt64(j, "pipeline_id"),
+			"stage": mStr(j, "stage"), "job": mStr(j, "job"),
 			"via": via, "source_kind": "pr_description", "vendor": entStr(sink["vendor"]),
 			"capabilities": caps, "gate_state": "absent", "source_principals": sources,
 			"identity_scope": meta.identityScope, "confidence": conf,
@@ -429,7 +432,8 @@ func derivePipelinePoisoning(cp engine.CurrentPhase, timer *engine.PhaseTimer, j
 	}
 	rec := map[string]any{
 		"kind": "PIPELINE_POISONING", "technique": "pipeline_poisoning",
-		"project": project, "pipeline_id": mInt64(j, "pipeline_id"), "job": mStr(j, "job"),
+		"project": project, "pipeline_id": mInt64(j, "pipeline_id"),
+		"stage": mStr(j, "stage"), "job": mStr(j, "job"),
 		"trigger": trigger, "via": via, "sink_kind": sinkKind, "sink_form": "script",
 		"exposes_system_access_token": mBool(j, "exposes_system_access_token"),
 		"identity_scope":              meta.identityScope, "source_principals": sources,

--- a/internal/ado/correlate_taint.go
+++ b/internal/ado/correlate_taint.go
@@ -163,7 +163,8 @@ func deriveReads(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.
 			for _, s := range secretsByGroup[gid] {
 				rec := map[string]any{
 					"kind": "READS", "project": project, "pipeline_id": pid, "stage": stage, "job": job,
-					"variable_group_id": gid, "secret_name": mStr(s, "name"), "secret_id": mStr(s, "_id"),
+					"variable_group_id": gid, "owner_project": mStr(s, "project"),
+					"secret_name": mStr(s, "name"), "secret_id": mStr(s, "_id"),
 					"via_level": mStr(e, "level"), "gate_strength": strength, "gate_state": state, "confidence": confidence,
 				}
 				key := fmt.Sprintf("%s__%d__%s__%s__%d__%s", adoSafe(project), pid, adoSafe(stage), adoSafe(job), gid, adoSafe(mStr(s, "name")))

--- a/internal/ado/correlate_taint.go
+++ b/internal/ado/correlate_taint.go
@@ -168,7 +168,7 @@ func deriveReads(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.
 					"via_level": mStr(e, "level"), "gate_strength": strength, "gate_state": state, "confidence": confidence,
 				}
 				key := fmt.Sprintf("%s__%d__%s__%s__%d__%s", adoSafe(project), pid, adoSafe(stage), adoSafe(job), gid, adoSafe(mStr(s, "name")))
-				if err := emit(cp, timer, engine.NormalizeADOEdges("reads", key), rec); err != nil {
+				if err := emitEdge(cp, timer, "reads", key, rec); err != nil {
 					return nil, err
 				}
 			}
@@ -219,7 +219,7 @@ func deriveQueueTimeInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, 
 		// several steps and sink kinds, and they must not overwrite each other.
 		key := fmt.Sprintf("%s__%s__%s__%v__%s", jobKeyOf(j), adoSafe(via), adoSafe(name),
 			ms["step_index"], adoSafe(location))
-		return emit(cp, timer, engine.NormalizeADOEdges("queue-time-injection", key), rec)
+		return emitEdge(cp, timer, "queue-time-injection", key, rec)
 	}
 
 	for _, raw := range mList(j, "macro_sinks") {
@@ -307,7 +307,7 @@ func deriveLoggingInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j 
 		// same kind, and they must not overwrite each other.
 		key := fmt.Sprintf("%s__%s__%d__%v__%s", jobKeyOf(j), adoSafe(via), echoStep,
 			consumer["step_index"], adoSafe(entStr(consumer["resource"])))
-		return emit(cp, timer, engine.NormalizeADOEdges("logging-command-injection", key), rec)
+		return emitEdge(cp, timer, "logging-command-injection", key, rec)
 	}
 
 	scUsages := mList(j, "service_connection_usages")
@@ -398,7 +398,7 @@ func deriveAgentInjection(cp engine.CurrentPhase, timer *engine.PhaseTimer, j ma
 			"target": jobID(j), "context": "azure_repos",
 		}
 		key := fmt.Sprintf("%s__%d", jobKeyOf(j), i)
-		if err := emit(cp, timer, engine.NormalizeADOEdges("agent-injection", key), rec); err != nil {
+		if err := emitEdge(cp, timer, "agent-injection", key, rec); err != nil {
 			return err
 		}
 	}
@@ -440,7 +440,7 @@ func derivePipelinePoisoning(cp engine.CurrentPhase, timer *engine.PhaseTimer, j
 		"gate_state": "absent", "confidence": confidence,
 		"target": jobID(j), "context": "azure_repos",
 	}
-	return emit(cp, timer, engine.NormalizeADOEdges("pipeline-poisoning", jobKeyOf(j)), rec)
+	return emitEdge(cp, timer, "pipeline-poisoning", jobKeyOf(j), rec)
 }
 
 // Strongest wins: the trigger list is ordered by how little the attacker must do.

--- a/internal/ado/graph_attach.go
+++ b/internal/ado/graph_attach.go
@@ -1,0 +1,212 @@
+package ado
+
+import (
+	"cmp"
+	"context"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/finding"
+)
+
+const (
+	reasonNoTarget           = "no_target"
+	reasonNoSubjectDir       = "no_subject_dir"
+	reasonSubjectUnresolved  = "subject_unresolved"
+	reasonNoProjection       = "no_projection"
+	reasonLabelMismatch      = "label_mismatch"
+	reasonEndpointUnresolved = "endpoint_unresolved"
+)
+
+func unattachedReasons() []string {
+	return []string{reasonEndpointUnresolved, reasonLabelMismatch, reasonNoProjection,
+		reasonNoSubjectDir, reasonNoTarget, reasonSubjectUnresolved}
+}
+
+type unattachedFinding struct {
+	Fingerprint string `json:"fingerprint"`
+	RuleID      string `json:"rule_id"`
+	Target      string `json:"target"`
+	SubjectKind string `json:"subject_kind"`
+	SubjectID   string `json:"subject_id"`
+	Reason      string `json:"reason"`
+	Detail      string `json:"detail"`
+}
+
+type attachResult struct {
+	total      int
+	attached   int
+	toNodes    int
+	toEdges    int
+	byReason   map[string]int
+	byRule     map[string]int
+	byTarget   map[string]int
+	unattached []unattachedFinding
+}
+
+type attacher struct {
+	c *corpus
+	n *nodeSet
+	s *edgeSet
+
+	targets    map[string]Target
+	fromRecord map[recordRef][]string
+	incident   map[string][]string
+
+	res attachResult
+}
+
+func newAttacher(c *corpus, n *nodeSet, s *edgeSet, fromRecord map[recordRef][]string, targets map[string]Target) *attacher {
+	a := &attacher{
+		c: c, n: n, s: s, targets: targets, fromRecord: fromRecord,
+		incident: map[string][]string{},
+		res: attachResult{
+			byReason: map[string]int{},
+			byRule:   map[string]int{},
+			byTarget: map[string]int{},
+		},
+	}
+	for _, r := range unattachedReasons() {
+		a.res.byReason[r] = 0
+	}
+	for _, id := range slices.Sorted(maps.Keys(s.byID)) {
+		e := s.byID[id]
+		a.incident[e.From] = append(a.incident[e.From], id)
+		if e.To != e.From {
+			a.incident[e.To] = append(a.incident[e.To], id)
+		}
+	}
+	return a
+}
+
+func (a *attacher) run(ctx context.Context, findings []finding.Finding) error {
+	for i := range findings {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		a.one(&findings[i])
+	}
+	slices.SortFunc(a.res.unattached, func(x, y unattachedFinding) int {
+		return cmp.Or(cmp.Compare(x.RuleID, y.RuleID), cmp.Compare(x.Fingerprint, y.Fingerprint))
+	})
+	return nil
+}
+
+func ruleID(f *finding.Finding) string {
+	if f.Rule == nil {
+		return ""
+	}
+	return f.Rule.ID
+}
+
+func (a *attacher) one(f *finding.Finding) {
+	a.res.total++
+	t, ok := a.targets[ruleID(f)]
+	if !ok {
+		a.fail(f, t, reasonNoTarget, "rule id is absent from the loaded rule set; rules and findings are out of sync")
+		return
+	}
+	dir, ok := adoScanProvider.SubjectDirs[f.Subject.Kind]
+	if !ok {
+		a.fail(f, t, reasonNoSubjectDir, "subject kind "+f.Subject.Kind+" names no 10-normalize directory")
+		return
+	}
+	if !a.c.byDir[dir][f.Subject.ID] {
+		a.fail(f, t, reasonSubjectUnresolved, "no record in "+dir+" carries this _id")
+		return
+	}
+
+	ref := findingRef{
+		RuleID: ruleID(f), Fingerprint: f.Fingerprint, Severity: f.Severity,
+		Confidence: f.Confidence, Target: renderTarget(t),
+		SubjectKind: f.Subject.Kind, SubjectID: f.Subject.ID, Title: f.Title,
+	}
+	nodeID, hasNode := a.n.subject(dir, f.Subject.ID)
+	edgeIDs := a.fromRecord[recordRef{dir, f.Subject.ID}]
+	if !hasNode && len(edgeIDs) == 0 {
+		a.fail(f, t, reasonNoProjection, "the record emitted no node and no edge")
+		return
+	}
+
+	if t.Kind == TargetNode {
+		a.attachNode(f, t, ref, nodeID, hasNode)
+		return
+	}
+	a.attachEdge(f, t, ref, nodeID, edgeIDs)
+}
+
+func (a *attacher) attachNode(f *finding.Finding, t Target, ref findingRef, nodeID string, hasNode bool) {
+	n := a.n.get(nodeID)
+	if !hasNode || n == nil || n.Labels[0] != t.Label {
+		a.fail(f, t, reasonLabelMismatch, "the subject resolves to no "+string(t.Label)+" node")
+		return
+	}
+	appendFinding(&n.Findings, ref)
+	a.res.attached++
+	a.res.toNodes++
+}
+
+func (a *attacher) attachEdge(f *finding.Finding, t Target, ref findingRef, nodeID string, edgeIDs []string) {
+	hits := 0
+	for _, id := range slices.Concat(edgeIDs, a.incident[nodeID]) {
+		if e := a.s.byID[id]; e != nil && e.Type == t.Type && appendFinding(&e.Findings, ref) {
+			hits++
+		}
+	}
+	if hits == 0 {
+		a.fail(f, t, reasonEndpointUnresolved, "no emitted "+renderTarget(t)+" belongs to the subject")
+		return
+	}
+	a.res.attached++
+	a.res.toEdges++
+}
+
+func appendFinding(fs *[]findingRef, ref findingRef) bool {
+	if slices.ContainsFunc(*fs, func(x findingRef) bool { return x.Fingerprint == ref.Fingerprint }) {
+		return false
+	}
+	*fs = append(*fs, ref)
+	return true
+}
+
+func (a *attacher) fail(f *finding.Finding, t Target, reason, detail string) {
+	target := renderTarget(t)
+	a.res.byReason[reason]++
+	a.res.byRule[ruleID(f)]++
+	a.res.byTarget[target]++
+	a.res.unattached = append(a.res.unattached, unattachedFinding{
+		Fingerprint: f.Fingerprint, RuleID: ruleID(f), Target: target,
+		SubjectKind: f.Subject.Kind, SubjectID: f.Subject.ID,
+		Reason: reason, Detail: detail,
+	})
+}
+
+func finalizeFindings(fs []findingRef, props map[string]any) []findingRef {
+	slices.SortFunc(fs, func(a, b findingRef) int {
+		return cmp.Or(
+			cmp.Compare(finding.SeverityRank(b.Severity), finding.SeverityRank(a.Severity)),
+			cmp.Compare(finding.ConfidenceRank(b.Confidence), finding.ConfidenceRank(a.Confidence)),
+			cmp.Compare(a.RuleID, b.RuleID),
+			cmp.Compare(a.Fingerprint, b.Fingerprint))
+	})
+	props["findings_count"] = len(fs)
+	buckets := map[string][]string{}
+	for _, f := range fs {
+		if b := severityBuckets[f.Severity]; b != "" {
+			buckets[b] = append(buckets[b], f.RuleID)
+		}
+	}
+	for _, b := range findingBuckets {
+		ids := buckets[b]
+		if len(ids) == 0 {
+			continue
+		}
+		// findings_<severity> is deduplicated to rule ids, so its length is a rule
+		// count and not the number of findings at that severity.
+		props["findings_count_"+strings.TrimPrefix(b, "findings_")] = len(ids)
+		slices.Sort(ids)
+		props[b] = slices.Compact(ids)
+	}
+	return fs
+}

--- a/internal/ado/graph_build.go
+++ b/internal/ado/graph_build.go
@@ -25,7 +25,7 @@ const (
 	graphDir = "30-graph"
 )
 
-func BuildGraph(ctx context.Context, cfg *engine.Config, runDir string) error {
+func BuildGraph(ctx context.Context, cfg *engine.Config, runDir string, targets map[string]Target) error {
 	state, err := engine.LoadState(runDir)
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func BuildGraph(ctx context.Context, cfg *engine.Config, runDir string) error {
 	}
 	ui.PhaseHeader("Graph")
 	timer := engine.StartPhaseTimer(engine.PhaseGraph, "graph")
-	stats, buildErr := runBuild(ctx, cfg, runDir, timer)
+	stats, buildErr := runBuild(ctx, cfg, runDir, targets, timer)
 
 	rec := timer.Stop(buildErr)
 	state.RecordPhase(rec)
@@ -44,12 +44,13 @@ func BuildGraph(ctx context.Context, cfg *engine.Config, runDir string) error {
 		ui.Outcome("Graph complete", []ui.Count{
 			{Label: "nodes", N: stats.nodes},
 			{Label: "edges", N: stats.edges},
+			{Label: "findings attached", N: stats.attached},
 		}, engine.Elapsed(rec.DurationS))
 	}
 	return errors.Join(buildErr, saveErr)
 }
 
-type buildStats struct{ nodes, edges int }
+type buildStats struct{ nodes, edges, attached int }
 
 type nodesFile struct {
 	Nodes []node `json:"nodes"`
@@ -59,7 +60,7 @@ type edgesFile struct {
 	Edges []edge `json:"edges"`
 }
 
-func runBuild(ctx context.Context, cfg *engine.Config, runDir string, timer *engine.PhaseTimer) (buildStats, error) {
+func runBuild(ctx context.Context, cfg *engine.Config, runDir string, targets map[string]Target, timer *engine.PhaseTimer) (buildStats, error) {
 	var errMu sync.Mutex
 	onError := func(e error) {
 		errMu.Lock()
@@ -92,7 +93,7 @@ func runBuild(ctx context.Context, cfg *engine.Config, runDir string, timer *eng
 	}
 
 	nodes := buildNodes(c)
-	edges, err := buildEdges(c, nodes)
+	edges, fromRecord, err := buildEdges(c, nodes)
 	if err != nil {
 		return buildStats{}, err
 	}
@@ -100,9 +101,20 @@ func runBuild(ctx context.Context, cfg *engine.Config, runDir string, timer *eng
 	dropped := dropDangling(nodes, edges)
 	nodes.sweepIllegal()
 
+	att := newAttacher(c, nodes, edges, fromRecord, targets)
+	if err := att.run(ctx, findings); err != nil {
+		return buildStats{}, err
+	}
+
 	all := nodes.all()
+	for i := range all {
+		all[i].Findings = finalizeFindings(all[i].Findings, all[i].Properties)
+	}
 	edgeList := edges.all()
-	sum := summarize(runDir, in, all, edgeList, edges, nodes, observed, dropped, len(findings))
+	for i := range edgeList {
+		edgeList[i].Findings = finalizeFindings(edgeList[i].Findings, edgeList[i].Properties)
+	}
+	sum := summarize(runDir, in, all, edgeList, edges, nodes, observed, dropped, &att.res)
 
 	cp := engine.CurrentPhase{RunDir: runDir}
 	for _, w := range []struct {
@@ -118,7 +130,7 @@ func runBuild(ctx context.Context, cfg *engine.Config, runDir string, timer *eng
 		}
 	}
 	timer.OutputFiles = 3
-	return buildStats{nodes: len(all), edges: len(edgeList)}, nil
+	return buildStats{nodes: len(all), edges: len(edgeList), attached: att.res.attached}, nil
 }
 
 func loadFindings(ctx context.Context, cfg *engine.Config, runDir string, onError func(error)) ([]finding.Finding, int, error) {
@@ -200,10 +212,13 @@ var containment = []struct {
 	{HasJob, Stage, Job},
 }
 
-func buildEdges(c *corpus, n *nodeSet) (*edgeSet, error) {
+type recordRef struct{ dir, id string }
+
+func buildEdges(c *corpus, n *nodeSet) (*edgeSet, map[recordRef][]string, error) {
 	s := newEdgeSet()
 	emitContainment(n, s)
 
+	fromRecord := map[recordRef][]string{}
 	gc := graphCtx{Org: c.org, Principal: principalLabels(c)}
 	for _, t := range EdgeTypes() {
 		for _, r := range c.byKind[string(t)] {
@@ -214,11 +229,16 @@ func buildEdges(c *corpus, n *nodeSet) (*edgeSet, error) {
 			}
 			props := edgeProps(r.fields)
 			for _, e := range rs {
-				s.add(e.Type, e.From, e.To, props)
+				id := s.add(e.Type, e.From, e.To, props)
+				if id == "" || r.id == "" {
+					continue
+				}
+				ref := recordRef{r.dir, r.id}
+				fromRecord[ref] = append(fromRecord[ref], id)
 			}
 		}
 	}
-	return s, s.err()
+	return s, fromRecord, s.err()
 }
 
 func emitContainment(n *nodeSet, s *edgeSet) {
@@ -375,20 +395,30 @@ type gapsSummary struct {
 	Register         []gapEntry  `json:"register"`
 }
 
+type findingsSummary struct {
+	Total              int                 `json:"total"`
+	Attached           int                 `json:"attached"`
+	Unattached         int                 `json:"unattached"`
+	AttachedTo         map[string]int      `json:"attached_to"`
+	UnattachedByReason map[string]int      `json:"unattached_by_reason"`
+	UnattachedByRule   map[string]int      `json:"unattached_by_rule"`
+	UnattachedDetail   []unattachedFinding `json:"unattached_detail"`
+}
+
 type summary struct {
-	RunID       string        `json:"run_id"`
-	GeneratedAt string        `json:"generated_at"`
-	Inputs      inputsSummary `json:"inputs"`
-	Nodes       nodesSummary  `json:"nodes"`
-	Edges       edgesSummary  `json:"edges"`
-	Findings    int           `json:"findings"`
-	Gaps        gapsSummary   `json:"gaps"`
+	RunID       string          `json:"run_id"`
+	GeneratedAt string          `json:"generated_at"`
+	Inputs      inputsSummary   `json:"inputs"`
+	Nodes       nodesSummary    `json:"nodes"`
+	Edges       edgesSummary    `json:"edges"`
+	Findings    findingsSummary `json:"findings"`
+	Gaps        gapsSummary     `json:"gaps"`
 }
 
 const conflictsReported = 20
 
 func summarize(runDir string, in inputsSummary, all []node, edgeList []edge, edges *edgeSet, nodes *nodeSet,
-	observed int, dropped map[EdgeType]int, findings int) summary {
+	observed int, dropped map[EdgeType]int, res *attachResult) summary {
 
 	byLabel := nodes.byLabel()
 	byType := edges.byType()
@@ -428,22 +458,45 @@ func summarize(runDir string, in inputsSummary, all []node, edgeList []edge, edg
 			DroppedDangling:   counted(dropped),
 			PropertyConflicts: edgeConflicts[:min(conflictsReported, len(edgeConflicts))],
 		},
-		Findings: findings,
+		Findings: findingsSummary{
+			Total:              res.total,
+			Attached:           res.attached,
+			Unattached:         len(res.unattached),
+			AttachedTo:         map[string]int{"nodes": res.toNodes, "edges": res.toEdges},
+			UnattachedByReason: res.byReason,
+			UnattachedByRule:   res.byRule,
+			UnattachedDetail:   res.unattached,
+		},
 		Gaps: gapsSummary{
 			EmptyLabels:      empties,
 			EmptyEdgeTypes:   emptyEdges,
 			EmptyEdgeTriples: emptyEdgeTriples(edgeList),
-			Register:         gapRegister,
+			Register:         registerWithCounts(res.byTarget),
 		},
 	}
 }
 
+// Targets names the rule targets whose unattached findings the gap explains, so
+// findings_blocked is computed from the run rather than written down. A target belongs
+// to exactly one row, or the column stops summing to findings.unattached.
 type gapEntry struct {
-	Subject     string `json:"subject"`
-	Kind        string `json:"kind"`
-	Status      string `json:"status"`
-	Reason      string `json:"reason"`
-	UpstreamFix string `json:"upstream_fix"`
+	Subject         string   `json:"subject"`
+	Kind            string   `json:"kind"`
+	Status          string   `json:"status"`
+	Reason          string   `json:"reason"`
+	UpstreamFix     string   `json:"upstream_fix"`
+	FindingsBlocked int      `json:"findings_blocked"`
+	Targets         []string `json:"targets"`
+}
+
+func registerWithCounts(byTarget map[string]int) []gapEntry {
+	out := slices.Clone(gapRegister)
+	for i := range out {
+		for _, t := range out[i].Targets {
+			out[i].FindingsBlocked += byTarget[t]
+		}
+	}
+	return out
 }
 
 var gapRegister = []gapEntry{{
@@ -464,6 +517,7 @@ var gapRegister = []gapEntry{{
 	Status:      "empty",
 	Reason:      "declared with normalizers in place and no instance in any corpus: the APIs return empty arrays because no test org provisions them. Fixture gaps, not code gaps, and distinct from a label whose writer is missing.",
 	UpstreamFix: "provision a secure file, a key-vault-linked variable group, a WIF service connection, a decorator extension and a service hook in the firing range.",
+	Targets:     []string{"node(SecureFile)"},
 }, {
 	Subject:     "extends: template stages",
 	Kind:        "node",
@@ -482,6 +536,7 @@ var gapRegister = []gapEntry{{
 	Status:      "partial",
 	Reason:      "a job whose pool is a vmImage names no project queue, so project_agent_pool_id is 0 and no ProjectAgentPool exists to point at. Every unbuilt RUNS_ON in every corpus is this case; the self-hosted jobs all resolve.",
 	UpstreamFix: "none wanted. Pointing hosted jobs at a stand-in pool would assert a shared machine, which is the claim the agent rules exist to test.",
+	Targets:     []string{"edge(RUNS_ON)"},
 }, {
 	Subject:     "attack edge step_index",
 	Kind:        "edge",
@@ -506,12 +561,6 @@ var gapRegister = []gapEntry{{
 	Status:      "not_collected",
 	Reason:      "no NormalizeADO path helper exists for any of them. Task groups are the ADO composite-action analogue and the reusable-code supply chain; cat-14's five rules are self-described posture proxies standing in for classic releases.",
 	UpstreamFix: "normalize the already-collected release-definition and build-definition surfaces, then add node writers.",
-}, {
-	Subject:     "graph: targets on ADO rules",
-	Kind:        "node",
-	Status:      "blocked",
-	Reason:      "0 of 66 ADO rules carry a graph: line, against 94 of 94 for GitHub, so no finding attaches to a node or edge and the graph carries structure without verdicts.",
-	UpstreamFix: "annotate the ruleset, then port the attacher. Five edge-subject kinds also leave subject.id empty, recoverable from provenance {project, pipeline_id, job}.",
 }, {
 	Subject:     "synthetic positional names",
 	Kind:        "node",

--- a/internal/ado/graph_build.go
+++ b/internal/ado/graph_build.go
@@ -1,0 +1,521 @@
+package ado
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+	"github.com/praetorian-inc/trajan/internal/finding"
+	"github.com/praetorian-inc/trajan/internal/ui"
+)
+
+const (
+	scanDir  = "20-scan"
+	graphDir = "30-graph"
+)
+
+func BuildGraph(ctx context.Context, cfg *engine.Config, runDir string) error {
+	state, err := engine.LoadState(runDir)
+	if err != nil {
+		return err
+	}
+	if err := state.CheckPhase(engine.PhaseGraph); err != nil {
+		return err
+	}
+	ui.PhaseHeader("Graph")
+	timer := engine.StartPhaseTimer(engine.PhaseGraph, "graph")
+	stats, buildErr := runBuild(ctx, cfg, runDir, timer)
+
+	rec := timer.Stop(buildErr)
+	state.RecordPhase(rec)
+	saveErr := state.Save(runDir)
+	if buildErr == nil {
+		ui.Outcome("Graph complete", []ui.Count{
+			{Label: "nodes", N: stats.nodes},
+			{Label: "edges", N: stats.edges},
+		}, engine.Elapsed(rec.DurationS))
+	}
+	return errors.Join(buildErr, saveErr)
+}
+
+type buildStats struct{ nodes, edges int }
+
+type nodesFile struct {
+	Nodes []node `json:"nodes"`
+}
+
+type edgesFile struct {
+	Edges []edge `json:"edges"`
+}
+
+func runBuild(ctx context.Context, cfg *engine.Config, runDir string, timer *engine.PhaseTimer) (buildStats, error) {
+	var errMu sync.Mutex
+	onError := func(e error) {
+		errMu.Lock()
+		timer.Errors = append(timer.Errors, e.Error())
+		errMu.Unlock()
+	}
+
+	c, err := loadCorpus(ctx, cfg, runDir, onError)
+	if err != nil {
+		return buildStats{}, err
+	}
+	findings, findingsSeen, err := loadFindings(ctx, cfg, runDir, onError)
+	if err != nil {
+		return buildStats{}, err
+	}
+	in := inputsSummary{
+		NormalizeSeen:    c.seen,
+		NormalizeDropped: c.seen - c.files,
+		FindingsSeen:     findingsSeen,
+		FindingsDropped:  findingsSeen - len(findings),
+	}
+	timer.InputFiles = in.NormalizeSeen + in.FindingsSeen
+	if in.NormalizeDropped+in.FindingsDropped > 0 {
+		slog.Warn("graph built on incomplete input", "normalize_dropped", in.NormalizeDropped,
+			"findings_dropped", in.FindingsDropped)
+	}
+
+	if err := os.RemoveAll(filepath.Join(runDir, graphDir)); err != nil {
+		return buildStats{}, fmt.Errorf("clear %s: %w", graphDir, err)
+	}
+
+	nodes := buildNodes(c)
+	edges, err := buildEdges(c, nodes)
+	if err != nil {
+		return buildStats{}, err
+	}
+	observed := backfillObserved(nodes, edges)
+	dropped := dropDangling(nodes, edges)
+	nodes.sweepIllegal()
+
+	all := nodes.all()
+	edgeList := edges.all()
+	sum := summarize(runDir, in, all, edgeList, edges, nodes, observed, dropped, len(findings))
+
+	cp := engine.CurrentPhase{RunDir: runDir}
+	for _, w := range []struct {
+		rel string
+		v   any
+	}{
+		{engine.GraphNodes(), nodesFile{all}},
+		{engine.GraphEdges(), edgesFile{edgeList}},
+		{engine.GraphSummary(), sum},
+	} {
+		if err := cp.Write(w.rel, w.v); err != nil {
+			return buildStats{}, fmt.Errorf("write %s: %w", w.rel, err)
+		}
+	}
+	timer.OutputFiles = 3
+	return buildStats{nodes: len(all), edges: len(edgeList)}, nil
+}
+
+func loadFindings(ctx context.Context, cfg *engine.Config, runDir string, onError func(error)) ([]finding.Finding, int, error) {
+	pp := engine.PriorPhase{RunDir: runDir}
+	if _, err := os.Stat(pp.Abs(scanDir)); err != nil {
+		return nil, 0, fmt.Errorf("%s unreadable; run `trajan ado scan` first: %w", scanDir, err)
+	}
+	files, err := pp.IterJSON(scanDir)
+	if err != nil {
+		return nil, 0, err
+	}
+	out := engine.RunPartial(ctx, cfg.Concurrency, files,
+		func(_ context.Context, f engine.PhaseFile) (finding.Finding, error) {
+			var v finding.Finding
+			if err := json.Unmarshal(f.Data, &v); err != nil {
+				return v, fmt.Errorf("%s/%s: %w", scanDir, f.Rel, err)
+			}
+			return v, nil
+		},
+		func(_ engine.PhaseFile, err error) { onError(err) })
+	if err := ctx.Err(); err != nil {
+		return nil, 0, err
+	}
+	slices.SortFunc(out, func(a, b finding.Finding) int { return cmp.Compare(a.Fingerprint, b.Fingerprint) })
+	return out, len(files), nil
+}
+
+var identityFields = map[NodeLabel]map[string]string{
+	Repository:              {"repo": "name"},
+	Pipeline:                {"pipeline_id": "id"},
+	ServiceConnection:       {"connection_id": "id"},
+	VariableGroup:           {"group_id": "id"},
+	SecretVariable:          {"owner_project": "project"},
+	SecureFile:              {"file_id": "id"},
+	ArtifactsFeed:           {"feed_id": "id"},
+	OrgAgentPool:            {"pool_id": "id"},
+	ProjectAgentPool:        {"queue_id": "id"},
+	ServiceHookSubscription: {"subscription_id": "id"},
+}
+
+func (c *corpus) identityOf(l NodeLabel, f map[string]any) map[string]string {
+	alias := identityFields[l]
+	key := make(map[string]string, len(IdentityKey(l)))
+	for _, k := range IdentityKey(l) {
+		if k == "org" {
+			key[k] = c.org
+			continue
+		}
+		src := k
+		if a, ok := alias[k]; ok {
+			src = a
+		}
+		key[k] = str(f[src])
+	}
+	return key
+}
+
+func buildNodes(c *corpus) *nodeSet {
+	s := newNodeSet()
+	for _, l := range NodeLabels() {
+		for _, r := range c.byKind[string(l)] {
+			n := s.upsert(l, c.identityOf(l, r.fields), s.recordProps(l, r.fields), r.rel)
+			s.index(r.dir, r.id, n)
+		}
+	}
+	return s
+}
+
+var containment = []struct {
+	edge   EdgeType
+	parent NodeLabel
+	child  NodeLabel
+}{
+	{HasProject, Organization, Project},
+	{HasRepository, Project, Repository},
+	{HasBranch, Repository, Branch},
+	{HasPipeline, Project, Pipeline},
+	{HasStage, Pipeline, Stage},
+	{HasJob, Stage, Job},
+}
+
+func buildEdges(c *corpus, n *nodeSet) (*edgeSet, error) {
+	s := newEdgeSet()
+	emitContainment(n, s)
+
+	gc := graphCtx{Org: c.org, Principal: principalLabels(c)}
+	for _, t := range EdgeTypes() {
+		for _, r := range c.byKind[string(t)] {
+			rs := resolveEndpoints(gc, r.fields)
+			if len(rs) == 0 {
+				s.miss(t, "", "", 1)
+				continue
+			}
+			props := edgeProps(r.fields)
+			for _, e := range rs {
+				s.add(e.Type, e.From, e.To, props)
+			}
+		}
+	}
+	return s, s.err()
+}
+
+func emitContainment(n *nodeSet, s *edgeSet) {
+	for _, ct := range containment {
+		for _, child := range n.all() {
+			if child.Labels[0] != ct.child {
+				continue
+			}
+			parent := endpoint{ct.parent, map[string]string{}}
+			for _, k := range IdentityKey(ct.parent) {
+				parent.Key[k] = child.Key[k]
+			}
+			s.add(ct.edge, parent, endpoint{ct.child, child.Key}, nil)
+		}
+	}
+}
+
+func principalLabels(c *corpus) func(string) (NodeLabel, bool) {
+	index := map[string]NodeLabel{}
+	for _, l := range []NodeLabel{User, SecurityGroup, BuildServiceIdentity} {
+		for _, r := range c.byKind[string(l)] {
+			if d := str(r.fields["descriptor"]); d != "" {
+				index[d] = l
+			}
+		}
+	}
+	return func(d string) (NodeLabel, bool) {
+		l, ok := index[d]
+		return l, ok
+	}
+}
+
+func edgeProps(f map[string]any) map[string]any {
+	out := make(map[string]any, len(f))
+	for k, v := range f {
+		if k == "_id" || k == "kind" || k == "_provenance" || !legalProp(v) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func backfillObserved(n *nodeSet, s *edgeSet) int {
+	minted := 0
+	for _, id := range slices.Sorted(maps.Keys(s.byID)) {
+		e := s.byID[id]
+		for _, ep := range [2]struct {
+			id    string
+			label NodeLabel
+		}{{e.From, e.FromLabel}, {e.To, e.ToLabel}} {
+			if n.has(ep.id) {
+				continue
+			}
+			label, key, ok := parseNodeID(ep.id)
+			if !ok || label != ep.label {
+				continue
+			}
+			if n.upsert(label, key, map[string]any{"observed_only": true}, "") != nil {
+				minted++
+			}
+		}
+	}
+	return minted
+}
+
+// esc is injective and leaves no unescaped '|', so splitting on unescaped '|' recovers
+// the identity tuple exactly.
+func parseNodeID(id string) (NodeLabel, map[string]string, bool) {
+	parts := []string{}
+	var b strings.Builder
+	escaped := false
+	for _, r := range id {
+		switch {
+		case escaped:
+			b.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			escaped = true
+		case r == '|':
+			parts = append(parts, b.String())
+			b.Reset()
+		default:
+			b.WriteRune(r)
+		}
+	}
+	parts = append(parts, b.String())
+
+	label := NodeLabel(parts[0])
+	want := IdentityKey(label)
+	if len(want) == 0 || len(parts)-1 != len(want) {
+		return "", nil, false
+	}
+	key := make(map[string]string, len(want))
+	for i, k := range want {
+		key[k] = parts[i+1]
+	}
+	return label, key, true
+}
+
+func dropDangling(n *nodeSet, s *edgeSet) map[EdgeType]int {
+	out := map[EdgeType]int{}
+	for id, e := range s.byID {
+		if !n.has(e.From) || !n.has(e.To) {
+			out[e.Type]++
+			delete(s.byID, id)
+		}
+	}
+	return out
+}
+
+type countByType[K ~string] struct {
+	Total  int       `json:"total"`
+	ByType map[K]int `json:"by_type"`
+}
+
+func counted[K ~string](m map[K]int) countByType[K] {
+	total := 0
+	for _, n := range m {
+		total += n
+	}
+	return countByType[K]{total, m}
+}
+
+type inputsSummary struct {
+	NormalizeSeen    int `json:"normalize_seen"`
+	NormalizeDropped int `json:"normalize_dropped"`
+	FindingsSeen     int `json:"findings_seen"`
+	FindingsDropped  int `json:"findings_dropped"`
+}
+
+type nodesSummary struct {
+	Total                int                `json:"total"`
+	ByLabel              map[NodeLabel]int  `json:"by_label"`
+	ObservedOnly         int                `json:"observed_only"`
+	IncompleteIdentities map[NodeLabel]int  `json:"incomplete_identities"`
+	IdentityMerges       []identityMerge    `json:"identity_merges"`
+	PropertyConflicts    []propertyConflict `json:"property_conflicts"`
+	DroppedProperties    int                `json:"dropped_properties"`
+}
+
+type edgesSummary struct {
+	Total             int                   `json:"total"`
+	ByType            map[EdgeType]int      `json:"by_type"`
+	Unbuilt           countByType[string]   `json:"unbuilt"`
+	DroppedDangling   countByType[EdgeType] `json:"dropped_dangling"`
+	PropertyConflicts []edgeConflict        `json:"property_conflicts"`
+}
+
+type gapsSummary struct {
+	EmptyLabels      []NodeLabel `json:"empty_labels"`
+	EmptyEdgeTypes   []EdgeType  `json:"empty_edge_types"`
+	EmptyEdgeTriples []string    `json:"empty_edge_triples"`
+	Register         []gapEntry  `json:"register"`
+}
+
+type summary struct {
+	RunID       string        `json:"run_id"`
+	GeneratedAt string        `json:"generated_at"`
+	Inputs      inputsSummary `json:"inputs"`
+	Nodes       nodesSummary  `json:"nodes"`
+	Edges       edgesSummary  `json:"edges"`
+	Findings    int           `json:"findings"`
+	Gaps        gapsSummary   `json:"gaps"`
+}
+
+const conflictsReported = 20
+
+func summarize(runDir string, in inputsSummary, all []node, edgeList []edge, edges *edgeSet, nodes *nodeSet,
+	observed int, dropped map[EdgeType]int, findings int) summary {
+
+	byLabel := nodes.byLabel()
+	byType := edges.byType()
+	conflicts := nodes.propertyConflicts()
+	edgeConflicts := edges.propertyConflicts()
+
+	empties := []NodeLabel{}
+	for _, l := range NodeLabels() {
+		if byLabel[l] == 0 {
+			empties = append(empties, l)
+		}
+	}
+	emptyEdges := []EdgeType{}
+	for _, t := range EdgeTypes() {
+		if byType[t] == 0 {
+			emptyEdges = append(emptyEdges, t)
+		}
+	}
+
+	return summary{
+		RunID:       filepath.Base(runDir),
+		GeneratedAt: engine.IsoformatUTC(time.Now()),
+		Inputs:      in,
+		Nodes: nodesSummary{
+			Total:                len(all),
+			ByLabel:              byLabel,
+			ObservedOnly:         observed,
+			IncompleteIdentities: nodes.incompleteIdentities(),
+			IdentityMerges:       nodes.merges(),
+			PropertyConflicts:    conflicts[:min(conflictsReported, len(conflicts))],
+			DroppedProperties:    nodes.dropped,
+		},
+		Edges: edgesSummary{
+			Total:             len(edgeList),
+			ByType:            byType,
+			Unbuilt:           counted(edges.unbuilt),
+			DroppedDangling:   counted(dropped),
+			PropertyConflicts: edgeConflicts[:min(conflictsReported, len(edgeConflicts))],
+		},
+		Findings: findings,
+		Gaps: gapsSummary{
+			EmptyLabels:      empties,
+			EmptyEdgeTypes:   emptyEdges,
+			EmptyEdgeTriples: emptyEdgeTriples(edgeList),
+			Register:         gapRegister,
+		},
+	}
+}
+
+type gapEntry struct {
+	Subject     string `json:"subject"`
+	Kind        string `json:"kind"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason"`
+	UpstreamFix string `json:"upstream_fix"`
+}
+
+var gapRegister = []gapEntry{{
+	Subject:     "RUNS_AS{Pipeline,BuildServiceIdentity}",
+	Kind:        "edge",
+	Status:      "identity_defect",
+	Reason:      "the runs-as record carries identity_scope (project or collection) and no descriptor, so there is no build service identity to point at. The principals are collected — principals/build-service holds them — but nothing joins a scope to one.",
+	UpstreamFix: "index BuildServiceIdentity by scope and project in the builder, then resolve the pair; the descriptor is already on the principal record.",
+}, {
+	Subject:     "TRIGGERS_ON_COMPLETION{Pipeline,Pipeline}",
+	Kind:        "edge",
+	Status:      "identity_defect",
+	Reason:      "source_pipeline is a pipeline name and Pipeline identity needs the definition id, so the endpoint cannot be named from the record alone.",
+	UpstreamFix: "build a (project, name) -> pipeline_id index in the builder. Names are not unique across projects, so source_project must qualify it.",
+}, {
+	Subject:     "SecureFile / KeyVault / WIFCredential / PipelineDecorator / ServiceHookSubscription",
+	Kind:        "node",
+	Status:      "empty",
+	Reason:      "declared with normalizers in place and no instance in any corpus: the APIs return empty arrays because no test org provisions them. Fixture gaps, not code gaps, and distinct from a label whose writer is missing.",
+	UpstreamFix: "provision a secure file, a key-vault-linked variable group, a WIF service connection, a decorator extension and a service hook in the firing range.",
+}, {
+	Subject:     "extends: template stages",
+	Kind:        "node",
+	Status:      "partial",
+	Reason:      "a pipeline that emits no jobs falls back to ADO's server-resolved preview, so extends: pipelines now yield stages and jobs. A pipeline mixing inline stages with a template stage reference still emits only the inline ones — jobs > 0, so the fallback does not fire, and widening the trigger would double-emit and erase the ${{ }} parameter sinks the inline stages carry.",
+	UpstreamFix: "none wanted. The preview substitutes every ${{ }} before returning, so it can only ever be a fallback.",
+}, {
+	Subject:     "HAS_ROLE for uncollected principals",
+	Kind:        "edge",
+	Status:      "partial",
+	Reason:      "an ACE whose identity the Graph API does not enumerate — built-in server SIDs — has no principal record, so there is no label to point at and the grant is counted rather than pointed at an invented node. 14 of 45 rows in the richest corpus.",
+	UpstreamFix: "none available: the descriptor is kept on the record, but User and SecurityGroup cannot be told apart without the Graph API returning the subject.",
+}, {
+	Subject:     "RUNS_ON for Microsoft-hosted jobs",
+	Kind:        "edge",
+	Status:      "partial",
+	Reason:      "a job whose pool is a vmImage names no project queue, so project_agent_pool_id is 0 and no ProjectAgentPool exists to point at. Every unbuilt RUNS_ON in every corpus is this case; the self-hosted jobs all resolve.",
+	UpstreamFix: "none wanted. Pointing hosted jobs at a stand-in pool would assert a shared machine, which is the claim the agent rules exist to test.",
+}, {
+	Subject:     "attack edge step_index",
+	Kind:        "edge",
+	Status:      "identity_defect",
+	Reason:      "parallel edges of one type between one pair do not exist in this model, so two sinks in different steps of the same job merge onto one edge and the second step_index is discarded.",
+	UpstreamFix: "carry the step indices as an array property rather than a scalar, once a rule needs to name the step.",
+}, {
+	Subject:     "ACL namespace coverage",
+	Kind:        "edge",
+	Status:      "partial",
+	Reason:      "3 of roughly 90 security namespaces are read (Git, Build, ServiceEndpoints), and the Build ACL is read at the project token only, so QUEUE_TIME_INJECTION source_principals is a project-wide approximation rather than a per-pipeline grant.",
+	UpstreamFix: "read the Build namespace at the definition token, and add the namespaces governing variable groups, secure files and environments.",
+}, {
+	Subject:     "ArtifactsFeed scope",
+	Kind:        "node",
+	Status:      "partial",
+	Reason:      "normalizeFeeds collects only the org-level feed list and hardcodes scope: \"org\", which is asserted rather than observed. Project-scoped feeds are invisible.",
+	UpstreamFix: "collect per-project feeds; scope is already in the identity key, so they slot in without rekeying.",
+}, {
+	Subject:     "task groups, classic releases, deployment groups",
+	Kind:        "node",
+	Status:      "not_collected",
+	Reason:      "no NormalizeADO path helper exists for any of them. Task groups are the ADO composite-action analogue and the reusable-code supply chain; cat-14's five rules are self-described posture proxies standing in for classic releases.",
+	UpstreamFix: "normalize the already-collected release-definition and build-definition surfaces, then add node writers.",
+}, {
+	Subject:     "graph: targets on ADO rules",
+	Kind:        "node",
+	Status:      "blocked",
+	Reason:      "0 of 66 ADO rules carry a graph: line, against 94 of 94 for GitHub, so no finding attaches to a node or edge and the graph carries structure without verdicts.",
+	UpstreamFix: "annotate the ruleset, then port the attacher. Five edge-subject kinds also leave subject.id empty, recoverable from provenance {project, pipeline_id, job}.",
+}, {
+	Subject:     "synthetic positional names",
+	Kind:        "node",
+	Status:      "identity_defect",
+	Reason:      "an unnamed stage or job becomes stage_<i> / job_<i>, so inserting a stage re-keys every downstream job and every taint edge that hangs off it. step_index is likewise array position and the only step identity.",
+	UpstreamFix: "none available: the YAML supplies no other identity, and a content hash would churn on every edit.",
+}}

--- a/internal/ado/graph_corpus.go
+++ b/internal/ado/graph_corpus.go
@@ -1,0 +1,94 @@
+package ado
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+)
+
+const normalizeDir = "10-normalize"
+
+type record struct {
+	rel    string
+	dir    string
+	kind   string
+	id     string
+	fields map[string]any
+}
+
+type corpus struct {
+	org    string
+	byKind map[string][]record
+
+	seen  int
+	files int
+}
+
+func loadCorpus(ctx context.Context, cfg *engine.Config, runDir string, onError func(error)) (*corpus, error) {
+	files, err := engine.PriorPhase{RunDir: runDir}.IterJSON(normalizeDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("%s: no normalized records", normalizeDir)
+	}
+
+	recs := engine.RunPartial(ctx, cfg.Concurrency, files,
+		func(_ context.Context, f engine.PhaseFile) (record, error) {
+			var m map[string]any
+			dec := json.NewDecoder(bytes.NewReader(f.Data))
+			dec.UseNumber()
+			if err := dec.Decode(&m); err != nil {
+				return record{}, fmt.Errorf("%s/%s: %w", normalizeDir, f.Rel, err)
+			}
+			rel := filepath.ToSlash(f.Rel)
+			dir, _, _ := strings.Cut(rel, "/")
+			id, _ := m["_id"].(string)
+			kind, _ := m["kind"].(string)
+			return record{rel: rel, dir: dir, kind: kind, id: id, fields: m}, nil
+		},
+		func(_ engine.PhaseFile, err error) { onError(err) })
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	slices.SortFunc(recs, func(a, b record) int { return strings.Compare(a.rel, b.rel) })
+
+	c := &corpus{byKind: map[string][]record{}, seen: len(files), files: len(recs)}
+	for _, r := range recs {
+		if r.kind == "" {
+			continue
+		}
+		c.byKind[r.kind] = append(c.byKind[r.kind], r)
+	}
+
+	orgs := c.byKind[string(Organization)]
+	if len(orgs) == 0 {
+		return nil, fmt.Errorf("%s: no organization record; every node identity is qualified by it", normalizeDir)
+	}
+	c.org = str(orgs[0].fields["org"])
+	if c.org == "" {
+		return nil, fmt.Errorf("%s: organization record has no %q", orgs[0].rel, "org")
+	}
+	return c, nil
+}
+
+func str(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case json.Number:
+		return t.String()
+	}
+	return ""
+}
+
+func truthy(v any) bool {
+	b, _ := v.(bool)
+	return b
+}

--- a/internal/ado/graph_corpus.go
+++ b/internal/ado/graph_corpus.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -25,6 +26,7 @@ type record struct {
 type corpus struct {
 	org    string
 	byKind map[string][]record
+	byDir  map[string]map[string]bool
 
 	seen  int
 	files int
@@ -48,7 +50,7 @@ func loadCorpus(ctx context.Context, cfg *engine.Config, runDir string, onError 
 				return record{}, fmt.Errorf("%s/%s: %w", normalizeDir, f.Rel, err)
 			}
 			rel := filepath.ToSlash(f.Rel)
-			dir, _, _ := strings.Cut(rel, "/")
+			dir := path.Dir(rel)
 			id, _ := m["_id"].(string)
 			kind, _ := m["kind"].(string)
 			return record{rel: rel, dir: dir, kind: kind, id: id, fields: m}, nil
@@ -59,8 +61,15 @@ func loadCorpus(ctx context.Context, cfg *engine.Config, runDir string, onError 
 	}
 	slices.SortFunc(recs, func(a, b record) int { return strings.Compare(a.rel, b.rel) })
 
-	c := &corpus{byKind: map[string][]record{}, seen: len(files), files: len(recs)}
+	c := &corpus{byKind: map[string][]record{}, byDir: map[string]map[string]bool{},
+		seen: len(files), files: len(recs)}
 	for _, r := range recs {
+		if r.id != "" {
+			if c.byDir[r.dir] == nil {
+				c.byDir[r.dir] = map[string]bool{}
+			}
+			c.byDir[r.dir][r.id] = true
+		}
 		if r.kind == "" {
 			continue
 		}

--- a/internal/ado/graph_endpoints.go
+++ b/internal/ado/graph_endpoints.go
@@ -290,11 +290,11 @@ func roleResourceEndpoint(org string, label NodeLabel, resourceID string) (endpo
 		}
 		return endpoint{Pipeline, map[string]string{"org": org, "project": parts[1], "pipeline_id": parts[2]}}, true
 	case ServiceConnection:
-		if len(parts) != 3 {
+		if len(parts) != 2 {
 			return endpoint{}, false
 		}
 		return endpoint{ServiceConnection, map[string]string{
-			"org": org, "owner_project": parts[1], "connection_id": parts[2],
+			"org": org, "owner_project": parts[0], "connection_id": parts[1],
 		}}, true
 	}
 	return endpoint{}, false

--- a/internal/ado/graph_endpoints.go
+++ b/internal/ado/graph_endpoints.go
@@ -1,6 +1,9 @@
 package ado
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 type endpoint struct {
 	Label NodeLabel
@@ -13,7 +16,12 @@ type resolved struct {
 	To   endpoint
 }
 
-type endpointResolver func(org string, rec map[string]any) (resolved, bool)
+type graphCtx struct {
+	Org       string
+	Principal func(descriptor string) (NodeLabel, bool)
+}
+
+type endpointResolver func(c graphCtx, rec map[string]any) []resolved
 
 func num(m map[string]any, k string) string {
 	if v := mInt64(m, k); v != 0 {
@@ -23,163 +31,279 @@ func num(m map[string]any, k string) string {
 }
 
 func complete(e endpoint) bool {
+	if len(IdentityKey(e.Label)) == 0 {
+		return false
+	}
 	for _, k := range IdentityKey(e.Label) {
 		if e.Key[k] == "" {
 			return false
 		}
 	}
-	return len(IdentityKey(e.Label)) > 0
+	return true
 }
 
-func pair(t EdgeType, from, to endpoint) (resolved, bool) {
+func one(t EdgeType, from, to endpoint) []resolved {
 	if !complete(from) || !complete(to) || !ValidEdge(t, from.Label, to.Label) {
-		return resolved{}, false
+		return nil
 	}
-	return resolved{Type: t, From: from, To: to}, true
+	return []resolved{{Type: t, From: from, To: to}}
 }
 
-func branchOf(org string, rec map[string]any) endpoint {
+func (c graphCtx) principalOf(descriptor string) (endpoint, bool) {
+	label, ok := c.Principal(descriptor)
+	if !ok {
+		return endpoint{}, false
+	}
+	return endpoint{label, map[string]string{"descriptor": descriptor}}, true
+}
+
+func (c graphCtx) fanOut(t EdgeType, descriptors []string, to endpoint) []resolved {
+	var out []resolved
+	for _, d := range descriptors {
+		from, ok := c.principalOf(d)
+		if !ok {
+			continue
+		}
+		out = append(out, one(t, from, to)...)
+	}
+	return out
+}
+
+func sourcePrincipals(rec map[string]any) []string {
+	var out []string
+	for _, raw := range mList(rec, "source_principals") {
+		if d := entStr(entMap(raw)["descriptor"]); d != "" {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func (c graphCtx) branchOf(rec map[string]any) endpoint {
 	return endpoint{Branch, map[string]string{
-		"org": org, "project": mStr(rec, "project"),
+		"org": c.Org, "project": mStr(rec, "project"),
 		"repo": mStr(rec, "repo"), "name": mStr(rec, "branch"),
 	}}
 }
 
-func pipelineOf(org, project, id string) endpoint {
-	return endpoint{Pipeline, map[string]string{"org": org, "project": project, "pipeline_id": id}}
+func (c graphCtx) pipelineOf(project, id string) endpoint {
+	return endpoint{Pipeline, map[string]string{"org": c.Org, "project": project, "pipeline_id": id}}
 }
 
-func groupOf(org, owner, id string) endpoint {
-	return endpoint{VariableGroup, map[string]string{"org": org, "owner_project": owner, "group_id": id}}
+func (c graphCtx) groupOf(owner, id string) endpoint {
+	return endpoint{VariableGroup, map[string]string{"org": c.Org, "owner_project": owner, "group_id": id}}
 }
 
-func policyOf(org string, rec map[string]any) endpoint {
+func (c graphCtx) policyOf(rec map[string]any) endpoint {
 	return endpoint{BranchPolicy, map[string]string{
-		"org": org, "project": mStr(rec, "project"), "config_id": num(rec, "config_id"),
+		"org": c.Org, "project": mStr(rec, "project"), "config_id": num(rec, "config_id"),
 	}}
 }
 
-func jobOf(org string, rec map[string]any) endpoint {
+func (c graphCtx) jobOf(rec map[string]any) endpoint {
 	return endpoint{Job, map[string]string{
-		"org": org, "project": mStr(rec, "project"),
+		"org": c.Org, "project": mStr(rec, "project"),
 		"pipeline_id": num(rec, "pipeline_id"),
 		"stage":       mStr(rec, "stage"), "job": mStr(rec, "job"),
 	}}
 }
 
+var roleResourceLabels = map[string]NodeLabel{
+	"Project":           Project,
+	"Repository":        Repository,
+	"Pipeline":          Pipeline,
+	"ServiceConnection": ServiceConnection,
+}
+
 var endpointResolvers = map[EdgeType]endpointResolver{
-	DefinedBy: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(DefinedBy,
-			pipelineOf(org, mStr(rec, "project"), num(rec, "pipeline_id")),
-			branchOf(org, rec))
+	DefinedBy: func(c graphCtx, rec map[string]any) []resolved {
+		return one(DefinedBy,
+			c.pipelineOf(mStr(rec, "project"), num(rec, "pipeline_id")),
+			c.branchOf(rec))
 	},
 
-	Defines: func(org string, rec map[string]any) (resolved, bool) {
+	Defines: func(c graphCtx, rec map[string]any) []resolved {
 		owner, gid := mStr(rec, "project"), num(rec, "group_id")
-		return pair(Defines,
-			groupOf(org, owner, gid),
+		return one(Defines,
+			c.groupOf(owner, gid),
 			endpoint{SecretVariable, map[string]string{
-				"org": org, "owner_project": owner, "group_id": gid, "name": mStr(rec, "secret_name"),
+				"org": c.Org, "owner_project": owner, "group_id": gid, "name": mStr(rec, "secret_name"),
 			}})
 	},
 
-	HasPolicy: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(HasPolicy, policyOf(org, rec), branchOf(org, rec))
+	HasPolicy: func(c graphCtx, rec map[string]any) []resolved {
+		return one(HasPolicy, c.policyOf(rec), c.branchOf(rec))
 	},
 
-	BuildValidates: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(BuildValidates,
-			policyOf(org, rec),
-			pipelineOf(org, mStr(rec, "project"), num(rec, "build_definition_id")))
+	BuildValidates: func(c graphCtx, rec map[string]any) []resolved {
+		return one(BuildValidates, c.policyOf(rec),
+			c.pipelineOf(mStr(rec, "project"), num(rec, "build_definition_id")))
 	},
 
-	ReferencesPool: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(ReferencesPool,
+	ReferencesPool: func(c graphCtx, rec map[string]any) []resolved {
+		return one(ReferencesPool,
 			endpoint{ProjectAgentPool, map[string]string{
-				"org": org, "project": mStr(rec, "project"), "queue_id": num(rec, "queue_id"),
+				"org": c.Org, "project": mStr(rec, "project"), "queue_id": num(rec, "queue_id"),
 			}},
-			endpoint{OrgAgentPool, map[string]string{"org": org, "pool_id": num(rec, "org_pool_id")}})
+			endpoint{OrgAgentPool, map[string]string{"org": c.Org, "pool_id": num(rec, "org_pool_id")}})
 	},
 
-	LinksTo: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(LinksTo,
-			groupOf(org, mStr(rec, "project"), num(rec, "variable_group_id")),
+	LinksTo: func(c graphCtx, rec map[string]any) []resolved {
+		return one(LinksTo,
+			c.groupOf(mStr(rec, "project"), num(rec, "variable_group_id")),
 			endpoint{KeyVault, map[string]string{"name": mStr(rec, "keyvault_name")}})
 	},
 
-	FederatesTo: func(org string, rec map[string]any) (resolved, bool) {
+	FederatesTo: func(c graphCtx, rec map[string]any) []resolved {
 		owner, conn := mStr(rec, "project"), mStr(rec, "connection_id")
-		return pair(FederatesTo,
+		return one(FederatesTo,
 			endpoint{ServiceConnection, map[string]string{
-				"org": org, "owner_project": owner, "connection_id": conn,
+				"org": c.Org, "owner_project": owner, "connection_id": conn,
 			}},
 			endpoint{WIFCredential, map[string]string{
-				"org": org, "owner_project": owner, "connection_id": conn, "subject": mStr(rec, "subject"),
+				"org": c.Org, "owner_project": owner, "connection_id": conn, "subject": mStr(rec, "subject"),
 			}})
 	},
 
-	Installs: func(org string, rec map[string]any) (resolved, bool) {
+	Installs: func(c graphCtx, rec map[string]any) []resolved {
 		ext := mStr(rec, "extension_id")
-		return pair(Installs,
-			endpoint{Extension, map[string]string{"org": org, "extension_id": ext}},
-			endpoint{PipelineDecorator, map[string]string{"org": org, "extension_id": ext}})
+		return one(Installs,
+			endpoint{Extension, map[string]string{"org": c.Org, "extension_id": ext}},
+			endpoint{PipelineDecorator, map[string]string{"org": c.Org, "extension_id": ext}})
 	},
 
-	Reads: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(Reads, jobOf(org, rec),
+	Reads: func(c graphCtx, rec map[string]any) []resolved {
+		return one(Reads, c.jobOf(rec),
 			endpoint{SecretVariable, map[string]string{
-				"org": org, "owner_project": mStr(rec, "owner_project"),
+				"org": c.Org, "owner_project": mStr(rec, "owner_project"),
 				"group_id": num(rec, "variable_group_id"), "name": mStr(rec, "secret_name"),
 			}})
 	},
 
-	ConsumesGroup: func(org string, rec map[string]any) (resolved, bool) {
+	ConsumesGroup: func(c graphCtx, rec map[string]any) []resolved {
 		var from endpoint
 		switch mStr(rec, "level") {
 		case "pipeline":
-			from = pipelineOf(org, mStr(rec, "project"), num(rec, "pipeline_id"))
+			from = c.pipelineOf(mStr(rec, "project"), num(rec, "pipeline_id"))
 		case "stage":
 			from = endpoint{Stage, map[string]string{
-				"org": org, "project": mStr(rec, "project"),
+				"org": c.Org, "project": mStr(rec, "project"),
 				"pipeline_id": num(rec, "pipeline_id"), "stage": mStr(rec, "stage"),
 			}}
 		case "job":
-			from = jobOf(org, rec)
+			from = c.jobOf(rec)
 		default:
-			return resolved{}, false
+			return nil
 		}
-		return pair(ConsumesGroup, from,
-			groupOf(org, mStr(rec, "owner_project"), num(rec, "variable_group_id")))
+		return one(ConsumesGroup, from,
+			c.groupOf(mStr(rec, "owner_project"), num(rec, "variable_group_id")))
 	},
 
-	UsesConnection: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(UsesConnection, jobOf(org, rec),
+	UsesConnection: func(c graphCtx, rec map[string]any) []resolved {
+		return one(UsesConnection, c.jobOf(rec),
 			endpoint{ServiceConnection, map[string]string{
-				"org": org, "owner_project": mStr(rec, "owner_project"),
+				"org": c.Org, "owner_project": mStr(rec, "owner_project"),
 				"connection_id": mStr(rec, "service_connection_id"),
 			}})
 	},
 
-	RunsOn: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(RunsOn, jobOf(org, rec),
+	RunsOn: func(c graphCtx, rec map[string]any) []resolved {
+		return one(RunsOn, c.jobOf(rec),
 			endpoint{ProjectAgentPool, map[string]string{
-				"org": org, "project": mStr(rec, "project"),
+				"org": c.Org, "project": mStr(rec, "project"),
 				"queue_id": num(rec, "project_agent_pool_id"),
 			}})
 	},
 
-	Targets: func(org string, rec map[string]any) (resolved, bool) {
-		return pair(Targets, jobOf(org, rec),
+	Targets: func(c graphCtx, rec map[string]any) []resolved {
+		return one(Targets, c.jobOf(rec),
 			endpoint{Environment, map[string]string{
-				"org": org, "project": mStr(rec, "project"), "name": mStr(rec, "environment"),
+				"org": c.Org, "project": mStr(rec, "project"), "name": mStr(rec, "environment"),
 			}})
+	},
+
+	MemberOf: func(c graphCtx, rec map[string]any) []resolved {
+		group, ok := c.principalOf(mStr(rec, "group"))
+		if !ok {
+			return nil
+		}
+		return c.fanOut(MemberOf, []string{mStr(rec, "member")}, group)
+	},
+
+	HasRole: func(c graphCtx, rec map[string]any) []resolved {
+		label, ok := roleResourceLabels[mStr(rec, "resource_kind")]
+		if !ok || !mBool(rec, "resource_resolved") {
+			return nil
+		}
+		to, ok := roleResourceEndpoint(c.Org, label, mStr(rec, "resource_id"))
+		if !ok {
+			return nil
+		}
+		return c.fanOut(HasRole, []string{mStr(rec, "graph_descriptor")}, to)
+	},
+
+	CanPushTo: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(CanPushTo, []string{mStr(rec, "principal")}, c.branchOf(rec))
+	},
+
+	CanMergeViaPR: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(CanMergeViaPR, []string{mStr(rec, "principal")}, c.branchOf(rec))
+	},
+
+	CanBypass: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(CanBypass, []string{mStr(rec, "principal")}, c.policyOf(rec))
+	},
+
+	PipelinePoisoning: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(PipelinePoisoning, sourcePrincipals(rec), c.jobOf(rec))
+	},
+
+	QueueTimeInjection: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(QueueTimeInjection, sourcePrincipals(rec), c.jobOf(rec))
+	},
+
+	LoggingCommandInjection: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(LoggingCommandInjection, sourcePrincipals(rec), c.jobOf(rec))
+	},
+
+	AgentInjection: func(c graphCtx, rec map[string]any) []resolved {
+		return c.fanOut(AgentInjection, sourcePrincipals(rec), c.jobOf(rec))
 	},
 }
 
-func resolveEndpoints(org string, rec map[string]any) (resolved, bool) {
+func roleResourceEndpoint(org string, label NodeLabel, resourceID string) (endpoint, bool) {
+	parts := strings.SplitN(resourceID, "/", 3)
+	switch label {
+	case Project:
+		if len(parts) != 2 {
+			return endpoint{}, false
+		}
+		return endpoint{Project, map[string]string{"org": org, "project": parts[1]}}, true
+	case Repository:
+		if len(parts) != 3 {
+			return endpoint{}, false
+		}
+		return endpoint{Repository, map[string]string{"org": org, "project": parts[1], "repo": parts[2]}}, true
+	case Pipeline:
+		if len(parts) != 3 {
+			return endpoint{}, false
+		}
+		return endpoint{Pipeline, map[string]string{"org": org, "project": parts[1], "pipeline_id": parts[2]}}, true
+	case ServiceConnection:
+		if len(parts) != 3 {
+			return endpoint{}, false
+		}
+		return endpoint{ServiceConnection, map[string]string{
+			"org": org, "owner_project": parts[1], "connection_id": parts[2],
+		}}, true
+	}
+	return endpoint{}, false
+}
+
+func resolveEndpoints(c graphCtx, rec map[string]any) []resolved {
 	r, ok := endpointResolvers[EdgeType(mStr(rec, "kind"))]
 	if !ok {
-		return resolved{}, false
+		return nil
 	}
-	return r(org, rec)
+	return r(c, rec)
 }

--- a/internal/ado/graph_endpoints.go
+++ b/internal/ado/graph_endpoints.go
@@ -59,6 +59,14 @@ func policyOf(org string, rec map[string]any) endpoint {
 	}}
 }
 
+func jobOf(org string, rec map[string]any) endpoint {
+	return endpoint{Job, map[string]string{
+		"org": org, "project": mStr(rec, "project"),
+		"pipeline_id": num(rec, "pipeline_id"),
+		"stage":       mStr(rec, "stage"), "job": mStr(rec, "job"),
+	}}
+}
+
 var endpointResolvers = map[EdgeType]endpointResolver{
 	DefinedBy: func(org string, rec map[string]any) (resolved, bool) {
 		return pair(DefinedBy,
@@ -115,6 +123,56 @@ var endpointResolvers = map[EdgeType]endpointResolver{
 		return pair(Installs,
 			endpoint{Extension, map[string]string{"org": org, "extension_id": ext}},
 			endpoint{PipelineDecorator, map[string]string{"org": org, "extension_id": ext}})
+	},
+
+	Reads: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(Reads, jobOf(org, rec),
+			endpoint{SecretVariable, map[string]string{
+				"org": org, "owner_project": mStr(rec, "owner_project"),
+				"group_id": num(rec, "variable_group_id"), "name": mStr(rec, "secret_name"),
+			}})
+	},
+
+	ConsumesGroup: func(org string, rec map[string]any) (resolved, bool) {
+		var from endpoint
+		switch mStr(rec, "level") {
+		case "pipeline":
+			from = pipelineOf(org, mStr(rec, "project"), num(rec, "pipeline_id"))
+		case "stage":
+			from = endpoint{Stage, map[string]string{
+				"org": org, "project": mStr(rec, "project"),
+				"pipeline_id": num(rec, "pipeline_id"), "stage": mStr(rec, "stage"),
+			}}
+		case "job":
+			from = jobOf(org, rec)
+		default:
+			return resolved{}, false
+		}
+		return pair(ConsumesGroup, from,
+			groupOf(org, mStr(rec, "owner_project"), num(rec, "variable_group_id")))
+	},
+
+	UsesConnection: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(UsesConnection, jobOf(org, rec),
+			endpoint{ServiceConnection, map[string]string{
+				"org": org, "owner_project": mStr(rec, "owner_project"),
+				"connection_id": mStr(rec, "service_connection_id"),
+			}})
+	},
+
+	RunsOn: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(RunsOn, jobOf(org, rec),
+			endpoint{ProjectAgentPool, map[string]string{
+				"org": org, "project": mStr(rec, "project"),
+				"queue_id": num(rec, "project_agent_pool_id"),
+			}})
+	},
+
+	Targets: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(Targets, jobOf(org, rec),
+			endpoint{Environment, map[string]string{
+				"org": org, "project": mStr(rec, "project"), "name": mStr(rec, "environment"),
+			}})
 	},
 }
 

--- a/internal/ado/graph_endpoints.go
+++ b/internal/ado/graph_endpoints.go
@@ -1,0 +1,127 @@
+package ado
+
+import "strconv"
+
+type endpoint struct {
+	Label NodeLabel
+	Key   map[string]string
+}
+
+type resolved struct {
+	Type EdgeType
+	From endpoint
+	To   endpoint
+}
+
+type endpointResolver func(org string, rec map[string]any) (resolved, bool)
+
+func num(m map[string]any, k string) string {
+	if v := mInt64(m, k); v != 0 {
+		return strconv.FormatInt(v, 10)
+	}
+	return ""
+}
+
+func complete(e endpoint) bool {
+	for _, k := range IdentityKey(e.Label) {
+		if e.Key[k] == "" {
+			return false
+		}
+	}
+	return len(IdentityKey(e.Label)) > 0
+}
+
+func pair(t EdgeType, from, to endpoint) (resolved, bool) {
+	if !complete(from) || !complete(to) || !ValidEdge(t, from.Label, to.Label) {
+		return resolved{}, false
+	}
+	return resolved{Type: t, From: from, To: to}, true
+}
+
+func branchOf(org string, rec map[string]any) endpoint {
+	return endpoint{Branch, map[string]string{
+		"org": org, "project": mStr(rec, "project"),
+		"repo": mStr(rec, "repo"), "name": mStr(rec, "branch"),
+	}}
+}
+
+func pipelineOf(org, project, id string) endpoint {
+	return endpoint{Pipeline, map[string]string{"org": org, "project": project, "pipeline_id": id}}
+}
+
+func groupOf(org, owner, id string) endpoint {
+	return endpoint{VariableGroup, map[string]string{"org": org, "owner_project": owner, "group_id": id}}
+}
+
+func policyOf(org string, rec map[string]any) endpoint {
+	return endpoint{BranchPolicy, map[string]string{
+		"org": org, "project": mStr(rec, "project"), "config_id": num(rec, "config_id"),
+	}}
+}
+
+var endpointResolvers = map[EdgeType]endpointResolver{
+	DefinedBy: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(DefinedBy,
+			pipelineOf(org, mStr(rec, "project"), num(rec, "pipeline_id")),
+			branchOf(org, rec))
+	},
+
+	Defines: func(org string, rec map[string]any) (resolved, bool) {
+		owner, gid := mStr(rec, "project"), num(rec, "group_id")
+		return pair(Defines,
+			groupOf(org, owner, gid),
+			endpoint{SecretVariable, map[string]string{
+				"org": org, "owner_project": owner, "group_id": gid, "name": mStr(rec, "secret_name"),
+			}})
+	},
+
+	HasPolicy: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(HasPolicy, policyOf(org, rec), branchOf(org, rec))
+	},
+
+	BuildValidates: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(BuildValidates,
+			policyOf(org, rec),
+			pipelineOf(org, mStr(rec, "project"), num(rec, "build_definition_id")))
+	},
+
+	ReferencesPool: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(ReferencesPool,
+			endpoint{ProjectAgentPool, map[string]string{
+				"org": org, "project": mStr(rec, "project"), "queue_id": num(rec, "queue_id"),
+			}},
+			endpoint{OrgAgentPool, map[string]string{"org": org, "pool_id": num(rec, "org_pool_id")}})
+	},
+
+	LinksTo: func(org string, rec map[string]any) (resolved, bool) {
+		return pair(LinksTo,
+			groupOf(org, mStr(rec, "project"), num(rec, "variable_group_id")),
+			endpoint{KeyVault, map[string]string{"name": mStr(rec, "keyvault_name")}})
+	},
+
+	FederatesTo: func(org string, rec map[string]any) (resolved, bool) {
+		owner, conn := mStr(rec, "project"), mStr(rec, "connection_id")
+		return pair(FederatesTo,
+			endpoint{ServiceConnection, map[string]string{
+				"org": org, "owner_project": owner, "connection_id": conn,
+			}},
+			endpoint{WIFCredential, map[string]string{
+				"org": org, "owner_project": owner, "connection_id": conn, "subject": mStr(rec, "subject"),
+			}})
+	},
+
+	Installs: func(org string, rec map[string]any) (resolved, bool) {
+		ext := mStr(rec, "extension_id")
+		return pair(Installs,
+			endpoint{Extension, map[string]string{"org": org, "extension_id": ext}},
+			endpoint{PipelineDecorator, map[string]string{"org": org, "extension_id": ext}})
+	},
+}
+
+func resolveEndpoints(org string, rec map[string]any) (resolved, bool) {
+	r, ok := endpointResolvers[EdgeType(mStr(rec, "kind"))]
+	if !ok {
+		return resolved{}, false
+	}
+	return r(org, rec)
+}

--- a/internal/ado/graph_endpoints_test.go
+++ b/internal/ado/graph_endpoints_test.go
@@ -69,7 +69,7 @@ func TestHasRoleTargetFollowsResourceKind(t *testing.T) {
 	}{
 		{"Project", "org/proj", true, Project, "org/proj"},
 		{"Repository", "org/proj/r", true, Repository, "org/proj/r"},
-		{"ServiceConnection", "org/owner/c1", true, ServiceConnection, "org/owner/c1"},
+		{"ServiceConnection", "owner/c1", true, ServiceConnection, "org/owner/c1"},
 		{"Project", "org", true, "", ""},
 		{"Project", "org/proj", false, "", ""},
 		{"DeploymentGroup", "org/proj", true, "", ""},

--- a/internal/ado/graph_endpoints_test.go
+++ b/internal/ado/graph_endpoints_test.go
@@ -1,0 +1,130 @@
+package ado
+
+import "testing"
+
+var testCtx = graphCtx{
+	Org: "org",
+	Principal: func(d string) (NodeLabel, bool) {
+		l, ok := map[string]NodeLabel{
+			"aad.user":  User,
+			"vssgp.grp": SecurityGroup,
+		}[d]
+		return l, ok
+	},
+}
+
+func keyString(e endpoint) string {
+	out := ""
+	for i, k := range IdentityKey(e.Label) {
+		if i > 0 {
+			out += "/"
+		}
+		out += e.Key[k]
+	}
+	return out
+}
+
+func TestConsumesGroupSourceFollowsLevel(t *testing.T) {
+	rec := map[string]any{
+		"kind": "CONSUMES_GROUP", "project": "proj", "pipeline_id": int64(1),
+		"stage": "s", "job": "b",
+		"owner_project": "owner", "variable_group_id": int64(4),
+	}
+	for _, tc := range []struct {
+		level string
+		label NodeLabel
+		from  string
+	}{
+		{"pipeline", Pipeline, "org/proj/1"},
+		{"stage", Stage, "org/proj/1/s"},
+		{"job", Job, "org/proj/1/s/b"},
+	} {
+		rec["level"] = tc.level
+		rs := resolveEndpoints(testCtx, rec)
+		if len(rs) != 1 {
+			t.Fatalf("%s: resolved %d edges, want 1", tc.level, len(rs))
+		}
+		if rs[0].From.Label != tc.label || keyString(rs[0].From) != tc.from {
+			t.Errorf("%s: from = %s %q, want %s %q",
+				tc.level, rs[0].From.Label, keyString(rs[0].From), tc.label, tc.from)
+		}
+		if got := keyString(rs[0].To); got != "org/owner/4" {
+			t.Errorf("%s: a group consumed across projects resolved to %q, not its owner", tc.level, got)
+		}
+	}
+
+	rec["level"] = "unknown"
+	if rs := resolveEndpoints(testCtx, rec); len(rs) != 0 {
+		t.Errorf("an unrecognized level resolved %d edges, want 0", len(rs))
+	}
+}
+
+func TestHasRoleTargetFollowsResourceKind(t *testing.T) {
+	for _, tc := range []struct {
+		kind     string
+		id       string
+		resolved bool
+		label    NodeLabel
+		to       string
+	}{
+		{"Project", "org/proj", true, Project, "org/proj"},
+		{"Repository", "org/proj/r", true, Repository, "org/proj/r"},
+		{"ServiceConnection", "org/owner/c1", true, ServiceConnection, "org/owner/c1"},
+		{"Project", "org", true, "", ""},
+		{"Project", "org/proj", false, "", ""},
+		{"DeploymentGroup", "org/proj", true, "", ""},
+	} {
+		rs := resolveEndpoints(testCtx, map[string]any{
+			"kind": "HAS_ROLE", "resource_kind": tc.kind, "resource_id": tc.id,
+			"resource_resolved": tc.resolved, "graph_descriptor": "vssgp.grp",
+		})
+		if !tc.resolved || tc.label == "" {
+			if len(rs) != 0 {
+				t.Errorf("%s %q resolved=%v: got %d edges, want 0", tc.kind, tc.id, tc.resolved, len(rs))
+			}
+			continue
+		}
+		if len(rs) != 1 {
+			t.Fatalf("%s: resolved %d edges, want 1", tc.kind, len(rs))
+		}
+		if rs[0].To.Label != tc.label || keyString(rs[0].To) != tc.to {
+			t.Errorf("%s: to = %s %q, want %s %q", tc.kind, rs[0].To.Label, keyString(rs[0].To), tc.label, tc.to)
+		}
+	}
+}
+
+func TestAttackEdgeFansOutOverSourcePrincipals(t *testing.T) {
+	rs := resolveEndpoints(testCtx, map[string]any{
+		"kind": "PIPELINE_POISONING", "project": "proj", "pipeline_id": int64(1),
+		"stage": "s", "job": "b",
+		"source_principals": []any{
+			map[string]any{"descriptor": "aad.user"},
+			map[string]any{"descriptor": "vssgp.grp"},
+			map[string]any{"descriptor": "aad.uncollected"},
+		},
+	})
+	if len(rs) != 2 {
+		t.Fatalf("resolved %d edges, want 2: an uncollected principal has no label to point at", len(rs))
+	}
+	for i, want := range []NodeLabel{User, SecurityGroup} {
+		if rs[i].From.Label != want {
+			t.Errorf("[%d] from = %s, want %s", i, rs[i].From.Label, want)
+		}
+		if got := keyString(rs[i].To); got != "org/proj/1/s/b" {
+			t.Errorf("[%d] to = %q", i, got)
+		}
+	}
+}
+
+func TestIncompleteIdentityDoesNotResolve(t *testing.T) {
+	for _, rec := range []map[string]any{
+		{"kind": "DEFINED_BY", "project": "proj", "repo": "r", "pipeline_id": int64(1)},
+		{"kind": "RUNS_ON", "project": "proj", "pipeline_id": int64(1), "job": "b", "project_agent_pool_id": int64(3)},
+		{"kind": "TARGETS", "project": "proj", "pipeline_id": int64(1), "stage": "s", "job": "b"},
+		{"kind": "READS", "project": "proj", "pipeline_id": int64(1), "stage": "s", "job": "b", "secret_name": "S"},
+	} {
+		if rs := resolveEndpoints(testCtx, rec); len(rs) != 0 {
+			t.Errorf("%s resolved despite an incomplete identity", rec["kind"])
+		}
+	}
+}

--- a/internal/ado/graph_nodes.go
+++ b/internal/ado/graph_nodes.go
@@ -1,0 +1,460 @@
+package ado
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type findingRef struct {
+	RuleID      string `json:"rule_id"`
+	Fingerprint string `json:"fingerprint"`
+	Severity    string `json:"severity"`
+	Confidence  string `json:"confidence"`
+	Target      string `json:"target"`
+	SubjectKind string `json:"subject_kind"`
+	SubjectID   string `json:"subject_id"`
+	Title       string `json:"title"`
+}
+
+type node struct {
+	ID         string            `json:"id"`
+	Labels     []NodeLabel       `json:"labels"`
+	Key        map[string]string `json:"key"`
+	Properties map[string]any    `json:"properties"`
+	Findings   []findingRef      `json:"findings"`
+}
+
+type edge struct {
+	ID         string         `json:"id"`
+	Type       EdgeType       `json:"type"`
+	From       string         `json:"from"`
+	To         string         `json:"to"`
+	FromLabel  NodeLabel      `json:"from_label"`
+	ToLabel    NodeLabel      `json:"to_label"`
+	Properties map[string]any `json:"properties"`
+	Findings   []findingRef   `json:"findings"`
+}
+
+type identityMerge struct {
+	Label         NodeLabel `json:"label"`
+	SourceRecords int       `json:"source_records"`
+	Nodes         int       `json:"nodes"`
+	MergedRecords int       `json:"merged_records"`
+}
+
+type propertyConflict struct {
+	Label     NodeLabel `json:"label"`
+	Property  string    `json:"property"`
+	Discarded int       `json:"discarded"`
+}
+
+type edgeConflict struct {
+	Type      EdgeType `json:"type"`
+	Property  string   `json:"property"`
+	Discarded int      `json:"discarded"`
+}
+
+func esc(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+func nodeID(l NodeLabel, key map[string]string) string {
+	parts := []string{string(l)}
+	for _, k := range IdentityKey(l) {
+		parts = append(parts, esc(key[k]))
+	}
+	return strings.Join(parts, "|")
+}
+
+func (e endpoint) id() string { return nodeID(e.Label, e.Key) }
+
+func edgeID(t EdgeType, from, to string) string {
+	return fmt.Sprintf("%s|%s|%s", t, esc(from), esc(to))
+}
+
+func edgeKey(t EdgeType, from, to NodeLabel) string {
+	return fmt.Sprintf("%s{%s,%s}", t, from, to)
+}
+
+// ADO has three expression syntaxes and a node named $(rolearn) or ${{ parameters.env }}
+// is a template, not an entity.
+func identifies(v string) bool {
+	return v != "" && !strings.Contains(v, "$(") && !strings.Contains(v, "${{") && !strings.Contains(v, "$[")
+}
+
+type conflictKey struct {
+	label    NodeLabel
+	property string
+}
+
+type nodeSet struct {
+	byID       map[string]*node
+	subjects   map[string]map[string]string
+	sourceRecs map[NodeLabel]int
+	incomplete map[NodeLabel]int
+	conflicts  map[conflictKey]int
+	illegal    map[conflictKey]bool
+	dropped    int
+}
+
+func newNodeSet() *nodeSet {
+	return &nodeSet{
+		byID:       map[string]*node{},
+		subjects:   map[string]map[string]string{},
+		sourceRecs: map[NodeLabel]int{},
+		incomplete: map[NodeLabel]int{},
+		conflicts:  map[conflictKey]int{},
+		illegal:    map[conflictKey]bool{},
+	}
+}
+
+func (s *nodeSet) upsert(l NodeLabel, key map[string]string, props map[string]any, source string) *node {
+	ident := IdentityKey(l)
+	if len(ident) == 0 {
+		return nil
+	}
+	k := make(map[string]string, len(ident))
+	for _, name := range ident {
+		v := key[name]
+		if !identifies(v) {
+			s.incomplete[l]++
+			return nil
+		}
+		k[name] = v
+	}
+	id := nodeID(l, k)
+	s.sourceRecs[l]++
+
+	n := s.byID[id]
+	if n == nil {
+		n = &node{ID: id, Labels: []NodeLabel{l}, Key: k, Properties: map[string]any{}, Findings: []findingRef{}}
+		s.byID[id] = n
+	}
+	s.merge(n, props)
+	if source != "" {
+		s.merge(n, map[string]any{"_source": []any{source}})
+	}
+	n.Properties["graph_id"] = id
+	return n
+}
+
+func (s *nodeSet) merge(n *node, props map[string]any) {
+	for _, k := range slices.Sorted(maps.Keys(props)) {
+		v := props[k]
+		old, seen := n.Properties[k]
+		if !seen {
+			n.Properties[k] = v
+			continue
+		}
+		ao, aok := old.([]any)
+		an, nok := v.([]any)
+		if aok && nok {
+			n.Properties[k] = unionArray(ao, an)
+			continue
+		}
+		if scalarKey(old) != scalarKey(v) {
+			s.conflicts[conflictKey{n.Labels[0], k}]++
+		}
+	}
+}
+
+func (s *nodeSet) index(kind, recordID string, n *node) {
+	if n == nil || recordID == "" {
+		return
+	}
+	if s.subjects[kind] == nil {
+		s.subjects[kind] = map[string]string{}
+	}
+	if _, dup := s.subjects[kind][recordID]; !dup {
+		s.subjects[kind][recordID] = n.ID
+	}
+}
+
+func (s *nodeSet) subject(kind, recordID string) (string, bool) {
+	id, ok := s.subjects[kind][recordID]
+	return id, ok
+}
+
+func (s *nodeSet) has(id string) bool { _, ok := s.byID[id]; return ok }
+
+func (s *nodeSet) all() []node {
+	out := make([]node, 0, len(s.byID))
+	for _, n := range s.byID {
+		out = append(out, *n)
+	}
+	slices.SortFunc(out, func(a, b node) int {
+		return cmp.Or(cmp.Compare(a.Labels[0], b.Labels[0]), cmp.Compare(a.ID, b.ID))
+	})
+	return out
+}
+
+func (s *nodeSet) byLabel() map[NodeLabel]int {
+	out := make(map[NodeLabel]int, len(identityKeys))
+	for _, l := range NodeLabels() {
+		out[l] = 0
+	}
+	for _, n := range s.byID {
+		out[n.Labels[0]]++
+	}
+	return out
+}
+
+func (s *nodeSet) merges() []identityMerge {
+	counts := s.byLabel()
+	out := []identityMerge{}
+	for _, l := range NodeLabels() {
+		src := s.sourceRecs[l]
+		if src == 0 || src == counts[l] {
+			continue
+		}
+		out = append(out, identityMerge{l, src, counts[l], src - counts[l]})
+	}
+	return out
+}
+
+func (s *nodeSet) propertyConflicts() []propertyConflict {
+	out := make([]propertyConflict, 0, len(s.conflicts))
+	for k, n := range s.conflicts {
+		out = append(out, propertyConflict{k.label, k.property, n})
+	}
+	slices.SortFunc(out, func(a, b propertyConflict) int {
+		return cmp.Or(cmp.Compare(b.Discarded, a.Discarded),
+			cmp.Compare(a.Label, b.Label), cmp.Compare(a.Property, b.Property))
+	})
+	return out
+}
+
+func (s *nodeSet) incompleteIdentities() map[NodeLabel]int { return maps.Clone(s.incomplete) }
+
+func (s *nodeSet) recordProps(l NodeLabel, fields map[string]any) map[string]any {
+	ident := IdentityKey(l)
+	out := make(map[string]any, len(fields))
+	for k, v := range fields {
+		if k == "_id" || k == "kind" || k == "_provenance" || slices.Contains(ident, k) {
+			continue
+		}
+		if !legalProp(v) {
+			s.illegal[conflictKey{l, k}] = true
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func (s *nodeSet) sweepIllegal() {
+	for _, n := range s.byID {
+		for k := range n.Properties {
+			if s.illegal[conflictKey{n.Labels[0], k}] {
+				delete(n.Properties, k)
+				s.dropped++
+			}
+		}
+	}
+}
+
+type edgeConflictKey struct {
+	edgeType EdgeType
+	property string
+}
+
+type edgeSet struct {
+	byID      map[string]*edge
+	unbuilt   map[string]int
+	conflicts map[edgeConflictKey]int
+	illegal   map[string]int
+}
+
+func newEdgeSet() *edgeSet {
+	return &edgeSet{byID: map[string]*edge{}, unbuilt: map[string]int{},
+		conflicts: map[edgeConflictKey]int{}, illegal: map[string]int{}}
+}
+
+func (s *edgeSet) add(t EdgeType, from, to endpoint, props map[string]any) {
+	if !complete(from) || !complete(to) {
+		s.unbuilt[edgeKey(t, from.Label, to.Label)]++
+		return
+	}
+	if !ValidEdge(t, from.Label, to.Label) {
+		s.illegal[edgeKey(t, from.Label, to.Label)]++
+		return
+	}
+	id := edgeID(t, from.id(), to.id())
+	e := s.byID[id]
+	if e == nil {
+		e = &edge{
+			ID: id, Type: t, From: from.id(), To: to.id(),
+			FromLabel: from.Label, ToLabel: to.Label,
+			Properties: map[string]any{}, Findings: []findingRef{},
+		}
+		s.byID[id] = e
+	}
+	for _, k := range slices.Sorted(maps.Keys(props)) {
+		v := props[k]
+		old, seen := e.Properties[k]
+		if !seen {
+			e.Properties[k] = v
+			continue
+		}
+		ao, aok := old.([]any)
+		an, nok := v.([]any)
+		if aok && nok {
+			e.Properties[k] = unionArray(ao, an)
+			continue
+		}
+		if scalarKey(old) != scalarKey(v) {
+			s.conflicts[edgeConflictKey{t, k}]++
+		}
+	}
+	e.Properties["graph_id"] = id
+}
+
+func (s *edgeSet) miss(t EdgeType, from, to NodeLabel, n int) { s.unbuilt[edgeKey(t, from, to)] += n }
+
+func (s *edgeSet) all() []edge {
+	out := make([]edge, 0, len(s.byID))
+	for _, e := range s.byID {
+		out = append(out, *e)
+	}
+	slices.SortFunc(out, func(a, b edge) int {
+		return cmp.Or(cmp.Compare(a.Type, b.Type), cmp.Compare(a.From, b.From), cmp.Compare(a.To, b.To))
+	})
+	return out
+}
+
+func (s *edgeSet) byType() map[EdgeType]int {
+	out := make(map[EdgeType]int, len(edgeEndpoints))
+	for _, t := range EdgeTypes() {
+		out[t] = 0
+	}
+	for _, e := range s.byID {
+		out[e.Type]++
+	}
+	return out
+}
+
+func (s *edgeSet) propertyConflicts() []edgeConflict {
+	out := make([]edgeConflict, 0, len(s.conflicts))
+	for k, n := range s.conflicts {
+		out = append(out, edgeConflict{k.edgeType, k.property, n})
+	}
+	slices.SortFunc(out, func(a, b edgeConflict) int {
+		return cmp.Or(cmp.Compare(b.Discarded, a.Discarded),
+			cmp.Compare(a.Type, b.Type), cmp.Compare(a.Property, b.Property))
+	})
+	return out
+}
+
+func (s *edgeSet) err() error {
+	if len(s.illegal) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d illegal endpoint pair(s): %v", len(s.illegal), s.illegal)
+}
+
+func emptyEdgeTriples(edgeList []edge) []string {
+	present := make(map[string]bool, len(edgeList))
+	for _, e := range edgeList {
+		present[edgeKey(e.Type, e.FromLabel, e.ToLabel)] = true
+	}
+	out := []string{}
+	for _, t := range EdgeTypes() {
+		for _, p := range edgeEndpoints[t] {
+			if k := edgeKey(t, p[0], p[1]); !present[k] {
+				out = append(out, k)
+			}
+		}
+	}
+	return out
+}
+
+func legalProp(v any) bool {
+	switch t := v.(type) {
+	case nil, bool, string, json.Number, float64:
+		return true
+	case []any:
+		return primitiveArray(t)
+	}
+	return false
+}
+
+func primitiveArray(a []any) bool {
+	kind := ""
+	for _, e := range a {
+		k := primKind(e)
+		if k == "" || (kind != "" && k != kind) {
+			return false
+		}
+		kind = k
+	}
+	return true
+}
+
+func primKind(v any) string {
+	switch v.(type) {
+	case string:
+		return "s"
+	case bool:
+		return "b"
+	case json.Number, float64:
+		return "n"
+	}
+	return ""
+}
+
+func unionArray(a, b []any) []any {
+	out := make([]any, 0, len(a)+len(b))
+	seen := make(map[string]bool, len(a)+len(b))
+	for _, e := range slices.Concat(a, b) {
+		k := scalarKey(e)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, e)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return lessPrimitive(out[i], out[j]) })
+	return out
+}
+
+func lessPrimitive(a, b any) bool {
+	na, aok := a.(json.Number)
+	nb, bok := b.(json.Number)
+	if aok && bok {
+		fa, ea := na.Float64()
+		fb, eb := nb.Float64()
+		if ea == nil && eb == nil && fa != fb {
+			return fa < fb
+		}
+	}
+	return scalarKey(a) < scalarKey(b)
+}
+
+func scalarKey(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return "\x00null"
+	case string:
+		return "s" + t
+	case bool:
+		return "b" + strconv.FormatBool(t)
+	case json.Number:
+		return "n" + t.String()
+	case float64:
+		return "n" + strconv.FormatFloat(t, 'g', -1, 64)
+	case []any:
+		parts := make([]string, 0, len(t))
+		for _, e := range t {
+			parts = append(parts, scalarKey(e))
+		}
+		return "a[" + strings.Join(parts, ",") + "]"
+	}
+	return "?"
+}

--- a/internal/ado/graph_nodes.go
+++ b/internal/ado/graph_nodes.go
@@ -184,6 +184,8 @@ func (s *nodeSet) subject(kind, recordID string) (string, bool) {
 
 func (s *nodeSet) has(id string) bool { _, ok := s.byID[id]; return ok }
 
+func (s *nodeSet) get(id string) *node { return s.byID[id] }
+
 func (s *nodeSet) all() []node {
 	out := make([]node, 0, len(s.byID))
 	for _, n := range s.byID {
@@ -277,14 +279,14 @@ func newEdgeSet() *edgeSet {
 		conflicts: map[edgeConflictKey]int{}, illegal: map[string]int{}}
 }
 
-func (s *edgeSet) add(t EdgeType, from, to endpoint, props map[string]any) {
+func (s *edgeSet) add(t EdgeType, from, to endpoint, props map[string]any) string {
 	if !complete(from) || !complete(to) {
 		s.unbuilt[edgeKey(t, from.Label, to.Label)]++
-		return
+		return ""
 	}
 	if !ValidEdge(t, from.Label, to.Label) {
 		s.illegal[edgeKey(t, from.Label, to.Label)]++
-		return
+		return ""
 	}
 	id := edgeID(t, from.id(), to.id())
 	e := s.byID[id]
@@ -314,6 +316,7 @@ func (s *edgeSet) add(t EdgeType, from, to endpoint, props map[string]any) {
 		}
 	}
 	e.Properties["graph_id"] = id
+	return id
 }
 
 func (s *edgeSet) miss(t EdgeType, from, to NodeLabel, n int) { s.unbuilt[edgeKey(t, from, to)] += n }

--- a/internal/ado/graph_push.go
+++ b/internal/ado/graph_push.go
@@ -1,0 +1,322 @@
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+
+	"github.com/praetorian-inc/trajan/internal/engine"
+	"github.com/praetorian-inc/trajan/internal/ui"
+)
+
+const pushBatch = 1000
+
+func PushGraph(ctx context.Context, cfg *engine.Config, runDir, neo4jURL, neo4jUser, neo4jPass string, reset bool) error {
+	state, err := engine.LoadState(runDir)
+	if err != nil {
+		return err
+	}
+	if err := state.CheckPhase(engine.PhasePush); err != nil {
+		return err
+	}
+	ui.PhaseHeader("Push")
+	timer := engine.StartPhaseTimer(engine.PhasePush, "push")
+	stats, pushErr := runPush(ctx, runDir, state, neo4jURL, neo4jUser, neo4jPass, reset)
+	rec := timer.Stop(pushErr)
+	state.RecordPhase(rec)
+	saveErr := state.Save(runDir)
+	if pushErr == nil {
+		ui.Outcome("Push complete", []ui.Count{
+			{Label: "nodes", N: stats.nodes},
+			{Label: "edges", N: stats.edges},
+		}, engine.Elapsed(rec.DurationS))
+	}
+	return errors.Join(pushErr, saveErr)
+}
+
+type pushStats struct{ nodes, edges int }
+
+func runPush(ctx context.Context, runDir string, state *engine.State, url, user, pass string, reset bool) (pushStats, error) {
+	var nf nodesFile
+	var ef edgesFile
+	for _, in := range []struct {
+		rel string
+		v   any
+	}{{engine.GraphNodes(), &nf}, {engine.GraphEdges(), &ef}} {
+		b, err := os.ReadFile(filepath.Join(runDir, in.rel))
+		if err != nil {
+			return pushStats{}, fmt.Errorf("read %s: %w (run graph first)", in.rel, err)
+		}
+		if err := json.Unmarshal(b, in.v); err != nil {
+			return pushStats{}, fmt.Errorf("parse %s: %w", in.rel, err)
+		}
+	}
+
+	drv, err := neo4j.NewDriverWithContext(url, neo4j.BasicAuth(user, pass, ""))
+	if err != nil {
+		return pushStats{}, err
+	}
+	defer drv.Close(ctx)
+	if err := drv.VerifyConnectivity(ctx); err != nil {
+		return pushStats{}, fmt.Errorf("connect %s: %w", url, err)
+	}
+
+	sess := drv.NewSession(ctx, neo4j.SessionConfig{AccessMode: neo4j.AccessModeWrite})
+	defer sess.Close(ctx)
+
+	if err := ensureConstraints(ctx, sess, nf.Nodes); err != nil {
+		return pushStats{}, err
+	}
+	if reset {
+		if _, err := runCypher(ctx, sess, "MATCH (n) DETACH DELETE n", nil); err != nil {
+			return pushStats{}, err
+		}
+	}
+
+	nodesWritten, err := pushNodes(ctx, sess, nf.Nodes, state)
+	if err != nil {
+		return pushStats{}, err
+	}
+	edgesWritten, err := pushEdges(ctx, sess, ef.Edges, state)
+	if err != nil {
+		return pushStats{}, err
+	}
+
+	if edgesWritten < len(ef.Edges) {
+		return pushStats{}, fmt.Errorf("%d edge(s) named an endpoint no node supplied", len(ef.Edges)-edgesWritten)
+	}
+	return pushStats{nodes: nodesWritten, edges: edgesWritten}, nil
+}
+
+func runCypher(ctx context.Context, sess neo4j.SessionWithContext, cypher string, params map[string]any) (int, error) {
+	res, err := sess.Run(ctx, cypher, params)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", firstLine(cypher), err)
+	}
+	sum, err := res.Consume(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("%s: %w", firstLine(cypher), err)
+	}
+	c := sum.Counters()
+	return c.NodesCreated() + c.PropertiesSet() + c.RelationshipsCreated(), nil
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func ensureConstraints(ctx context.Context, sess neo4j.SessionWithContext, nodes []node) error {
+	for _, l := range slices.Sorted(maps.Keys(labelsPresent(nodes))) {
+		q := fmt.Sprintf("CREATE CONSTRAINT trajan_%s_id IF NOT EXISTS FOR (n:%s) REQUIRE n._id IS UNIQUE",
+			strings.ToLower(string(l)), l)
+		if _, err := runCypher(ctx, sess, q, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func labelsPresent(nodes []node) map[NodeLabel]bool {
+	out := map[NodeLabel]bool{}
+	for _, n := range nodes {
+		if len(n.Labels) > 0 {
+			out[n.Labels[0]] = true
+		}
+	}
+	return out
+}
+
+func pushNodes(ctx context.Context, sess neo4j.SessionWithContext, nodes []node, state *engine.State) (int, error) {
+	byLabel := map[NodeLabel][]any{}
+	for _, n := range nodes {
+		if len(n.Labels) == 0 {
+			continue
+		}
+		props := scalarProps(n.Properties, n.Findings, n.ID, state)
+		for k, v := range n.Key {
+			props[k] = v
+		}
+		byLabel[n.Labels[0]] = append(byLabel[n.Labels[0]], map[string]any{"id": n.ID, "props": props})
+	}
+
+	total := 0
+	for _, l := range slices.Sorted(maps.Keys(labelsPresent(nodes))) {
+		q := fmt.Sprintf("UNWIND $rows AS r MERGE (n:%s {_id: r.id}) SET n += r.props", l)
+		for chunk := range slices.Chunk(byLabel[l], pushBatch) {
+			if _, err := runCypher(ctx, sess, q, map[string]any{"rows": chunk}); err != nil {
+				return total, err
+			}
+			total += len(chunk)
+		}
+	}
+	return total, nil
+}
+
+func pushEdges(ctx context.Context, sess neo4j.SessionWithContext, edges []edge, state *engine.State) (int, error) {
+	type triple struct {
+		t        EdgeType
+		from, to NodeLabel
+	}
+	byTriple := map[triple][]any{}
+	for _, e := range edges {
+		k := triple{e.Type, e.FromLabel, e.ToLabel}
+		byTriple[k] = append(byTriple[k], map[string]any{
+			"from": e.From, "to": e.To,
+			"props": scalarProps(e.Properties, e.Findings, e.ID, state),
+		})
+	}
+
+	keys := make([]triple, 0, len(byTriple))
+	for k := range byTriple {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, func(a, b triple) int {
+		return strings.Compare(string(a.t)+string(a.from)+string(a.to), string(b.t)+string(b.from)+string(b.to))
+	})
+
+	total := 0
+	for _, k := range keys {
+		q := fmt.Sprintf(`UNWIND $rows AS r
+MATCH (a:%s {_id: r.from})
+MATCH (b:%s {_id: r.to})
+MERGE (a)-[e:%s]->(b)
+SET e += r.props
+RETURN count(*) AS n`, k.from, k.to, k.t)
+		for chunk := range slices.Chunk(byTriple[k], pushBatch) {
+			res, err := sess.Run(ctx, q, map[string]any{"rows": chunk})
+			if err != nil {
+				return total, fmt.Errorf("%s{%s,%s}: %w", k.t, k.from, k.to, err)
+			}
+			rec, err := res.Single(ctx)
+			if err != nil {
+				return total, fmt.Errorf("%s{%s,%s}: %w", k.t, k.from, k.to, err)
+			}
+			n, _ := rec.Get("n")
+			written, _ := n.(int64)
+			total += int(written)
+		}
+	}
+	return total, nil
+}
+
+// A null property is dropped because SET n += {k: null} removes the key anyway.
+func scalarProps(props map[string]any, findings []findingRef, id string, state *engine.State) map[string]any {
+	out := make(map[string]any, len(props)+5)
+	for k, v := range props {
+		if v == nil {
+			continue
+		}
+		if a, ok := v.([]any); ok {
+			out[k] = scalarArray(a)
+			continue
+		}
+		out[k] = pushScalar(v)
+	}
+	if len(findings) > 0 {
+		fps := make([]string, 0, len(findings))
+		rules := make([]string, 0, len(findings))
+		for _, f := range findings {
+			fps = append(fps, f.Fingerprint)
+			rules = append(rules, f.RuleID)
+		}
+		slices.Sort(rules)
+		out["finding_fingerprints"] = fps
+		out["finding_rule_ids"] = slices.Compact(rules)
+	}
+	out["_id"] = id
+	out["_org"] = state.Org
+	out["_run_id"] = state.RunID
+	return out
+}
+
+// The corpus decodes with UseNumber, so an identity value that reached a property as
+// json.Number must land as an integer rather than a string.
+func pushScalar(v any) any {
+	switch t := v.(type) {
+	case json.Number:
+		if n, err := t.Int64(); err == nil {
+			return n
+		}
+		if f, err := t.Float64(); err == nil {
+			return f
+		}
+		return t.String()
+	case float64:
+		if t == float64(int64(t)) {
+			return int64(t)
+		}
+	}
+	return v
+}
+
+func scalarArray(a []any) any {
+	if len(a) == 0 {
+		return []string{}
+	}
+	switch pushScalar(a[0]).(type) {
+	case string:
+		out := make([]string, 0, len(a))
+		for _, v := range a {
+			s, ok := v.(string)
+			if !ok {
+				return jsonArray(a)
+			}
+			out = append(out, s)
+		}
+		return out
+	case int64:
+		out := make([]int64, 0, len(a))
+		for _, v := range a {
+			n, ok := pushScalar(v).(int64)
+			if !ok {
+				return jsonArray(a)
+			}
+			out = append(out, n)
+		}
+		return out
+	case float64:
+		out := make([]float64, 0, len(a))
+		for _, v := range a {
+			f, ok := pushScalar(v).(float64)
+			if !ok {
+				return jsonArray(a)
+			}
+			out = append(out, f)
+		}
+		return out
+	case bool:
+		out := make([]bool, 0, len(a))
+		for _, v := range a {
+			b, ok := v.(bool)
+			if !ok {
+				return jsonArray(a)
+			}
+			out = append(out, b)
+		}
+		return out
+	}
+	return jsonArray(a)
+}
+
+func jsonArray(a []any) []string {
+	out := make([]string, 0, len(a))
+	for _, v := range a {
+		b, err := json.Marshal(v)
+		if err != nil {
+			b = []byte(fmt.Sprint(v))
+		}
+		out = append(out, string(b))
+	}
+	return out
+}

--- a/internal/ado/graph_target.go
+++ b/internal/ado/graph_target.go
@@ -1,0 +1,58 @@
+package ado
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TargetKind string
+
+const (
+	TargetNode TargetKind = "node"
+	TargetEdge TargetKind = "edge"
+)
+
+// An edge target names only its type: an ADO attack edge starts at whichever
+// principal the record resolved to, so no single From/To pair describes it.
+type Target struct {
+	Kind  TargetKind
+	Label NodeLabel
+	Type  EdgeType
+}
+
+const targetForms = "node(<Label>) or edge(<TYPE>)"
+
+func ParseTarget(s string) (Target, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return Target{}, fmt.Errorf("missing graph target: want %s", targetForms)
+	}
+	open := strings.IndexByte(s, '(')
+	if open < 0 || !strings.HasSuffix(s, ")") {
+		return Target{}, fmt.Errorf("malformed graph target %q: want %s", s, targetForms)
+	}
+	arg := strings.TrimSpace(s[open+1 : len(s)-1])
+	switch TargetKind(strings.TrimSpace(s[:open])) {
+	case TargetNode:
+		if l := NodeLabel(arg); ValidNodeLabel(l) {
+			return Target{Kind: TargetNode, Label: l}, nil
+		}
+		return Target{}, fmt.Errorf("unknown node label %q in %q", arg, s)
+	case TargetEdge:
+		if t := EdgeType(arg); ValidEdgeType(t) {
+			return Target{Kind: TargetEdge, Type: t}, nil
+		}
+		return Target{}, fmt.Errorf("unknown edge type %q in %q", arg, s)
+	}
+	return Target{}, fmt.Errorf("unknown graph target form in %q: want %s", s, targetForms)
+}
+
+func renderTarget(t Target) string {
+	switch t.Kind {
+	case TargetNode:
+		return fmt.Sprintf("node(%s)", t.Label)
+	case TargetEdge:
+		return fmt.Sprintf("edge(%s)", t.Type)
+	}
+	return ""
+}

--- a/internal/ado/normalize.go
+++ b/internal/ado/normalize.go
@@ -76,6 +76,13 @@ func emit(cp engine.CurrentPhase, timer *engine.PhaseTimer, rel string, rec any)
 	return nil
 }
 
+// The key already discriminates one edge of a kind from every other, so it is an
+// identity and not just a filename.
+func emitEdge(cp engine.CurrentPhase, timer *engine.PhaseTimer, kind, key string, rec map[string]any) error {
+	rec["_id"] = key
+	return emit(cp, timer, engine.NormalizeADOEdges(kind, key), rec)
+}
+
 // collect writes the whole org roster but fans out only to the scoped project, so a
 // scoped run must re-apply that filter or it emits project subjects whose detail was
 // never collected.

--- a/internal/ado/normalize_entities.go
+++ b/internal/ado/normalize_entities.go
@@ -368,7 +368,7 @@ func emitWIFCredential(cp engine.CurrentPhase, timer *engine.PhaseTimer, e map[s
 		"wif_credential_id": id + "/" + key, "app_registration_id": spn,
 		"subject": strOrNull(subject),
 		"issuer":  strOrNull(entStr(params["workloadIdentityFederationIssuer"]))}
-	return emit(cp, timer, engine.NormalizeADOEdges("federates-to", adoSafe(id)), fed)
+	return emitEdge(cp, timer, "federates-to", adoSafe(id), fed)
 }
 
 func normalizeVariableGroupsShared(prior engine.PriorPhase, cp engine.CurrentPhase, org string, projs []projectMeta, timer *engine.PhaseTimer) error {
@@ -446,7 +446,7 @@ func emitKeyVaultLink(cp engine.CurrentPhase, timer *engine.PhaseTimer, rec map[
 		"keyvault_name": vault, "keyvault_id": owner + "/" + vault,
 		"service_connection_id": mStr(rec, "keyvault_service_connection_id"),
 	}
-	return emit(cp, timer, engine.NormalizeADOEdges("links-to", fmt.Sprintf("%s__%d", adoSafe(owner), gid)), link)
+	return emitEdge(cp, timer, "links-to", fmt.Sprintf("%s__%d", adoSafe(owner), gid), link)
 }
 
 func variableGroupRec(g map[string]any) map[string]any {
@@ -489,7 +489,7 @@ func emitSecretVariables(cp engine.CurrentPhase, timer *engine.PhaseTimer, g map
 			return err
 		}
 		def := map[string]any{"kind": "DEFINES", "group_id": gid, "secret_name": name, "project": owner}
-		if err := emit(cp, timer, engine.NormalizeADOEdges("defines", fmt.Sprintf("%d__%s", gid, adoSafe(name))), def); err != nil {
+		if err := emitEdge(cp, timer, "defines", fmt.Sprintf("%d__%s", gid, adoSafe(name)), def); err != nil {
 			return err
 		}
 	}
@@ -577,7 +577,7 @@ func normalizeAgentQueues(prior engine.PriorPhase, cp engine.CurrentPhase, org s
 		}
 		if orgPool != 0 {
 			ref := map[string]any{"kind": "REFERENCES_POOL", "project": p.Name, "queue_id": qid, "org_pool_id": orgPool}
-			if err := emit(cp, timer, engine.NormalizeADOEdges("references-pool", fmt.Sprintf("%s__%d", adoSafe(p.Name), qid)), ref); err != nil {
+			if err := emitEdge(cp, timer, "references-pool", fmt.Sprintf("%s__%d", adoSafe(p.Name), qid), ref); err != nil {
 				return err
 			}
 		}

--- a/internal/ado/normalize_extra.go
+++ b/internal/ado/normalize_extra.go
@@ -54,7 +54,7 @@ func normalizeExtensions(prior engine.PriorPhase, cp engine.CurrentPhase, org st
 				"_id": id + "/decorator", "kind": "PipelineDecorator", "org": org,
 				"extension_id": id, "publisher_id": pub, "scopes": entListOrEmpty(e["scopes"]),
 			}
-			if err := emit(cp, timer, engine.NormalizeADOEdges("installs", adoSafe(id)), map[string]any{
+			if err := emitEdge(cp, timer, "installs", adoSafe(id), map[string]any{
 				"kind": "INSTALLS", "org": org, "extension_id": id, "decorator_id": id + "/decorator",
 			}); err != nil {
 				return err

--- a/internal/ado/normalize_pipeline.go
+++ b/internal/ado/normalize_pipeline.go
@@ -91,14 +91,19 @@ func normalizePipelines(ctx context.Context, prior engine.PriorPhase, cp engine.
 		}
 
 		settable := settableVarSet(entObj(def, "variables"))
-		facts := pipelineYAMLFacts{}
+		facts, jobs := pipelineYAMLFacts{}, 0
 		if processType == 2 && strings.EqualFold(entStr(repo["type"]), "TfsGit") {
 			content := entryYAML(prior, project, id, repo, entStr(process["yamlFilename"]))
 			if content != "" {
-				facts, err = parsePipelineYAML(cp, timer, project, id, content, settable)
+				facts, jobs, err = parsePipelineYAML(cp, timer, project, id, content, settable)
 				if err != nil {
 					return err
 				}
+			}
+		}
+		if jobs == 0 {
+			if err := expandFromPreview(prior, cp, timer, project, id, settable); err != nil {
+				return err
 			}
 		}
 		pipe["extends_template"] = strOrNull(facts.extendsTemplate)
@@ -258,11 +263,11 @@ func splitRepoName(name, dfltProject string) (project, repo string) {
 // Variable groups are deliberately not merged down levels: each of Pipeline, Stage
 // and Job carries only what it declares, which is what makes the CONSUMES_GROUP level
 // recoverable later.
-func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, content string, settable map[string]bool) (pipelineYAMLFacts, error) {
+func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, content string, settable map[string]bool) (pipelineYAMLFacts, int, error) {
 	var root map[string]any
 	if err := yaml.Unmarshal([]byte(content), &root); err != nil {
 		timer.Errors = append(timer.Errors, fmt.Sprintf("pipeline %s/%d: yaml parse: %v", project, pipelineID, err))
-		return pipelineYAMLFacts{}, nil // a bad YAML doc is per-item non-fatal
+		return pipelineYAMLFacts{}, 0, nil // a bad YAML doc is per-item non-fatal
 	}
 	facts := pipelineYAMLFacts{
 		variableGroups:    variableGroups(root["variables"]),
@@ -272,9 +277,8 @@ func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project
 		settableVariables: settableVariablesOf(root["variables"]),
 	}
 	if err := emitPipelineResources(cp, timer, project, pipelineID, root); err != nil {
-		return facts, err
+		return facts, 0, err
 	}
-	pipelinePool := root["pool"]
 
 	tsList, tsByAlias := resolveTemplateSources(root, project)
 	facts.templateSources = tsList
@@ -290,31 +294,54 @@ func parsePipelineYAML(cp engine.CurrentPhase, timer *engine.PhaseTimer, project
 		}
 	}
 	if root["extends"] != nil {
-		return facts, nil // the jobs live in the template, expanded in a deferred pass
+		return facts, 0, nil // the jobs live in the template, recovered from the preview
 	}
+	n, err := emitStagesAndJobs(cp, timer, project, pipelineID, root, settable, engine.CollectADOBuildDefFull(project, pipelineID))
+	return facts, n, err
+}
 
+func expandFromPreview(prior engine.PriorPhase, cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, settable map[string]bool) error {
+	rel := engine.CollectADOPipelinePreview(project, pipelineID)
+	content := entStr(entLoadData(prior, rel)["finalYaml"])
+	if content == "" {
+		return nil
+	}
+	var root map[string]any
+	if err := yaml.Unmarshal([]byte(content), &root); err != nil {
+		timer.Errors = append(timer.Errors, fmt.Sprintf("pipeline %s/%d: preview yaml parse: %v", project, pipelineID, err))
+		return nil
+	}
+	_, err := emitStagesAndJobs(cp, timer, project, pipelineID, root, settable, rel)
+	return err
+}
+
+func emitStagesAndJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, root map[string]any, settable map[string]bool, provFile string) (int, error) {
+	pipelinePool := root["pool"]
 	if stages, ok := root["stages"].([]any); ok {
+		n := 0
 		for i, s := range stages {
 			sm, ok := s.(map[string]any)
 			if !ok {
 				continue
 			}
 			if sm["template"] != nil && sm["stage"] == nil {
-				continue // a stage-template reference is expanded in the deferred pass
+				continue
 			}
 			stageName := firstStr(sm, "stage", fmt.Sprintf("stage_%d", i))
-			if err := emitStageJobs(cp, timer, project, pipelineID, stageName, sm, pipelinePool, settable); err != nil {
-				return facts, err
+			c, err := emitStageJobs(cp, timer, project, pipelineID, stageName, sm, pipelinePool, settable, provFile)
+			if err != nil {
+				return n, err
 			}
+			n += c
 		}
-		return facts, nil
+		return n, nil
 	}
 	// With no stages the root plays pipeline, stage and job at once. Its variable groups
 	// are already stamped on the Pipeline node, so they are stripped before the same map
 	// stands in for the Stage/Job — otherwise one declaration is counted at every level
 	// and CONSUMES_GROUP is emitted three times.
 	delete(root, "variables")
-	return facts, emitStageJobs(cp, timer, project, pipelineID, "__default", root, pipelinePool, settable)
+	return emitStageJobs(cp, timer, project, pipelineID, "__default", root, pipelinePool, settable, provFile)
 }
 
 // A resources.pipelines entry is a pipeline-completion trigger, which is the
@@ -343,7 +370,7 @@ func emitPipelineResources(cp engine.CurrentPhase, timer *engine.PhaseTimer, pro
 	return nil
 }
 
-func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage string, m map[string]any, inheritedPool any, settable map[string]bool) error {
+func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage string, m map[string]any, inheritedPool any, settable map[string]bool, provFile string) (int, error) {
 	stagePool := m["pool"]
 	if stagePool == nil {
 		stagePool = inheritedPool
@@ -359,33 +386,38 @@ func emitStageJobs(cp engine.CurrentPhase, timer *engine.PhaseTimer, project str
 		"depends_on":      stringsOf(m["dependsOn"]),
 		"variable_groups": toAnyList(variableGroups(m["variables"])), // stage-level declarations only
 		"environment":     strOrNull(yamlStr(m["environment"])),      // stage-level env (deployment stages carry it on jobs)
-		"_provenance":     prov(engine.CollectADOBuildDefFull(project, pipelineID)),
+		"_provenance":     prov(provFile),
 	}
 	if err := emit(cp, timer, engine.NormalizeADOStage(project, pipelineID, stage), stageRec); err != nil {
-		return err
+		return 0, err
 	}
 
 	jobs, ok := m["jobs"].([]any)
 	if !ok {
-		return emitJob(cp, timer, project, pipelineID, stage, "__default", m, stagePool, settable)
+		if err := emitJob(cp, timer, project, pipelineID, stage, "__default", m, stagePool, settable, provFile); err != nil {
+			return 0, err
+		}
+		return 1, nil
 	}
+	n := 0
 	for i, j := range jobs {
 		jm, ok := j.(map[string]any)
 		if !ok {
 			continue
 		}
 		if jm["template"] != nil && jm["job"] == nil && jm["deployment"] == nil {
-			continue // job-template reference — expanded in the deferred template pass
+			continue
 		}
 		jobName := firstStr(jm, "job", firstStr(jm, "deployment", fmt.Sprintf("job_%d", i)))
-		if err := emitJob(cp, timer, project, pipelineID, stage, jobName, jm, stagePool, settable); err != nil {
-			return err
+		if err := emitJob(cp, timer, project, pipelineID, stage, jobName, jm, stagePool, settable, provFile); err != nil {
+			return n, err
 		}
+		n++
 	}
-	return nil
+	return n, nil
 }
 
-func emitJob(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage, job string, m map[string]any, inheritedPool any, settable map[string]bool) error {
+func emitJob(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, pipelineID int64, stage, job string, m map[string]any, inheritedPool any, settable map[string]bool, provFile string) error {
 	jobPool := m["pool"]
 	if jobPool == nil {
 		jobPool = inheritedPool
@@ -429,7 +461,7 @@ func emitJob(cp engine.CurrentPhase, timer *engine.PhaseTimer, project string, p
 		"exec_sinks":                  f.execSinks,
 		"executes_checked_out_code":   f.executesCheckedOutCode,
 		"exposes_system_access_token": f.referencesAccessToken,
-		"_provenance":                 prov(engine.CollectADOBuildDefFull(project, pipelineID)),
+		"_provenance":                 prov(provFile),
 	}
 	return emit(cp, timer, engine.NormalizeADOJob(project, pipelineID, stage, job), rec)
 }

--- a/internal/ado/normalize_pipeline.go
+++ b/internal/ado/normalize_pipeline.go
@@ -365,7 +365,7 @@ func emitPipelineResources(cp engine.CurrentPhase, timer *engine.PhaseTimer, pro
 			"trigger": rm["trigger"], "branches": rm["branches"], "tags": rm["tags"], "stages": rm["stages"],
 		}
 		key := fmt.Sprintf("%s__%d__%s", adoSafe(project), pipelineID, adoSafe(firstStr(rm, "pipeline", fmt.Sprintf("res_%d", i))))
-		if err := emit(cp, timer, engine.NormalizeADOEdges("triggers-on-completion", key), rec); err != nil {
+		if err := emitEdge(cp, timer, "triggers-on-completion", key, rec); err != nil {
 			return err
 		}
 	}

--- a/internal/ado/normalize_pipeline.go
+++ b/internal/ado/normalize_pipeline.go
@@ -21,6 +21,8 @@ var scInputNames = []string{
 	"kubernetesServiceConnection", "awsCredentials", "serviceConnection", "externalEndpoint", "externalEndpoints",
 }
 
+const checkoutTaskID = "6d15af64-176c-496d-b583-fd2ae21d4df4"
+
 func sortedKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -526,6 +528,13 @@ func walkSteps(steps []any, settable map[string]bool) jobFacts {
 		sm, ok := s.(map[string]any)
 		if !ok {
 			continue
+		}
+		if strings.HasPrefix(yamlStr(sm["task"]), checkoutTaskID) {
+			in := entMap(sm["inputs"])
+			sm = map[string]any{
+				"checkout": in["repository"], "clean": in["clean"], "fetchDepth": in["fetchDepth"],
+				"persistCredentials": in["persistCredentials"], "submodules": in["submodules"],
+			}
 		}
 		if ck, ok := sm["checkout"]; ok {
 			f.checkouts = append(f.checkouts, map[string]any{

--- a/internal/ado/rules_test.go
+++ b/internal/ado/rules_test.go
@@ -1,0 +1,47 @@
+package ado
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/praetorian-inc/trajan/internal/engine/detect"
+)
+
+// detect carries rule.Graph unparsed, so a typo'd target survives loading and then
+// silently attaches nothing when the graph phase indexes rule -> target.
+func TestEveryEmbeddedRuleHasAParsableGraphTarget(t *testing.T) {
+	rules, err := detect.LoadRules("ado", nil)
+	if err != nil {
+		t.Fatalf("LoadRules: %v", err)
+	}
+	if len(rules) == 0 {
+		t.Fatal("no rules loaded")
+	}
+	var bad []string
+	for _, r := range rules {
+		if _, err := ParseTarget(r.Graph); err != nil {
+			bad = append(bad, r.ID+": "+err.Error())
+		}
+	}
+	if len(bad) > 0 {
+		t.Errorf("rule(s) with an unusable graph target:\n%s", strings.Join(bad, "\n"))
+	}
+}
+
+// The attacher resolves through SubjectDirs, so a subject kind absent from it cannot
+// attach however well-formed its target is.
+func TestEveryRuleSubjectNamesANormalizeDirectory(t *testing.T) {
+	rules, err := detect.LoadRules("ado", nil)
+	if err != nil {
+		t.Fatalf("LoadRules: %v", err)
+	}
+	var bad []string
+	for _, r := range rules {
+		if _, ok := adoScanProvider.SubjectDirs[r.Subject]; !ok {
+			bad = append(bad, r.ID+": subject "+r.Subject)
+		}
+	}
+	if len(bad) > 0 {
+		t.Errorf("rule subject(s) with no record directory:\n%s", strings.Join(bad, "\n"))
+	}
+}

--- a/internal/ado/scan.go
+++ b/internal/ado/scan.go
@@ -2,7 +2,6 @@ package ado
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/praetorian-inc/trajan/internal/engine/detect"
 )
@@ -39,20 +38,9 @@ var adoScanProvider = detect.Provider{
 		"can_merge_via_pr":          "edges/can-merge-via-pr",
 		"can_bypass":                "edges/can-bypass",
 	},
-	Display:    adoDisplay,
-	Repo:       func(s map[string]any) string { return detect.StringField(s, "project") },
-	File:       func(s map[string]any) string { return detect.StringField(s, "yaml_path") },
-	SubjectKey: adoSubjectKey,
-}
-
-// Derived-edge records carry no _id, so they key on their full serialized form —
-// otherwise distinct edges collide to a single finding.
-func adoSubjectKey(s map[string]any) string {
-	if id := detect.StringField(s, "_id"); id != "" {
-		return id
-	}
-	b, _ := json.Marshal(s) // sorted keys → deterministic across runs
-	return string(b)
+	Display: adoDisplay,
+	Repo:    func(s map[string]any) string { return detect.StringField(s, "project") },
+	File:    func(s map[string]any) string { return detect.StringField(s, "yaml_path") },
 }
 
 type ScanOptions = detect.ScanOptions
@@ -61,7 +49,7 @@ func Scan(ctx context.Context, runDir string, opts ScanOptions) error {
 	return detect.Scan(ctx, runDir, adoScanProvider, opts)
 }
 
-// Edge subjects have no _id, so they fall back to project + target job.
+// An edge subject's _id discriminates rather than names, so it renders from its target.
 func adoDisplay(kind string, s map[string]any) string {
 	proj := detect.StringField(s, "project")
 	switch kind {
@@ -74,14 +62,14 @@ func adoDisplay(kind string, s map[string]any) string {
 			return proj + " › " + id
 		}
 	}
-	if id := detect.StringField(s, "_id"); id != "" {
-		return id
-	}
 	if t := detect.StringField(s, "target"); t != "" {
 		return proj + " › " + t
 	}
 	if j := detect.StringField(s, "job"); j != "" {
 		return proj + " › " + j
+	}
+	if id := detect.StringField(s, "_id"); id != "" {
+		return id
 	}
 	return proj
 }

--- a/internal/ado/schema.go
+++ b/internal/ado/schema.go
@@ -1,0 +1,169 @@
+package ado
+
+import (
+	"maps"
+	"slices"
+)
+
+type NodeLabel string
+
+const (
+	Organization            NodeLabel = "Organization"
+	Project                 NodeLabel = "Project"
+	Repository              NodeLabel = "Repository"
+	Branch                  NodeLabel = "Branch"
+	BranchPolicy            NodeLabel = "BranchPolicy"
+	Pipeline                NodeLabel = "Pipeline"
+	Stage                   NodeLabel = "Stage"
+	Job                     NodeLabel = "Job"
+	Environment             NodeLabel = "Environment"
+	ServiceConnection       NodeLabel = "ServiceConnection"
+	WIFCredential           NodeLabel = "WIFCredential"
+	VariableGroup           NodeLabel = "VariableGroup"
+	SecretVariable          NodeLabel = "SecretVariable"
+	SecureFile              NodeLabel = "SecureFile"
+	KeyVault                NodeLabel = "KeyVault"
+	ArtifactsFeed           NodeLabel = "ArtifactsFeed"
+	OrgAgentPool            NodeLabel = "OrgAgentPool"
+	ProjectAgentPool        NodeLabel = "ProjectAgentPool"
+	Extension               NodeLabel = "Extension"
+	PipelineDecorator       NodeLabel = "PipelineDecorator"
+	ServiceHookSubscription NodeLabel = "ServiceHookSubscription"
+	User                    NodeLabel = "User"
+	SecurityGroup           NodeLabel = "SecurityGroup"
+	BuildServiceIdentity    NodeLabel = "BuildServiceIdentity"
+)
+
+type EdgeType string
+
+const (
+	HasProject    EdgeType = "HAS_PROJECT"
+	HasRepository EdgeType = "HAS_REPOSITORY"
+	HasBranch     EdgeType = "HAS_BRANCH"
+	HasPipeline   EdgeType = "HAS_PIPELINE"
+	HasStage      EdgeType = "HAS_STAGE"
+	HasJob        EdgeType = "HAS_JOB"
+
+	DefinedBy      EdgeType = "DEFINED_BY"
+	Defines        EdgeType = "DEFINES"
+	HasPolicy      EdgeType = "HAS_POLICY"
+	HasRole        EdgeType = "HAS_ROLE"
+	MemberOf       EdgeType = "MEMBER_OF"
+	ReferencesPool EdgeType = "REFERENCES_POOL"
+	Installs       EdgeType = "INSTALLS"
+	LinksTo        EdgeType = "LINKS_TO"
+	FederatesTo    EdgeType = "FEDERATES_TO"
+
+	Reads                EdgeType = "READS"
+	ConsumesGroup        EdgeType = "CONSUMES_GROUP"
+	UsesConnection       EdgeType = "USES_CONNECTION"
+	RunsOn               EdgeType = "RUNS_ON"
+	RunsAs               EdgeType = "RUNS_AS"
+	Targets              EdgeType = "TARGETS"
+	BuildValidates       EdgeType = "BUILD_VALIDATES"
+	TriggersOnCompletion EdgeType = "TRIGGERS_ON_COMPLETION"
+
+	CanPushTo     EdgeType = "CAN_PUSH_TO"
+	CanMergeViaPR EdgeType = "CAN_MERGE_VIA_PR"
+	CanBypass     EdgeType = "CAN_BYPASS"
+
+	PipelinePoisoning       EdgeType = "PIPELINE_POISONING"
+	QueueTimeInjection      EdgeType = "QUEUE_TIME_INJECTION"
+	LoggingCommandInjection EdgeType = "LOGGING_COMMAND_INJECTION"
+	AgentInjection          EdgeType = "AGENT_INJECTION"
+)
+
+var identityKeys = map[NodeLabel][]string{
+	Organization:            {"org"},
+	Project:                 {"org", "project"},
+	Repository:              {"org", "project", "repo"},
+	Branch:                  {"org", "project", "repo", "name"},
+	BranchPolicy:            {"org", "project", "config_id"},
+	Pipeline:                {"org", "project", "pipeline_id"},
+	Stage:                   {"org", "project", "pipeline_id", "stage"},
+	Job:                     {"org", "project", "pipeline_id", "stage", "job"},
+	Environment:             {"org", "project", "name"},
+	ServiceConnection:       {"org", "owner_project", "connection_id"},
+	WIFCredential:           {"org", "owner_project", "connection_id", "subject"},
+	VariableGroup:           {"org", "owner_project", "group_id"},
+	SecretVariable:          {"org", "owner_project", "group_id", "name"},
+	SecureFile:              {"org", "project", "file_id"},
+	KeyVault:                {"name"},
+	ArtifactsFeed:           {"org", "scope", "feed_id"},
+	OrgAgentPool:            {"org", "pool_id"},
+	ProjectAgentPool:        {"org", "project", "queue_id"},
+	Extension:               {"org", "extension_id"},
+	PipelineDecorator:       {"org", "extension_id"},
+	ServiceHookSubscription: {"org", "subscription_id"},
+	User:                    {"descriptor"},
+	SecurityGroup:           {"descriptor"},
+	BuildServiceIdentity:    {"descriptor"},
+}
+
+var edgeEndpoints = map[EdgeType][][2]NodeLabel{
+	HasProject:    {{Organization, Project}},
+	HasRepository: {{Project, Repository}},
+	HasBranch:     {{Repository, Branch}},
+	HasPipeline:   {{Project, Pipeline}},
+	HasStage:      {{Pipeline, Stage}},
+	HasJob:        {{Stage, Job}},
+
+	DefinedBy: {{Pipeline, Branch}},
+	Defines:   {{VariableGroup, SecretVariable}},
+	HasPolicy: {{BranchPolicy, Branch}},
+	HasRole: {
+		{User, Project},
+		{User, Repository},
+		{User, Pipeline},
+		{User, ServiceConnection},
+		{SecurityGroup, Project},
+		{SecurityGroup, Repository},
+		{SecurityGroup, Pipeline},
+		{SecurityGroup, ServiceConnection},
+		{BuildServiceIdentity, Project},
+		{BuildServiceIdentity, Repository},
+		{BuildServiceIdentity, Pipeline},
+		{BuildServiceIdentity, ServiceConnection},
+	},
+	MemberOf: {
+		{User, SecurityGroup},
+		{SecurityGroup, SecurityGroup},
+		{BuildServiceIdentity, SecurityGroup},
+	},
+	ReferencesPool: {{ProjectAgentPool, OrgAgentPool}},
+	Installs:       {{Extension, PipelineDecorator}},
+	LinksTo:        {{VariableGroup, KeyVault}},
+	FederatesTo:    {{ServiceConnection, WIFCredential}},
+
+	Reads:                {{Job, SecretVariable}},
+	ConsumesGroup:        {{Pipeline, VariableGroup}, {Stage, VariableGroup}, {Job, VariableGroup}},
+	UsesConnection:       {{Job, ServiceConnection}},
+	RunsOn:               {{Job, ProjectAgentPool}},
+	RunsAs:               {{Pipeline, BuildServiceIdentity}},
+	Targets:              {{Job, Environment}},
+	BuildValidates:       {{BranchPolicy, Pipeline}},
+	TriggersOnCompletion: {{Pipeline, Pipeline}},
+
+	CanPushTo:     {{User, Branch}, {SecurityGroup, Branch}, {BuildServiceIdentity, Branch}},
+	CanMergeViaPR: {{User, Branch}, {SecurityGroup, Branch}, {BuildServiceIdentity, Branch}},
+	CanBypass:     {{User, BranchPolicy}, {SecurityGroup, BranchPolicy}, {BuildServiceIdentity, BranchPolicy}},
+
+	PipelinePoisoning:       {{User, Job}, {SecurityGroup, Job}, {BuildServiceIdentity, Job}},
+	QueueTimeInjection:      {{User, Job}, {SecurityGroup, Job}, {BuildServiceIdentity, Job}},
+	LoggingCommandInjection: {{User, Job}, {SecurityGroup, Job}, {BuildServiceIdentity, Job}},
+	AgentInjection:          {{User, Job}, {SecurityGroup, Job}, {BuildServiceIdentity, Job}},
+}
+
+func ValidNodeLabel(l NodeLabel) bool { _, ok := identityKeys[l]; return ok }
+
+func ValidEdgeType(t EdgeType) bool { _, ok := edgeEndpoints[t]; return ok }
+
+func ValidEdge(t EdgeType, from, to NodeLabel) bool {
+	return slices.Contains(edgeEndpoints[t], [2]NodeLabel{from, to})
+}
+
+func NodeLabels() []NodeLabel { return slices.Sorted(maps.Keys(identityKeys)) }
+
+func EdgeTypes() []EdgeType { return slices.Sorted(maps.Keys(edgeEndpoints)) }
+
+func IdentityKey(l NodeLabel) []string { return identityKeys[l] }

--- a/internal/ado/schema.go
+++ b/internal/ado/schema.go
@@ -154,6 +154,15 @@ var edgeEndpoints = map[EdgeType][][2]NodeLabel{
 	AgentInjection:          {{User, Job}, {SecurityGroup, Job}, {BuildServiceIdentity, Job}},
 }
 
+var severityBuckets = map[string]string{
+	"critical": "findings_critical",
+	"high":     "findings_high",
+	"medium":   "findings_medium",
+	"low":      "findings_low",
+}
+
+var findingBuckets = []string{"findings_critical", "findings_high", "findings_medium", "findings_low"}
+
 func ValidNodeLabel(l NodeLabel) bool { _, ok := identityKeys[l]; return ok }
 
 func ValidEdgeType(t EdgeType) bool { _, ok := edgeEndpoints[t]; return ok }

--- a/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/build-validation-secret-exposure.yaml
@@ -2,6 +2,7 @@ id: cat-01/build-validation-secret-exposure
 scenario_id: cat-01/01
 title: "Untrusted-triggered pipeline job runs attacker code with the system access token"
 subject: pipeline_poisoning
+graph: edge(PIPELINE_POISONING)
 severity: critical
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/open-access-secret-reachable.yaml
@@ -2,6 +2,7 @@ id: cat-01/open-access-secret-reachable
 scenario_id: cat-01/05
 title: "Ungated pipeline job is poisonable by an untrusted trigger"
 subject: pipeline_poisoning
+graph: edge(PIPELINE_POISONING)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-01-build-validation/self-hosted-pool-pr-build-pivot.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/self-hosted-pool-pr-build-pivot.yaml
@@ -2,6 +2,7 @@ id: cat-01/self-hosted-pool-pr-build-pivot
 scenario_id: cat-01/06
 title: "Privileged job runs on a self-hosted agent pool that persists state between builds"
 subject: job
+graph: edge(RUNS_ON)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
+++ b/internal/detection-rules/ado/cat-01-build-validation/trigger-override-false-safe.yaml
@@ -2,6 +2,7 @@ id: cat-01/trigger-override-false-safe
 scenario_id: cat-01/07
 title: "Non-blocking Build validation policy — false-safe PR gate"
 subject: branch_policy
+graph: node(BranchPolicy)
 severity: medium
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/allow-override-drift.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/allow-override-drift.yaml
@@ -2,6 +2,7 @@ id: cat-02/allow-override-drift
 scenario_id: cat-02/04
 title: "Pipeline variable marked settable-at-queue-time while the queue-time limit is enforced"
 subject: pipeline
+graph: node(Pipeline)
 severity: medium
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/freeform-parameter-injection.yaml
@@ -2,6 +2,7 @@ id: cat-02/freeform-parameter-injection
 scenario_id: cat-02/03
 title: "Free-form string runtime parameter template-expanded into a script sink"
 subject: queue_time_injection
+graph: edge(QUEUE_TIME_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/predefined-variable-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/predefined-variable-injection.yaml
@@ -2,6 +2,7 @@ id: cat-02/predefined-variable-injection
 scenario_id: cat-02/01
 title: "Attacker-controlled predefined variable macro-expanded into a script body"
 subject: queue_time_injection
+graph: edge(QUEUE_TIME_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-input-selects-target.yaml
@@ -2,6 +2,7 @@ id: cat-02/queue-input-selects-target
 scenario_id: cat-02/05
 title: "Queue-time input selects the agent pool, service connection, or task"
 subject: queue_time_injection
+graph: edge(QUEUE_TIME_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/queue-time-macro-injection.yaml
@@ -2,6 +2,7 @@ id: cat-02/queue-time-macro-injection
 scenario_id: cat-02/01
 title: "Unrestricted queue-time variable macro-expanded into a script body"
 subject: queue_time_injection
+graph: edge(QUEUE_TIME_INJECTION)
 severity: critical
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
+++ b/internal/detection-rules/ado/cat-02-queue-time-injection/settable-var-into-arguments.yaml
@@ -2,6 +2,7 @@ id: cat-02/settable-var-into-arguments
 scenario_id: cat-02/02
 title: "Queue-time variable flows into a shell task arguments input"
 subject: queue_time_injection
+graph: edge(QUEUE_TIME_INJECTION)
 severity: high
 confidence: low
 description: >

--- a/internal/detection-rules/ado/cat-03-secret-isolation/keyvault-linked-group-broad-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/keyvault-linked-group-broad-access.yaml
@@ -2,6 +2,7 @@ id: cat-03/keyvault-linked-group-broad-access
 scenario_id: cat-03/03
 title: "Key Vault-linked variable group is open to every pipeline"
 subject: variable_group
+graph: node(VariableGroup)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-03-secret-isolation/multistage-ungated-stage-reads-secret.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/multistage-ungated-stage-reads-secret.yaml
@@ -2,6 +2,7 @@ id: cat-03/multistage-ungated-stage-reads-secret
 scenario_id: cat-03/06
 title: "Multistage pipeline: named stage reads a pipeline-scoped secret with no gate"
 subject: reads
+graph: edge(READS)
 severity: medium
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-03-secret-isolation/no-branch-control-feature-branch-secret.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/no-branch-control-feature-branch-secret.yaml
@@ -2,6 +2,7 @@ id: cat-03/secret-reachable-no-gate
 scenario_id: cat-03/02
 title: "Pipeline reads a variable-group secret with no branch/approval gate"
 subject: reads
+graph: edge(READS)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-03-secret-isolation/secure-file-open-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/secure-file-open-access.yaml
@@ -2,6 +2,7 @@ id: cat-03/secure-file-open-access
 scenario_id: cat-03/05
 title: "Secure File Open access lets any pipeline download the signing key"
 subject: secure_file
+graph: node(SecureFile)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-03-secret-isolation/variable-group-open-access.yaml
+++ b/internal/detection-rules/ado/cat-03-secret-isolation/variable-group-open-access.yaml
@@ -2,6 +2,7 @@ id: cat-03/variable-group-open-access
 scenario_id: cat-03/01
 title: "Variable group Open access exposes secrets to every pipeline"
 subject: variable_group
+graph: node(VariableGroup)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-04-service-connections/collection-scope-token-cross-repo.yaml
+++ b/internal/detection-rules/ado/cat-04-service-connections/collection-scope-token-cross-repo.yaml
@@ -2,6 +2,7 @@ id: cat-04/collection-scope-token-cross-repo
 scenario_id: cat-04/04
 title: "Collection-scoped job authorization token reaches every repo in the org"
 subject: org
+graph: node(Organization)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-04-service-connections/collection-scoped-pipeline-identity.yaml
+++ b/internal/detection-rules/ado/cat-04-service-connections/collection-scoped-pipeline-identity.yaml
@@ -2,6 +2,7 @@ id: cat-04/collection-scoped-pipeline-identity
 scenario_id: cat-04/05
 title: "Pipeline runs with a collection-scoped identity"
 subject: pipeline
+graph: node(Pipeline)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-04-service-connections/cross-project-shared-connection.yaml
+++ b/internal/detection-rules/ado/cat-04-service-connections/cross-project-shared-connection.yaml
@@ -2,6 +2,7 @@ id: cat-04/cross-project-shared-connection
 scenario_id: cat-04/06
 title: "Service connection shared into another project without a check"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-04-service-connections/no-checks-on-service-connection.yaml
+++ b/internal/detection-rules/ado/cat-04-service-connections/no-checks-on-service-connection.yaml
@@ -2,6 +2,7 @@ id: cat-04/no-checks-on-service-connection
 scenario_id: cat-04/02
 title: "Per-pipeline service connection with no Branch control / approval check"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-04-service-connections/open-access-arm-connection.yaml
+++ b/internal/detection-rules/ado/cat-04-service-connections/open-access-arm-connection.yaml
@@ -2,6 +2,7 @@ id: cat-04/open-access-arm-connection
 scenario_id: cat-04/01
 title: "Open-access Azure connection with no Approvals & checks"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-04-service-connections/system-accesstoken-repo-tamper.yaml
+++ b/internal/detection-rules/ado/cat-04-service-connections/system-accesstoken-repo-tamper.yaml
@@ -2,6 +2,7 @@ id: cat-04/system-accesstoken-repo-tamper
 scenario_id: cat-04/03
 title: "Pipeline exposes System.AccessToken with no protecting check"
 subject: pipeline_poisoning
+graph: edge(PIPELINE_POISONING)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-05-wif-oidc/wif-all-pipelines-grant.yaml
+++ b/internal/detection-rules/ado/cat-05-wif-oidc/wif-all-pipelines-grant.yaml
@@ -2,6 +2,7 @@ id: cat-05/wif-all-pipelines-grant
 scenario_id: cat-05/01
 title: "WIF service connection authorized to all pipelines"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-05-wif-oidc/wif-identity-reused-across-tiers.yaml
+++ b/internal/detection-rules/ado/cat-05-wif-oidc/wif-identity-reused-across-tiers.yaml
@@ -2,6 +2,7 @@ id: cat-05/wif-identity-reused-across-tiers
 scenario_id: cat-05/03
 title: "WIF service connection shared across projects — one identity, mixed trust tiers"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-05-wif-oidc/wif-management-group-scope.yaml
+++ b/internal/detection-rules/ado/cat-05-wif-oidc/wif-management-group-scope.yaml
@@ -2,6 +2,7 @@ id: cat-05/wif-management-group-scope
 scenario_id: cat-05/04
 title: "WIF service connection scoped to a management group — token spans all child subscriptions"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-05-wif-oidc/wif-no-branch-gate.yaml
+++ b/internal/detection-rules/ado/cat-05-wif-oidc/wif-no-branch-gate.yaml
@@ -2,6 +2,7 @@ id: cat-05/wif-no-branch-gate
 scenario_id: cat-05/02
 title: "WIF service connection has no Approval or Branch-control check"
 subject: service_connection
+graph: node(ServiceConnection)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-06-branch-policy-bypass/build-validation-optional-non-blocking.yaml
+++ b/internal/detection-rules/ado/cat-06-branch-policy-bypass/build-validation-optional-non-blocking.yaml
@@ -2,6 +2,7 @@ id: cat-06/build-validation-optional-non-blocking
 scenario_id: cat-06/04
 title: "Build-validation policy is non-blocking or manual — PR completes without a passing build"
 subject: branch_policy
+graph: node(BranchPolicy)
 severity: medium
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-06-branch-policy-bypass/bypass-policies-when-pushing-silent.yaml
+++ b/internal/detection-rules/ado/cat-06-branch-policy-bypass/bypass-policies-when-pushing-silent.yaml
@@ -2,6 +2,7 @@ id: cat-06/bypass-policies-when-pushing-silent
 scenario_id: cat-06/01
 title: "Principal can land code on a policy-protected branch via a bypass weakness"
 subject: can_push_to
+graph: edge(CAN_PUSH_TO)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-06-branch-policy-bypass/edit-policies-self-grant-then-weaken.yaml
+++ b/internal/detection-rules/ado/cat-06-branch-policy-bypass/edit-policies-self-grant-then-weaken.yaml
@@ -2,6 +2,7 @@ id: cat-06/edit-policies-self-grant-then-weaken
 scenario_id: cat-06/07
 title: "Principal with Edit-policies can weaken branch protection then land code"
 subject: can_push_to
+graph: edge(CAN_PUSH_TO)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-06-branch-policy-bypass/self-approve-creator-vote-counts.yaml
+++ b/internal/detection-rules/ado/cat-06-branch-policy-bypass/self-approve-creator-vote-counts.yaml
@@ -2,6 +2,7 @@ id: cat-06/self-approve-creator-vote-counts
 scenario_id: cat-06/03
 title: "Reviewer policy allows self-approval — one person can author and merge"
 subject: branch_policy
+graph: node(BranchPolicy)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-06-branch-policy-bypass/stale-approval-votes-not-reset-on-push.yaml
+++ b/internal/detection-rules/ado/cat-06-branch-policy-bypass/stale-approval-votes-not-reset-on-push.yaml
@@ -2,6 +2,7 @@ id: cat-06/stale-approval-votes-not-reset-on-push
 scenario_id: cat-06/05
 title: "Reviewer policy does not reset votes on a new push — approve-then-swap (TOCTOU)"
 subject: branch_policy
+graph: node(BranchPolicy)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/classic-pipeline-creation-allowed.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/classic-pipeline-creation-allowed.yaml
@@ -2,6 +2,7 @@ id: cat-07/classic-pipeline-creation-allowed
 scenario_id: cat-07/06
 title: "Classic pipeline creation allowed org-wide bypasses YAML-only guardrails"
 subject: org
+graph: node(Organization)
 severity: medium
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/fork-builds-unprotected.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/fork-builds-unprotected.yaml
@@ -1,6 +1,7 @@
 id: cat-07/fork-builds-unprotected
 title: "Fork pull-request builds enabled without fork protection org-wide"
 subject: org
+graph: node(Organization)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/implied-yaml-ci-trigger-enabled.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/implied-yaml-ci-trigger-enabled.yaml
@@ -1,6 +1,7 @@
 id: cat-07/implied-yaml-ci-trigger-enabled
 title: "Implied YAML CI trigger not disabled at project level"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/pipeline-decorator-org-backdoor.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/pipeline-decorator-org-backdoor.yaml
@@ -2,6 +2,7 @@ id: cat-07/pipeline-decorator-org-backdoor
 scenario_id: cat-07/03
 title: "Non-builtin pipeline decorator extension injects steps into every job org-wide"
 subject: extension
+graph: node(Extension)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/protect-access-repos-off.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/protect-access-repos-off.yaml
@@ -2,6 +2,7 @@ id: cat-07/protect-access-repos-off
 scenario_id: cat-07/01
 title: "Protect access to repositories in YAML pipelines OFF at project level"
 subject: project
+graph: node(Project)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/queue-time-vars-limit-off.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/queue-time-vars-limit-off.yaml
@@ -2,6 +2,7 @@ id: cat-07/queue-time-vars-limit-off
 scenario_id: cat-07/02
 title: "Limit variables settable at queue time OFF org-wide exposes every pipeline"
 subject: org
+graph: node(Organization)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/shell-args-sanitizing-off.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/shell-args-sanitizing-off.yaml
@@ -1,6 +1,7 @@
 id: cat-07/shell-args-sanitizing-off
 title: "Shell task argument sanitizing disabled at project level"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-07-org-project-settings/unrestricted-job-auth-scope.yaml
+++ b/internal/detection-rules/ado/cat-07-org-project-settings/unrestricted-job-auth-scope.yaml
@@ -1,6 +1,7 @@
 id: cat-07/unrestricted-job-auth-scope
 title: "Job authorization scope not limited to current project org-wide"
 subject: org
+graph: node(Organization)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-08-templates/cross-project-template-collection-token.yaml
+++ b/internal/detection-rules/ado/cat-08-templates/cross-project-template-collection-token.yaml
@@ -2,6 +2,7 @@ id: cat-08/cross-project-template-collection-token
 scenario_id: cat-08/06
 title: "Cross-project template extension runs with a collection-scoped token"
 subject: pipeline
+graph: node(Pipeline)
 severity: critical
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-08-templates/cross-project-template-source.yaml
+++ b/internal/detection-rules/ado/cat-08-templates/cross-project-template-source.yaml
@@ -2,6 +2,7 @@ id: cat-08/cross-project-template-source
 scenario_id: cat-08/06
 title: "Pipeline extends a template from another project's repository"
 subject: pipeline
+graph: node(Pipeline)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-08-templates/template-source-unpinned-ref.yaml
+++ b/internal/detection-rules/ado/cat-08-templates/template-source-unpinned-ref.yaml
@@ -2,6 +2,7 @@ id: cat-08/template-source-unpinned-ref
 scenario_id: cat-08/01
 title: "Pipeline extends a template from an unpinned (mutable) ref"
 subject: pipeline
+graph: node(Pipeline)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-09-environment-checks-bypass/branch-control-allows-all-refs.yaml
+++ b/internal/detection-rules/ado/cat-09-environment-checks-bypass/branch-control-allows-all-refs.yaml
@@ -2,6 +2,7 @@ id: cat-09/branch-control-allows-all-refs
 scenario_id: cat-09/04
 title: "Branch control check allows all refs or treats unknown protection as pass"
 subject: environment
+graph: node(Environment)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-09-environment-checks-bypass/environment-open-access.yaml
+++ b/internal/detection-rules/ado/cat-09-environment-checks-bypass/environment-open-access.yaml
@@ -2,6 +2,7 @@ id: cat-09/environment-open-access
 scenario_id: cat-09/02
 title: "Environment grants open access to all pipelines with no approval gate"
 subject: environment
+graph: node(Environment)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-09-environment-checks-bypass/prod-environment-no-checks.yaml
+++ b/internal/detection-rules/ado/cat-09-environment-checks-bypass/prod-environment-no-checks.yaml
@@ -2,6 +2,7 @@ id: cat-09/prod-environment-no-checks
 scenario_id: cat-09/01
 title: "Production environment has no approval gate — deploys run ungated"
 subject: environment
+graph: node(Environment)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-09-environment-checks-bypass/self-approval-allowed.yaml
+++ b/internal/detection-rules/ado/cat-09-environment-checks-bypass/self-approval-allowed.yaml
@@ -2,6 +2,7 @@ id: cat-09/self-approval-allowed
 scenario_id: cat-09/03
 title: "Approval check permits approvers to approve their own runs"
 subject: environment
+graph: node(Environment)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-10-agent-pools/pool-agent-autoupdate-self-hosted.yaml
+++ b/internal/detection-rules/ado/cat-10-agent-pools/pool-agent-autoupdate-self-hosted.yaml
@@ -2,6 +2,7 @@ id: cat-10/pool-agent-autoupdate-self-hosted
 scenario_id: cat-10/09
 title: "Self-hosted agent pool with auto-update enabled — agent-software supply-chain fan-out"
 subject: agent_pool
+graph: node(OrgAgentPool)
 severity: low
 confidence: low
 description: >

--- a/internal/detection-rules/ado/cat-10-agent-pools/pool-open-access-self-hosted.yaml
+++ b/internal/detection-rules/ado/cat-10-agent-pools/pool-open-access-self-hosted.yaml
@@ -2,6 +2,7 @@ id: cat-10/pool-open-access-self-hosted
 scenario_id: cat-10/02
 title: "Self-hosted agent pool auto-provisioned into all projects — broad reach onto internal infrastructure"
 subject: agent_pool
+graph: node(OrgAgentPool)
 severity: medium
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-10-agent-pools/pool-run-as-root-self-hosted.yaml
+++ b/internal/detection-rules/ado/cat-10-agent-pools/pool-run-as-root-self-hosted.yaml
@@ -2,6 +2,7 @@ id: cat-10/pool-run-as-root-self-hosted
 scenario_id: cat-10/05
 title: "Self-hosted agent pool with a run-as-root agent — any job on it inherits host privilege"
 subject: agent_pool
+graph: node(OrgAgentPool)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-10-agent-pools/shared-nonephemeral-agent-residue.yaml
+++ b/internal/detection-rules/ado/cat-10-agent-pools/shared-nonephemeral-agent-residue.yaml
@@ -2,6 +2,7 @@ id: cat-10/shared-nonephemeral-agent-residue
 scenario_id: cat-10/01
 title: "Non-ephemeral self-hosted agent pool — host state persists between jobs for residue harvest"
 subject: agent_pool
+graph: node(OrgAgentPool)
 severity: low
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-11-artifacts-triggers/dependency-confusion-upstream-shadow.yaml
+++ b/internal/detection-rules/ado/cat-11-artifacts-triggers/dependency-confusion-upstream-shadow.yaml
@@ -2,6 +2,7 @@ id: cat-11/dependency-confusion-upstream-shadow
 scenario_id: cat-11/06
 title: "Artifacts feed has public upstream sources enabled (dependency-confusion / substitution surface)"
 subject: feed
+graph: node(ArtifactsFeed)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-11-artifacts-triggers/feed-broad-write-permissions.yaml
+++ b/internal/detection-rules/ado/cat-11-artifacts-triggers/feed-broad-write-permissions.yaml
@@ -2,6 +2,7 @@ id: cat-11/feed-broad-write-permissions
 scenario_id: cat-11/05
 title: "Artifacts feed grants package-write/save (Collaborator/Contributor) to non-admin identities"
 subject: feed
+graph: node(ArtifactsFeed)
 severity: medium
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-11-artifacts-triggers/feed-view-promotion-bypass.yaml
+++ b/internal/detection-rules/ado/cat-11-artifacts-triggers/feed-view-promotion-bypass.yaml
@@ -2,6 +2,7 @@ id: cat-11/feed-view-promotion-bypass
 scenario_id: cat-11/08
 title: "Feed release view is not an approval gate — promotion/publish is a Contributor-level action"
 subject: feed
+graph: node(ArtifactsFeed)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/generate-then-execute.yaml
@@ -2,6 +2,7 @@ id: cat-12/generate-then-execute
 scenario_id: cat-12/05
 title: "Agent-generated output executed in the same run without human review"
 subject: agent_injection
+graph: edge(AGENT_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/indirect-injection-agentic-rce.yaml
@@ -2,6 +2,7 @@ id: cat-12/indirect-injection-agentic-rce
 scenario_id: cat-12/03
 title: "Injected AI agent holds tool/shell execution — indirect-injection RCE on the build host"
 subject: agent_injection
+graph: edge(AGENT_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/overscoped-ai-extension.yaml
@@ -2,6 +2,7 @@ id: cat-12/overscoped-ai-extension
 scenario_id: cat-12/04
 title: "Org-installed third-party extension holds over-broad write scopes"
 subject: extension
+graph: node(Extension)
 severity: high
 confidence: medium
 description: >

--- a/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/pr-text-prompt-injection.yaml
@@ -2,6 +2,7 @@ id: cat-12/pr-text-prompt-injection
 scenario_id: cat-12/01
 title: "Untrusted input reaches an AI agent step holding a privileged capability with no review gate"
 subject: agent_injection
+graph: edge(AGENT_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
+++ b/internal/detection-rules/ado/cat-12-ai-tasks/secret-exfil-via-injection.yaml
@@ -2,6 +2,7 @@ id: cat-12/secret-exfil-via-injection
 scenario_id: cat-12/07
 title: "Injected AI agent has an exfiltration channel for the run's secrets and token"
 subject: agent_injection
+graph: edge(AGENT_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-13-logging-injection/artifact-upload-exfiltration.yaml
+++ b/internal/detection-rules/ado/cat-13-logging-injection/artifact-upload-exfiltration.yaml
@@ -2,6 +2,7 @@ id: cat-13/artifact-upload-exfiltration
 scenario_id: cat-13/05
 title: "Untrusted text echoed to stdout injects ##vso[artifact.upload] to exfiltrate local secret files"
 subject: logging_command_injection
+graph: edge(LOGGING_COMMAND_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-13-logging-injection/prependpath-binary-shadow-rce.yaml
+++ b/internal/detection-rules/ado/cat-13-logging-injection/prependpath-binary-shadow-rce.yaml
@@ -2,6 +2,7 @@ id: cat-13/prependpath-binary-shadow-rce
 scenario_id: cat-13/02
 title: "Untrusted text echoed to stdout injects ##vso[task.prependpath] to shadow a later binary (RCE)"
 subject: logging_command_injection
+graph: edge(LOGGING_COMMAND_INJECTION)
 severity: critical
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-13-logging-injection/setendpoint-connection-redirect.yaml
+++ b/internal/detection-rules/ado/cat-13-logging-injection/setendpoint-connection-redirect.yaml
@@ -2,6 +2,7 @@ id: cat-13/setendpoint-connection-redirect
 scenario_id: cat-13/03
 title: "Untrusted text echoed to stdout injects ##vso[task.setendpoint] to redirect a live service connection"
 subject: logging_command_injection
+graph: edge(LOGGING_COMMAND_INJECTION)
 severity: critical
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-13-logging-injection/setvariable-control-flip.yaml
+++ b/internal/detection-rules/ado/cat-13-logging-injection/setvariable-control-flip.yaml
@@ -2,6 +2,7 @@ id: cat-13/setvariable-control-flip
 scenario_id: cat-13/01
 title: "Untrusted text echoed to stdout injects ##vso[task.setvariable] to flip a control variable"
 subject: logging_command_injection
+graph: edge(LOGGING_COMMAND_INJECTION)
 severity: high
 confidence: high
 description: >

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/classic-inherits-connection-weaker-guardrails.yaml
@@ -2,6 +2,7 @@ id: cat-14/classic-inherits-connection-weaker-guardrails
 scenario_id: cat-14/05
 title: "Classic release creation enabled (parallel weaker path to checked resources)"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: low
 description: >

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/cross-project-artifact-prod-deploy.yaml
@@ -2,6 +2,7 @@ id: cat-14/cross-project-artifact-prod-deploy
 scenario_id: cat-14/04
 title: "Classic release creation enabled with release auth scope not project-limited"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: low
 description: >

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/release-gate-fails-open.yaml
@@ -2,6 +2,7 @@ id: cat-14/release-gate-fails-open
 scenario_id: cat-14/03
 title: "Classic release creation enabled (fail-open release gates possible)"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: low
 description: >

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/self-approval-classic-release-stage.yaml
@@ -2,6 +2,7 @@ id: cat-14/self-approval-classic-release-stage
 scenario_id: cat-14/01
 title: "Classic release creation enabled (self-approvable prod release stages possible)"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: low
 description: >

--- a/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
+++ b/internal/detection-rules/ado/cat-14-classic-release-task-groups/task-group-edit-affects-all.yaml
@@ -2,6 +2,7 @@ id: cat-14/task-group-edit-affects-all
 scenario_id: cat-14/02
 title: "Classic build/release creation enabled (task-group fan-out surface exists)"
 subject: project
+graph: node(Project)
 severity: medium
 confidence: low
 description: >


### PR DESCRIPTION
Adds the graph phase for Azure DevOps. `trajan ado graph` builds a property graph from normalized records and scan findings; `trajan ado push` loads it into Neo4j.

Nodes and edges cover ADO's structure and its permission model — organization down through project, repo, pipeline, stage and job, plus the service connections, variable groups, agent pools, environments and principals those jobs reach. Node identity is composed from the parent's, so containment falls out of identity, resources shared across projects resolve to their owner, and the same identity seen in several organizations merges to one node.

Every ADO detection rule now names a graph target, so findings attach to the node or edge they describe and carry rule id, severity and fingerprint as queryable properties. An attack path traverses from a principal, through the job it can poison, to the secret or service connection that job reaches, naming the rule that proves each hop.

The graph code is forked from `internal/graph` rather than shared with it; `internal/graph` is unchanged, and does not break any current functionality.

Fixes LAB-4285
