### PR TITLE
ci: pin Gemini reviewer to public-workflows v2.19.8 (ENG-7716)

### DIFF
--- a/.github/workflows/gemini-code.yml
+++ b/.github/workflows/gemini-code.yml
@@ -15,9 +15,10 @@ jobs:
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event_name != 'pull_request_review_comment' || contains(github.event.comment.body, '@gemini'))
-    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@3fb9ffbace86c9e93a7b92170241dd54b5031608  # v2.11.3
+    uses: praetorian-inc/public-workflows/.github/workflows/gemini-code.yml@7d5ab6d7c9288e7513e2995dc432a86e73ded955  # v2.19.8 (ENG-7716)
     permissions:
       contents: read
       pull-requests: write
+      actions: read  # ENG-7654: fetch-graph downloads this repo's graphify artifact (fail-open skip if none)
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary
- Pin this repo's Gemini PR-review caller to `public-workflows` v2.19.8 (`7d5ab6d7`, #171).
- Inherits `gemini-3.8-flash` (ENG-7646), Gemini CLI 0.58.0, size-aware turn cap, and fetch-graph (ENG-7656 / ENG-6428 / ENG-7654).
- Leave `model` unset so the reusable default applies.
- Grant `actions: read` when missing so fetch-graph can fail-open instead of permission-error.

Tracked by ENG-7716. Palatine (#930) and guard (#8361) already ship this pin.

## Test plan
- [ ] `uses:` SHA is `7d5ab6d7c9288e7513e2995dc432a86e73ded955`
- [ ] No `with.model` override
- [ ] `actions: read` is present on the caller job
